### PR TITLE
Store CRSP/Compustat identifier columns as 64-bit integers

### DIFF
--- a/r/wrds-crsp-and-compustat.qmd
+++ b/r/wrds-crsp-and-compustat.qmd
@@ -122,9 +122,13 @@ crsp_monthly <- msf_db |>
   collect() |>
   mutate(
     date = ymd(date),
-    shrout = shrout * 1000
+    permno = bit64::as.integer64(permno),
+    shrout = bit64::as.integer64(shrout * 1000),
+    siccd = bit64::as.integer64(siccd)
   )
 ```
+
+Note that we store the identifier and count columns (`permno`, `shrout`, `siccd`) as 64-bit integers, so that the resulting parquet files carry identical column types across the R and Python editions of this book.
 
 Now, we have all the relevant monthly return data in memory and proceed with preparing the data for future analyses. We perform the preparation step at the current stage since we want to avoid executing the same mutations every time we use the data in subsequent chapters. 
 
@@ -522,7 +526,7 @@ We keep only the last available information for each firm-year group. Note that 
 ```{r}
 #| eval: !expr params$download_data
 compustat_annual <- compustat_annual |>
-  mutate(year = year(datadate)) |>
+  mutate(year = bit64::as.integer64(year(datadate))) |>
   group_by(gvkey, year) |>
   filter(datadate == max(datadate)) |>
   ungroup()


### PR DESCRIPTION
## What

Casts `permno`, `shrout`, `siccd` (CRSP monthly) and the Compustat fiscal `year` to `integer64` via `bit64` before the parquet files are written.

## Why

R collects these columns from WRDS as doubles (`permno`, `shrout`, `year`) or int32 (`siccd`), so the parquet schemas diverge from the Python edition, which writes Int64. The automated cross-language comparison (#214) flags:

```
crsp_monthly: dtype differences {'permno': ('Float64', 'Int64'), 'shrout': ('Float64', 'Int64'), 'siccd': ('Int32', 'Int64')}
compustat_annual: dtype differences {'year': ('Float64', 'Int32' / 'Int64')}
```

Standardizing on Int64 makes the two data folders schema-identical for these columns — groundwork for a potential shared data folder across editions.

`bit64` is already available through the `arrow` dependency chain; a short prose note in the chapter explains the convention to readers. The daily CRSP file is unaffected (it stores only `permno` as a hive partition key plus `date`/`ret`).

## Notes

- Takes effect at the next WRDS data refresh (`params$download_data`); no immediate re-render needed.
- The Python edition's matching `year` cast (Int32 → Int64) lands on the polars migration branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)