### PR TITLE
Update introduction-to-tidy-finance.qmd

### DIFF
--- a/python/introduction-to-tidy-finance.qmd
+++ b/python/introduction-to-tidy-finance.qmd
@@ -29,7 +29,7 @@ import yfinance as yf
 Note that `import pandas as pd` implies that we can call all pandas functions later with a simple `pd.function()`. Instead, utilizing `from pandas import *` is generally discouraged, as it leads to namespace pollution. This statement imports all functions and classes from `pandas` into your current namespace, potentially causing conflicts with functions you define or those from other imported libraries. Using the `pd` abbreviation is a very convenient way to prevent this.\index{pandas}
 
 We first download daily prices for one stock symbol, e.g., the Apple stock, *AAPL*, directly from the data provider Yahoo!Finance. To download the data, you can use the function `yf.download()`. 
-The data from Yahoo!Finance comes as a dataframe, a two-dimensional, tabular data structure in which each row is indexed, and each column has a name. 
+The data from Yahoo!Finance comes as a dataframe, a two-dimensional, tabular data structure in which each row is indexed, and each column has a name. In this case, since only one ticker symbol is requested we specify that the data be returned with a single-level index.
 After the download, we apply a set of functions directly on the dataframe. First, we put the date index into a separate column. 
 Second, we add the column `symbol` that stores the symbol information, and finally, we rename all columns to lowercase names. Dataframes allow for *chaining* all these operations sequentially through using `.`.\index{Stock prices} \index{Chaining}
 
@@ -41,7 +41,8 @@ prices = (yf.download(
     tickers="AAPL", 
     start="2000-01-01", 
     end="2023-12-31", 
-    progress=False
+    progress=False,
+    multi_level_index=False,
   )
   .reset_index()
   .assign(symbol="AAPL")


### PR DESCRIPTION
As of October 2024, yfinance provides results using a mutli-level index by default, even with a single ticker symbol. This causes the ggplot command to fail. The most straightforward solution is to specify that the multi-level index be omitted from the results using the `multi_level_index=False` flag.