### PR TITLE
Fix legend suppression broken by plotnine update

### DIFF
--- a/python/constrained-optimization-and-backtesting.qmd
+++ b/python/constrained-optimization-and-backtesting.qmd
@@ -215,7 +215,7 @@ rebalancing_figure = (
         ),
     )
     + geom_line()
-    + guides(linetype=None)
+    + guides(linetype="none")
     + labs(
         x="Transaction cost parameter",
         y="Distance from MVP",

--- a/python/difference-in-differences.qmd
+++ b/python/difference-in-differences.qmd
@@ -215,7 +215,7 @@ model_without_fe_figure = (
     + geom_hline(yintercept=0, linetype="dashed")
     + geom_errorbar(aes(ymin="ci_low", ymax="ci_up"), alpha=0.5)
     + geom_point()
-    + guides(linetype=None)
+    + guides(linetype="none")
     + labs(
         x="", y="Yield", shape="Polluter?", color="Polluter?",
         title="Polluters respond stronger than green firms"


### PR DESCRIPTION
## What

`guides(linetype=None)` no longer suppresses the linetype legend in current plotnine versions — `None` now means "use the default guide" rather than "hide it". As a result, two figures show a stray second legend (titled `factor(gamma)` in Constrained Optimization and Backtesting, `treatment` in Difference in Differences) next to the correctly labeled one.

The fix follows ggplot2 semantics, which plotnine adopted: pass the string `"none"` instead.

Two one-character-class changes:
- `python/constrained-optimization-and-backtesting.qmd` (fig: portfolio weights by risk aversion)
- `python/difference-in-differences.qmd` (fig: yield response of polluters)

Verified empirically against the installed plotnine: `None` leaves the stray legend, `"none"` suppresses it.

## Notes

- Source-only change; the two chapters need a re-render for the corrected figures to reach `_freeze/` and `docs/`.
- Independent of (but also applied on) the polars migration branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)