### PR TITLE
Drop month column from q-factors data

### DIFF
--- a/python/accessing-and-managing-financial-data.qmd
+++ b/python/accessing-and-managing-financial-data.qmd
@@ -219,7 +219,7 @@ factors_q_monthly = (
     .with_columns(
         date=pl.date(pl.col("year"), pl.col("month"), 1)
     )
-    .drop(["R_F", "R_MKT", "year"])
+    .drop(["R_F", "R_MKT", "year", "month"])
     .rename(lambda x: x.replace("R_", "").lower())
     .filter(
         (pl.col("date") >= pl.lit(start_date).str.to_date())


### PR DESCRIPTION
## Summary
- The q-Factors chunk in `python/accessing-and-managing-financial-data.qmd` dropped `year` but forgot `month`, so `data-python/factors_q_monthly.parquet` carried a spurious integer `month` column (values 1-12).
- This leaked downstream: `python/factor-selection-via-machine-learning.qmd` prefixes every column with `factor_q_` and joins it into the regressor matrix, so `factor_q_month` ended up as a bogus regressor in the machine-learning factor-selection exercise.
- Fix adds `month` to the drop list, matching the fix already applied in the R chapter (`r/accessing-and-managing-financial-data.qmd`). The Python-specific drops of `R_F`/`R_MKT` are intentionally unchanged.

The regenerated `factors_q_monthly.parquet` (columns now `me, ia, roe, eg, date`, 696 rows, 1967-01 to 2024-12) is gitignored, so it is not part of this PR; the `_freeze` caches of both affected chapters will refresh on the next `quarto render`.

Note: while regenerating, `global-q.org` rejected the default `requests` user-agent and returned HTML — the chunk may need a browser `User-Agent` header the next time it actually re-executes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)