### PR TITLE
Document accepted method differences vs the R edition in the changelog

### DIFF
--- a/python/changelog.qmd
+++ b/python/changelog.qmd
@@ -7,6 +7,12 @@ metadata:
 
 You can find every single change in our [commit history](https://github.com/tidy-finance/website/commits/main). We collect the most important changes for [Tidy Finance with Python](index.qmd) in the list below. 
 
+- June 12, 2026, Differences to Tidy Finance with R: Readers comparing the Python and R editions may notice small numerical differences. They stem from different library implementations, not from data or methodology, and the conclusions in the affected chapters agree across editions:
+  - `polars` computes quantiles with the "nearest" interpolation method by default, while R and `numpy` interpolate linearly, which leads to last-digit differences in summary tables throughout the book.
+  - In [Factor Selection via Machine Learning](factor-selection-via-machine-learning.qmd), `scikit-learn` uses coordinate descent with a different lambda path than `glmnet` in R, so estimated coefficients differ while the conclusions agree.
+  - `pyfixest` and R's `fixest` apply different small-sample degrees-of-freedom conventions, which shows up in the third decimal of standard errors in [Fixed Effects and Clustered Standard Errors](fixed-effects-and-clustered-standard-errors.qmd) and [Difference in Differences](difference-in-differences.qmd).
+  - In [Constrained Optimization and Backtesting](constrained-optimization-and-backtesting.qmd), `scipy.optimize` and R's `optim()` can return different allocations at numerically identical objective values.
+  - Simulation-based chapters such as [Option Pricing via Machine Learning](option-pricing-via-machine-learning.qmd) use different random number generators in Python and R, so simulated draws differ by design.
 - [August 4, 2024, Commit e30cff9:](https://github.com/tidy-finance/website/commit/e30cff9f615d3250b502484e66fd5c938deb140c) We switched to `pyfixest` instead of `linearmodels` for fixed effects regressions for better alignment with the R version. 
 - [August 4, 2024, Commit 524bdd1:](https://github.com/tidy-finance/website/commit/524bdd1561e72814fa0524a09c3b8b78fb4d3030) We added an additional filter to the Compustat download to exclude non-US companies in [WRDS, CRSP, and Compustat](wrds-crsp-and-compustat.qmd). 
 - [August 1, 2024, Commit 2980cf2:](https://github.com/tidy-finance/website/commit/2980cf2881986862ee6d5a19f5b9cc43cf4ccfef) We updated the data until 2023-12-31 in all chapters.


### PR DESCRIPTION
## Problem
The polars translation accepts several small, legitimate numerical differences relative to Tidy Finance with R. They stem from library implementation details, not from data or methodology, but none of them were documented anywhere reader-facing - readers comparing editions had no explanation for the discrepancies.

## Evidence
The cross-edition comparison catalogued five accepted differences:
1. polars `.quantile()` defaults to "nearest" interpolation vs linear in R/numpy (last-digit differences in summary tables throughout the book).
2. scikit-learn (coordinate descent, different lambda path) vs glmnet in factor selection - coefficients differ, conclusions agree.
3. pyfixest vs fixest small-sample/dof conventions - third-decimal SE differences in fixed effects and difference-in-differences.
4. scipy.optimize vs R optim() - different allocations at numerically identical objective values in constrained optimization.
5. Simulation chapters (option pricing) use different RNGs, so simulated draws differ by design.

## Fix
Added a dated "Differences to Tidy Finance with R" entry (June 12, 2026, no commit link) at the top of the bullet list in `python/changelog.qmd`, in the changelog's existing style with chapter links. Wording deliberately avoids overclaiming: conclusions agree, results are not claimed identical.

## Verification
- polars 1.37.1 signature confirmed: `quantile(self, quantile, interpolation="nearest")`; observed `pl.Series([1,2,3,4]).quantile(0.25)` = 2.0 (nearest) vs 1.75 with `interpolation="linear"` and `np.quantile(..., 0.25)` = 1.75.
- sklearn imports confirmed in `python/factor-selection-via-machine-learning.qmd`; pyfixest used in exactly the fixed-effects and difference-in-differences chapters; `scipy.optimize.minimize` imported and called in the constrained-optimization chapter; `np.random.seed` used in the option-pricing chapter.
- All five chapter links resolve to existing `.qmd` files.

## Follow-ups
- `docs/python/changelog.html` is one entry stale until the next render from the main checkout: rendering inside this worktree falls back to a standalone pandoc render (no site theme) because Quarto 1.9 does not treat files under the hidden `.claude/worktrees/` path as project inputs (reproduced twice). The changelog has no `_freeze` entry (no executable code), so nothing else is stale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)