### PR TITLE
Fix issue with inline Jupyter code not evaluating

### DIFF
--- a/python/wrds-crsp-and-compustat.qmd
+++ b/python/wrds-crsp-and-compustat.qmd
@@ -483,7 +483,7 @@ Eventually, we end up with more than 72 million rows of daily return data. Note 
 
 To download the daily CRSP data via the `tidyfinance` package, you can call:
 
-```{r}
+```{python}
 #| eval: false
 crsp_daily = tf.download_data(
   domain="wrds",


### PR DESCRIPTION
I noticed that the paragraph starting with "Figure 1" at [https://www.tidy-finance.org/python/wrds-crsp-and-compustat.html#first-glimpse-of-the-crsp-sample](https://www.tidy-finance.org/python/wrds-crsp-and-compustat.html#first-glimpse-of-the-crsp-sample) had several places with inline Jupyter code that is rendering like ``{python} crsp_monthly['date'].max().year`` instead of "2024". 

The issue was caused by a code block with ``{r}`` instead of ``{python}``. The code block is not evaluated so it didn't cause the code not to run, but it seems having any R code blocks causes Quatro to use `knitr` as the render engine instead of `jupyter`. (See discussion at [https://github.com/quarto-dev/quarto-cli/issues/13185#issuecomment-3572641641](https://github.com/quarto-dev/quarto-cli/issues/13185#issuecomment-3572641641).)

Note: If you needed a R code block and want to render inline code with Jupyter you can also specify `engine: jupyter` in the YAML.