### PR TITLE
Make fast beta estimation post bilingual (R + Python)

### DIFF
--- a/blog/fast-beta-estimation/index.qmd
+++ b/blog/fast-beta-estimation/index.qmd
@@ -1,5 +1,5 @@
 ---
-title: "Fast Beta Estimation with Polars"
+title: "Fast, Vectorized Beta Estimation"
 author:
   - name: Stefan Voigt
     url: https://www.voigtstefan.me/
@@ -7,16 +7,18 @@ author:
       - name: University of Copenhagen
       - name: Danish Finance Institute
 date: "2026-06-12"
-description: Vectorizing rolling CAPM regressions with precomputed cumulants speeds up beta estimation by orders of magnitude
+description: Vectorizing rolling CAPM regressions with precomputed cumulants speeds up beta estimation by orders of magnitude — in both Python and R
 categories:
   - Python
+  - R
   - Beta
   - polars
+  - tidyverse
 ---
 
-In [Beta Estimation](../../python/beta-estimation.qmd), we estimate rolling CAPM betas for the entire CRSP universe by calling a regression routine for every stock and every monthly estimation window. That design is easy to read and easy to generalize, but it requires over two million individual regression fits — even parallelized across all cores, the estimation takes hours.
+In Beta Estimation ([R](../../r/beta-estimation.qmd) / [Python](../../python/beta-estimation.qmd)), we estimate rolling CAPM betas for the entire CRSP universe by calling a regression routine for every stock and every monthly estimation window. That design is easy to read and easy to generalize, but it requires over two million individual regression fits — even parallelized across all cores, the estimation takes hours.
 
-This post shows that `polars` can produce the *identical* estimates in a few seconds. The trick is that, for a single-regressor model, the OLS coefficients and their $t$-statistics are simple functions of precomputed cumulants: the observation count $n$ and the sums $\sum x_t$, $\sum y_t$, $\sum x_t^2$, $\sum y_t^2$, and $\sum x_t y_t$. Because sums are additive, we can compute them once per stock-month and let `polars` aggregate them over rolling calendar windows in a single vectorized pass — no loops, no parallelization machinery. We then reproduce every output of the book chapter with this approach.
+This post shows that the *identical* estimates can be produced in a few seconds, in both languages, without a single explicit regression and without any parallelization machinery. The trick is that, for a single-regressor model, the OLS coefficients and their $t$-statistics are simple functions of precomputed cumulants: the observation count $n$ and the sums $\sum x_t$, $\sum y_t$, $\sum x_t^2$, $\sum y_t^2$, and $\sum x_t y_t$. Because sums are additive, we can compute them once per stock-month and aggregate them over rolling calendar windows in a single vectorized pass — `polars` does this in Python, `dplyr` together with `slider` in R. We then reproduce every output of the book chapter with this approach.
 
 To be specific, with $x$ denoting the market excess return, $y$ the stock excess return, and all sums running over a rolling estimation window with $n$ observations, the slope and intercept follow as
 
@@ -28,6 +30,9 @@ $$
 where $S_{xy} = \sum x_t y_t - \frac{1}{n}\sum x_t \sum y_t$ and $S_{xx} = \sum x_t^2 - \frac{1}{n}\left(\sum x_t\right)^2$. With $S_{yy}$ defined analogously, the residual variance is $\hat\sigma^2 = (S_{yy} - \hat\beta S_{xy}) / (n - 2)$, and the $t$-statistics follow from the standard errors $\text{se}(\hat\beta) = \sqrt{\hat\sigma^2 / S_{xx}}$ and $\text{se}(\hat\alpha) = \sqrt{\hat\sigma^2 \left(\frac{1}{n} + \frac{\bar x^2}{S_{xx}}\right)}$.
 
 We use the following packages:
+
+::: {.panel-tabset group="language"}
+### Python
 
 ```{python}
 #| message: false
@@ -45,9 +50,25 @@ from mizani.formatters import percent_format
 exec(open("python/render-plotnine-custom.py").read())
 ```
 
+### R
+
+```{r}
+#| message: false
+library(tidyverse)
+library(arrow)
+library(slider)
+library(scales)
+```
+
+We rely on `slider` [@slider] for its fast, index-aware rolling-sum function, but otherwise stay within the tidyverse.
+:::
+
 ## Data
 
-As in the chapter, we combine monthly CRSP returns with the market excess returns from the Fama-French data library, both stored in the Parquet files introduced in [WRDS, CRSP, and Compustat](../../python/wrds-crsp-and-compustat.qmd).
+As in the chapter, we combine monthly CRSP returns with the market excess returns from the Fama-French data library, both stored in the Parquet files introduced in WRDS, CRSP, and Compustat ([R](../../r/wrds-crsp-and-compustat.qmd) / [Python](../../python/wrds-crsp-and-compustat.qmd)).
+
+::: {.panel-tabset group="language"}
+### Python
 
 ```{python}
 crsp_monthly = (pl.read_parquet("data-python/crsp_monthly.parquet")
@@ -61,9 +82,28 @@ crsp_monthly = (pl.read_parquet("data-python/crsp_monthly.parquet")
 )
 ```
 
+### R
+
+```{r}
+crsp_monthly <- read_parquet("data-r/crsp_monthly.parquet") |>
+  select(permno, date, industry, ret_excess) |>
+  drop_na() |>
+  left_join(
+    read_parquet("data-r/factors_ff3_monthly.parquet") |>
+      select(date, mkt_excess),
+    join_by(date)
+  )
+```
+:::
+
 ## Vectorized Rolling Estimation
 
-The function below performs the rolling estimation in three steps: (i) collapse the data to one row of cumulants per stock and month, (ii) aggregate the cumulants over rolling windows of `look_back` calendar months via `rolling()`, keeping only windows with at least `min_obs` observations and `look_back` months of available history, and (iii) map the aggregated sums into $\hat\alpha$, $\hat\beta$, and their $t$-statistics. The output format mirrors the chapter exactly: one row per stock, month, and coefficient.
+The function below performs the rolling estimation in three steps: (i) collapse the data to one row of cumulants per stock and month, (ii) aggregate the cumulants over rolling windows of `look_back` calendar months, keeping only windows with at least `min_obs` observations and `look_back` months of available history, and (iii) map the aggregated sums into $\hat\alpha$, $\hat\beta$, and their $t$-statistics. The output format mirrors the chapter exactly: one row per stock, month, and coefficient.
+
+The two editions differ only in the windowing primitive. In Python, `polars` aggregates the cumulants over a calendar window with `rolling()`. In R, we use `slider::slide_index_sum()`, a C-level rolling sum that respects an index, so there is no R-level loop over windows. The only subtlety is that we index the window by an integer month counter (`year * 12 + month`) rather than by the calendar `date`: this sidesteps `lubridate`'s end-of-month arithmetic (e.g., subtracting a month from the 31st can yield `NA`) and defines the 60-month window unambiguously.
+
+::: {.panel-tabset group="language"}
+### Python
 
 ```{python}
 def roll_capm_estimation(data, look_back=60, min_obs=48):
@@ -140,7 +180,66 @@ def roll_capm_estimation(data, look_back=60, min_obs=48):
     )
 ```
 
-Estimating betas for the entire monthly CRSP sample — around 26,000 stocks and over two million rolling windows — is now a matter of seconds:
+### R
+
+```{r}
+roll_capm_estimation <- function(data, look_back = 60, min_obs = 48) {
+  cumulants <- data |>
+    summarize(
+      n = n(),
+      sum_x = sum(mkt_excess),
+      sum_y = sum(ret_excess),
+      sum_xx = sum(mkt_excess^2),
+      sum_yy = sum(ret_excess^2),
+      sum_xy = sum(mkt_excess * ret_excess),
+      .by = c(permno, date)
+    ) |>
+    arrange(permno, date) |>
+    mutate(
+      period = year(date) * 12 + month(date),
+      month_index = row_number(),
+      .by = permno
+    )
+
+  rolling_sums <- cumulants |>
+    mutate(
+      across(
+        c(n, sum_x, sum_y, sum_xx, sum_yy, sum_xy),
+        \(col) slide_index_sum(col, period, before = look_back - 1)
+      ),
+      .by = permno
+    ) |>
+    filter(month_index >= look_back, n >= min_obs)
+
+  estimates <- rolling_sums |>
+    mutate(
+      s_xx = sum_xx - sum_x^2 / n,
+      s_xy = sum_xy - sum_x * sum_y / n,
+      s_yy = sum_yy - sum_y^2 / n,
+      beta = s_xy / s_xx,
+      alpha = (sum_y - beta * sum_x) / n,
+      sigma2 = (s_yy - beta * s_xy) / (n - 2),
+      t_alpha = alpha / sqrt(sigma2 * (1 / n + (sum_x / n)^2 / s_xx)),
+      t_beta = beta / sqrt(sigma2 / s_xx)
+    )
+
+  bind_rows(
+    estimates |>
+      transmute(permno, date, coefficient = "alpha",
+                estimate = alpha, t_statistic = t_alpha),
+    estimates |>
+      transmute(permno, date, coefficient = "mkt_excess",
+                estimate = beta, t_statistic = t_beta)
+  ) |>
+    arrange(permno, date, coefficient)
+}
+```
+:::
+
+Estimating betas for the entire monthly CRSP sample — around 26,000 stocks and over two million rolling windows — is now a matter of seconds. Note that the whole sample is processed in a single call: there is no nesting by stock and no parallelization.
+
+::: {.panel-tabset group="language"}
+### Python
 
 ```{python}
 tic = time.perf_counter()
@@ -150,7 +249,25 @@ toc = time.perf_counter()
 print(f"Monthly estimation: {capm_monthly.shape[0]:,} rows in {toc - tic:.1f} seconds")
 ```
 
-The estimates are numerically identical to the regression-based approach of the chapter — closed-form OLS is still OLS. We verify this claim for one stock and window: the latest five-year window of Apple's returns, estimated via `statsmodels`.
+### R
+
+```{r}
+tic <- Sys.time()
+capm_monthly <- roll_capm_estimation(crsp_monthly)
+toc <- Sys.time()
+
+cat(sprintf(
+  "Monthly estimation: %s rows in %.1f seconds\n",
+  format(nrow(capm_monthly), big.mark = ","),
+  as.numeric(toc - tic, units = "secs")
+))
+```
+:::
+
+The estimates are numerically identical to the regression-based approach of the chapter — closed-form OLS is still OLS. We verify this claim for one stock and window: the latest five-year window of Apple's returns, estimated via the standard regression routine.
+
+::: {.panel-tabset group="language"}
+### Python
 
 ```{python}
 import statsmodels.formula.api as smf
@@ -177,9 +294,37 @@ print(f"statsmodels t:    {fit.tvalues['mkt_excess']:.12f}")
 print(f"vectorized t:     {apple_vectorized['t_statistic'][0]:.12f}")
 ```
 
+### R
+
+```{r}
+apple_window <- crsp_monthly |>
+  filter(permno == 14593) |>
+  arrange(date) |>
+  tail(60)
+
+fit <- lm(ret_excess ~ mkt_excess, data = apple_window)
+coefs <- summary(fit)$coefficients
+
+apple_vectorized <- capm_monthly |>
+  filter(
+    permno == 14593,
+    date == max(apple_window$date),
+    coefficient == "mkt_excess"
+  )
+
+cat(sprintf("lm beta:          %.12f\n", coefs["mkt_excess", "Estimate"]))
+cat(sprintf("vectorized beta:  %.12f\n", apple_vectorized$estimate))
+cat(sprintf("lm t:             %.12f\n", coefs["mkt_excess", "t value"]))
+cat(sprintf("vectorized t:     %.12f\n", apple_vectorized$t_statistic))
+```
+:::
+
 ## Daily Betas Without Batching
 
-The chapter splits the daily CRSP data into batches of stocks to keep memory in check during the parallelized estimation. The cumulant approach makes this unnecessary: since the data immediately collapses to one row per stock and month, we can lazily scan the full partitioned dataset and process all 180 million daily observations in one go. Following the chapter, we truncate daily dates to the start of the month — so the windows still span 60 months, with one estimate per month — and require at least 1,000 daily observations.
+The chapter splits the daily CRSP data into batches of stocks to keep memory in check during the parallelized estimation. The cumulant approach makes this unnecessary: since the data immediately collapses to one row per stock and month, we can read the full partitioned dataset and process all 180 million daily observations in one go. Following the chapter, we truncate daily dates to the start of the month — so the windows still span 60 months, with one estimate per month — and require at least 1,000 daily observations.
+
+::: {.panel-tabset group="language"}
+### Python
 
 ```{python}
 factors_ff3_daily = (pl.read_parquet("data-python/factors_ff3_daily.parquet")
@@ -207,9 +352,37 @@ toc = time.perf_counter()
 print(f"Daily estimation: {capm_daily.shape[0]:,} rows in {toc - tic:.1f} seconds")
 ```
 
+### R
+
+```{r}
+factors_ff3_daily <- read_parquet("data-r/factors_ff3_daily.parquet") |>
+  select(date, mkt_excess)
+
+tic <- Sys.time()
+crsp_daily <- open_dataset("data-r/crsp_daily") |>
+  select(permno, date, ret_excess) |>
+  collect()
+
+capm_daily <- crsp_daily |>
+  inner_join(factors_ff3_daily, join_by(date)) |>
+  mutate(date = floor_date(date, "month")) |>
+  roll_capm_estimation(min_obs = 1000)
+toc <- Sys.time()
+
+cat(sprintf(
+  "Daily estimation: %s rows in %.1f seconds\n",
+  format(nrow(capm_daily), big.mark = ","),
+  as.numeric(toc - tic, units = "secs")
+))
+```
+:::
+
 ## Reproducing the Chapter's Results
 
-The remainder of this post reproduces every output of [Beta Estimation](../../python/beta-estimation.qmd) from the two estimate tables. First, the rolling betas of four well-known stocks:
+The remainder of this post reproduces every output of the chapter from the two estimate tables. First, the rolling betas of four well-known stocks:
+
+::: {.panel-tabset group="language"}
+### Python
 
 ```{python}
 #| fig-cap: "The figure shows monthly beta estimates for example stocks using five years of data, estimated with the vectorized cumulant approach."
@@ -232,7 +405,35 @@ beta_examples = (capm_monthly
 ).show()
 ```
 
+### R
+
+```{r}
+#| fig-cap: "The figure shows monthly beta estimates for example stocks using five years of data, estimated with the vectorized cumulant approach."
+#| fig-alt: "Title: Monthly beta estimates for example stocks using five years of data. The figure shows a time series of beta estimates based on five years of monthly data for Apple, Berkshire Hathaway, Microsoft, and Tesla. The estimated betas vary over time but are always positive for each stock."
+examples <- tibble(
+  permno = c(14593, 10107, 93436, 17778),
+  company = c("Apple", "Microsoft", "Tesla", "Berkshire Hathaway")
+)
+
+beta_examples <- capm_monthly |>
+  filter(coefficient == "mkt_excess") |>
+  inner_join(examples, join_by(permno))
+
+beta_examples |>
+  ggplot(aes(x = date, y = estimate, color = company, linetype = company)) +
+  geom_line() +
+  labs(
+    x = NULL, y = NULL, color = NULL, linetype = NULL,
+    title = "Monthly beta estimates for example stocks using 5 years of data"
+  ) +
+  scale_x_date(date_breaks = "5 years", date_labels = "%Y")
+```
+:::
+
 Next, the distribution of average firm-specific betas by industry:
+
+::: {.panel-tabset group="language"}
+### Python
 
 ```{python}
 #| fig-cap: "The box plots show the average firm-specific beta estimates by industry."
@@ -266,7 +467,33 @@ industry_order = (beta_industries
 ).show()
 ```
 
+### R
+
+```{r}
+#| fig-cap: "The box plots show the average firm-specific beta estimates by industry."
+#| fig-alt: "Title: Firm-specific beta distributions by industry. The figure shows box plots for each industry. The large majority of all stocks has CAPM betas between 0.5 and 1.5, with very few negative values."
+beta_monthly <- capm_monthly |>
+  filter(coefficient == "mkt_excess") |>
+  select(permno, date, beta = estimate) |>
+  mutate(return_type = "monthly")
+
+beta_industries <- beta_monthly |>
+  inner_join(crsp_monthly, join_by(permno, date)) |>
+  drop_na(beta) |>
+  summarize(beta = mean(beta), .by = c(industry, permno))
+
+beta_industries |>
+  ggplot(aes(x = reorder(industry, beta, FUN = median), y = beta)) +
+  geom_boxplot() +
+  coord_flip() +
+  labs(x = NULL, y = NULL, title = "Firm-specific beta distributions by industry")
+```
+:::
+
 The monthly deciles of estimated betas over time:
+
+::: {.panel-tabset group="language"}
+### Python
 
 ```{python}
 #| fig-cap: "The figure shows monthly deciles of estimated betas. Each line corresponds to the monthly cross-sectional quantile of the estimated CAPM beta."
@@ -296,7 +523,34 @@ n_quantiles = beta_quantiles["quantile"].n_unique()
 ).show()
 ```
 
+### R
+
+```{r}
+#| fig-cap: "The figure shows monthly deciles of estimated betas. Each line corresponds to the monthly cross-sectional quantile of the estimated CAPM beta."
+#| fig-alt: "Title: Monthly deciles of estimated betas. The figure shows time series of deciles of estimated betas. The deciles vary substantially over time and tend to move jointly."
+beta_monthly |>
+  group_by(date) |>
+  reframe(
+    beta = quantile(beta, seq(0.1, 0.9, 0.1)),
+    quantile = 100 * seq(0.1, 0.9, 0.1)
+  ) |>
+  ggplot(aes(
+    x = date, y = beta,
+    color = as_factor(quantile), linetype = as_factor(quantile)
+  )) +
+  geom_line() +
+  labs(
+    x = NULL, y = NULL, color = NULL, linetype = NULL,
+    title = "Monthly deciles of estimated betas"
+  ) +
+  scale_x_date(date_breaks = "5 years", date_labels = "%Y")
+```
+:::
+
 The comparison of monthly and daily estimates for the example stocks:
+
+::: {.panel-tabset group="language"}
+### Python
 
 ```{python}
 #| fig-cap: "The figure shows the comparison of beta estimates using monthly and daily data for example stocks."
@@ -321,7 +575,36 @@ beta = pl.concat([beta_monthly, beta_daily])
 ).show()
 ```
 
+### R
+
+```{r}
+#| fig-cap: "The figure shows the comparison of beta estimates using monthly and daily data for example stocks."
+#| fig-alt: "Title: Comparison of beta estimates using monthly and daily data. The figure shows a time series of beta estimates using five years of monthly versus daily data for Apple, Berkshire Hathaway, Microsoft, and Tesla. The estimates based on daily data are smoother, but trend and level are similar across frequencies."
+#| fig-height: 8
+beta_daily <- capm_daily |>
+  filter(coefficient == "mkt_excess") |>
+  select(permno, date, beta = estimate) |>
+  mutate(return_type = "daily")
+
+beta <- bind_rows(beta_monthly, beta_daily)
+
+beta |>
+  inner_join(examples, join_by(permno)) |>
+  ggplot(aes(x = date, y = beta, color = return_type, linetype = return_type)) +
+  geom_line() +
+  facet_wrap(~company, ncol = 1) +
+  labs(
+    x = NULL, y = NULL, color = NULL, linetype = NULL,
+    title = "Comparison of beta estimates using monthly and daily data"
+  ) +
+  scale_x_date(date_breaks = "10 years", date_labels = "%Y")
+```
+:::
+
 The share of stocks with available beta estimates over time:
+
+::: {.panel-tabset group="language"}
+### Python
 
 ```{python}
 #| fig-cap: "The figure shows the end-of-month share of securities with beta estimates, separately for the monthly and daily estimation."
@@ -345,7 +628,35 @@ beta_coverage = (crsp_monthly
 ).show()
 ```
 
+### R
+
+```{r}
+#| fig-cap: "The figure shows the end-of-month share of securities with beta estimates, separately for the monthly and daily estimation."
+#| fig-alt: "Title: End-of-month share of securities with beta estimates. The figure shows two time series with the share of securities with beta estimates using monthly or daily data. The daily estimates exhibit almost no missing data, while the monthly estimates cover around 75 percent of all stock-month combinations."
+beta_coverage <- crossing(
+  crsp_monthly,
+  tibble(return_type = c("monthly", "daily"))
+) |>
+  left_join(beta, join_by(permno, date, return_type)) |>
+  group_by(date, return_type) |>
+  summarize(share = sum(!is.na(beta)) / n(), .groups = "drop")
+
+beta_coverage |>
+  ggplot(aes(x = date, y = share, color = return_type, linetype = return_type)) +
+  geom_line() +
+  labs(
+    x = NULL, y = NULL, color = NULL, linetype = NULL,
+    title = "End-of-month share of securities with beta estimates"
+  ) +
+  scale_y_continuous(labels = percent) +
+  scale_x_date(date_breaks = "10 years", date_labels = "%Y")
+```
+:::
+
 The summary statistics of both estimate sets:
+
+::: {.panel-tabset group="language"}
+### Python
 
 ```{python}
 (beta
@@ -365,7 +676,29 @@ The summary statistics of both estimate sets:
 )
 ```
 
+### R
+
+```{r}
+beta |>
+  group_by(return_type) |>
+  summarize(
+    count = n(),
+    mean = mean(beta),
+    std = sd(beta),
+    min = min(beta),
+    q25 = quantile(beta, 0.25),
+    median = median(beta),
+    q75 = quantile(beta, 0.75),
+    max = max(beta)
+  ) |>
+  mutate(across(c(mean, std, min, q25, median, q75, max), \(x) round(x, 2)))
+```
+:::
+
 And, finally, the correlation between the monthly and daily estimators:
+
+::: {.panel-tabset group="language"}
+### Python
 
 ```{python}
 (beta
@@ -377,6 +710,21 @@ And, finally, the correlation between the monthly and daily estimators:
 )
 ```
 
+### R
+
+```{r}
+beta |>
+  pivot_wider(
+    id_cols = c(permno, date),
+    names_from = return_type, values_from = beta
+  ) |>
+  select(monthly, daily) |>
+  drop_na() |>
+  cor() |>
+  round(2)
+```
+:::
+
 ## Takeaways
 
-All outputs match the chapter — the same betas, the same figures, the same summary statistics — but the entire estimation finishes in a few minutes - dominated by reading the 180 million daily returns - instead of many hours. Whenever a rolling estimator can be written in terms of additive cumulants, precomputing them and letting `polars` aggregate over rolling windows turns a parallelization problem into a one-pass computation. The pattern extends naturally to multi-factor models: with $k$ regressors, the required cumulants are the entries of the stacked moment matrices $X'X$, $X'y$, and $y'y$ — the same logic, just more sums.
+All outputs match the chapter — the same betas, the same figures, the same summary statistics — but the entire estimation finishes in a few minutes (dominated by reading the 180 million daily returns) instead of many hours. The same pattern works across languages: whenever a rolling estimator can be written in terms of additive cumulants, precomputing them and letting a vectorized rolling aggregation — `polars` in Python, `dplyr` and `slider` in R — accumulate them over windows turns a parallelization problem into a one-pass computation. In R, this also removes the need for `furrr` and the per-stock nesting used in the chapter. The pattern extends naturally to multi-factor models: with $k$ regressors, the required cumulants are the entries of the stacked moment matrices $X'X$, $X'y$, and $y'y$ — the same logic, just more sums.

--- a/python/beta-estimation.qmd
+++ b/python/beta-estimation.qmd
@@ -191,6 +191,10 @@ beta_figure.show()
 
 ## Parallelized Rolling-Window Estimation
 
+::: callout-tip
+For a single-regressor model such as the CAPM, the rolling regressions can also be computed in closed form from precomputed cumulants, which avoids fitting millions of individual models. Our blog post [Fast, Vectorized Beta Estimation](../blog/fast-beta-estimation/index.qmd) shows how to reproduce the results of this chapter in seconds, without parallelization.
+:::
+
 Even though we could now just apply the function using `.groubby()` on the whole CRSP sample, we advise against doing it as it is computationally quite expensive. Remember that we have to perform rolling-window estimations across all stocks and time periods. However, this estimation problem is an ideal scenario to employ the power of parallelization. Parallelization means that we split the tasks which perform rolling-window estimations across different workers (or cores on your local machine). 
 
 If you have a Windows or Mac machine, it makes most sense use the default parallelization backend of `joblib`, which means that separate Python processes are running in the background on the same machine to perform the individual jobs. If you check out the documentation of `joblib.parallel_config()`, you can also see other ways to resolve the parallelization in different environments. Note that we use `availableCores()` to determine the number of cores available for parallelization, but keep one core free for other tasks. Some machines might freeze if all cores are busy with Python jobs. \index{Parallelization}

--- a/r/beta-estimation.qmd
+++ b/r/beta-estimation.qmd
@@ -163,6 +163,10 @@ beta_examples |>
 
 ## Parallelized Rolling-Window Estimation
 
+::: callout-tip
+For a single-regressor model such as the CAPM, the rolling regressions can also be computed in closed form from precomputed cumulants, which avoids fitting millions of individual models. Our blog post [Fast, Vectorized Beta Estimation](../blog/fast-beta-estimation/index.qmd) shows how to reproduce the results of this chapter in seconds, without parallelization.
+:::
+
 Even though we could now just apply the function using the approach from above on the whole CRSP sample, we advise against doing it as it is computationally quite expensive. Remember that we have to perform rolling-window estimations across all stocks and time periods. However, this estimation problem is an ideal scenario to employ the power of parallelization. Parallelization means that we split the tasks which perform rolling-window estimations across different workers (or cores on your local machine). 
 
 If you have a Windows or Mac machine, it makes most sense to define `multisession`, which means that separate R processes are running in the background on the same machine to perform the individual jobs. If you check out the documentation of `plan()`, you can also see other ways to resolve the parallelization in different environments. Note that we use `availableCores()` to determine the number of cores available for parallelization, but keep one core free for other tasks. Some machines might freeze if all cores are busy with R jobs. \index{Parallelization}


### PR DESCRIPTION
## What this addresses

Christoph's review on #222 asked two things this PR delivers:

> I wonder whether a similar approach can be implemented in R using tidyverse? In that case, the blog post could address both languages.

> A reference in the corresponding Python chapter to the blog post would be great.

**Short answer to the review question: yes, cleanly.** The cumulant trick is language-agnostic — for a single-regressor OLS, the coefficients and t-stats are closed-form functions of additive sums, so nothing is polars-specific.

## Changes

This PR is stacked on top of #222 (base = `blog/fast-beta-estimation`), so the diff is only the bilingual delta.

- **`blog/fast-beta-estimation/index.qmd`** is now bilingual, using `::: {.panel-tabset group="language"}` with R and Python tabs for every step (the established pattern from the *Tidy Market Microstructure* post). The R edition:
  - collapses to per-stock-month cumulants with `dplyr::summarize(.by = ...)`;
  - rolls the cumulants over a 60-month window with `slider::slide_index_sum()`, a C-level index-aware rolling sum (no R-level loop over windows);
  - indexes the window by an integer month counter (`year*12 + month`) rather than the calendar `date`, which sidesteps `lubridate`'s end-of-month `NA` arithmetic and defines the 60-month window unambiguously;
  - maps the sums to closed-form OLS with `mutate()`.
  - Because the regression is gone, the R version no longer needs `furrr` or the per-stock `nest()`/`future_map()` from the chapter — the whole CRSP universe goes through in one vectorized pass, exactly like the polars version.
- Retitled to **"Fast, Vectorized Beta Estimation"** and generalized the prose; added `R`, `tidyverse`, `slider` categories.
- Added a `callout-tip` in **both** `r/beta-estimation.qmd` and `python/beta-estimation.qmd` linking to the blog post.

## ⚠️ Needs a re-render by a maintainer (couldn't be done here)

This environment has no R, no Python data, and no Quarto, so the committed `docs/` HTML and `_freeze` output from #222 are **stale** and must be regenerated.

One thing to confirm during that render: the post now mixes R and Python in a single `.qmd`, unlike the rest of the book where the two editions live in separate files. Quarto will use the **knitr engine** with **reticulate** for the Python chunks, so `reticulate` needs to point at the Python environment that has `polars`, `plotnine`, and `statsmodels`. If a single mixed-engine document doesn't fit the render pipeline, the alternative is to split the R edition into its own sibling post — happy to do that instead.

## Still open from the review (not in this PR)
- A thumbnail (Christoph suggested one of the figures rather than AI art) — best added after the re-render, when the figure PNGs exist.

The R code mirrors the verified Python closed-form math exactly, but note it could not be executed/verified in this environment.


---
_Generated by [Claude Code](https://claude.ai/code/session_01CLpufYacd8Yc6JeEUugFKR)_