### PR TITLE
Fix two unrendered inline Python expressions

### DIFF
--- a/python/constrained-optimization-and-backtesting.qmd
+++ b/python/constrained-optimization-and-backtesting.qmd
@@ -372,7 +372,7 @@ weights_reg_t = pl.DataFrame(
 weights_reg_t.with_columns(pl.col(pl.Float64).round(3))
 ```
 
-@fig-1702 shows the optimal allocation weights across all `python len(industry_returns.columns)` industries for the four different strategies considered so far: minimum variance, efficient portfolio with $\gamma$ = 2, efficient portfolio with short-sale constraints, and the Regulation-T constrained portfolio.\index{Graph!Bar chart}
+@fig-1702 shows the optimal allocation weights across all `{python} len(industry_returns.columns)` industries for the four different strategies considered so far: minimum variance, efficient portfolio with $\gamma$ = 2, efficient portfolio with short-sale constraints, and the Regulation-T constrained portfolio.\index{Graph!Bar chart}
 
 ```{python}
 #| label: fig-1702

--- a/python/option-pricing-via-machine-learning.qmd
+++ b/python/option-pricing-via-machine-learning.qmd
@@ -149,7 +149,7 @@ option_prices = option_prices.with_columns(
 
 The code above generates more than 1.5 million random parameter constellations (in the definition of the `option_prices` dataframe). For each of these values, the *true* prices reflecting the Black-Scholes model are given and a random innovation term *pollutes* the observed prices. The intuition of this application is simple: the simulated data provides many observations of option prices, by using the Black-Scholes equation we can evaluate the actual predictive performance of a ML method, which would be hard in a realistic context where the actual arbitrage-free price would be unknown. 
 
-Next, we split the data into a training set (which contains 1 percent of all the observed option prices) and a test set that will only be used for the final evaluation. Note that the entire grid of possible combinations contains `python len(option_prices.columns)` different specifications. Thus, the sample to learn the Black-Scholes price contains only 31,489 observations and is therefore relatively small.
+Next, we split the data into a training set (which contains 1 percent of all the observed option prices) and a test set that will only be used for the final evaluation. Note that the entire grid of possible combinations contains `{python} f'{option_prices.shape[0]:,}'` different specifications. Thus, the sample to learn the Black-Scholes price contains only 31,489 observations and is therefore relatively small.
 
 ```{python}
 train_data, test_data = train_test_split(


### PR DESCRIPTION
## Problem

Two inline expressions in the rendered Python pages appeared as **literal code text** instead of computed values, because they used `` `python expr` `` rather than the correct Quarto inline syntax `` `{python} expr` ``:

- `constrained-optimization-and-backtesting.qmd`: "across all `` `python len(industry_returns.columns)` `` industries"
- `option-pricing-via-machine-learning.qmd`: "the entire grid ... contains `` `python len(option_prices.columns)` `` different specifications"

The option-pricing expression was **also semantically wrong**: it would have printed the column count (6), not the grid size.

Found by the systematic R↔Python rendered-output comparison.

## Fix

- Correct the inline syntax to `` `{python} ...` `` at both sites.
- option-pricing: change the expression to `option_prices.shape[0]` (formatted) so it reports the grid row count.

## Verification

- Grid size: 21 × 71 × 6 × 22 × 8 = **1,574,496** rows, matching the R edition's "1574496 different specifications".
- `{python}` is the working inline form used elsewhere (e.g. `working-with-stock-returns.qmd`).
- constrained-optimization `len(industry_returns.columns)` = **10** industries, matching R.

## Follow-ups

- Re-render is batched separately; option-pricing's slow `lbfgs` cell makes an isolated re-render expensive, so the freeze/docs update is deferred to the next full render pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)