### PR TITLE
Start rolling-beta windows at min_obs, matching the R edition

### DIFF
--- a/python/beta-estimation.qmd
+++ b/python/beta-estimation.qmd
@@ -115,7 +115,7 @@ def roll_capm_estimation(data, look_back=60, min_obs=48):
     results = []
     dates = data["date"].unique().sort()
 
-    for i in range(look_back - 1, len(dates)):
+    for i in range(min_obs - 1, len(dates)):
         end_date = dates[i]
         start_date = end_date - relativedelta(months=look_back - 1)
 


### PR DESCRIPTION
## Problem

`roll_capm_estimation` looped `for i in range(look_back - 1, len(dates))`, producing no estimate before a stock's **60th** observation month — even though `min_obs = 48`-observation windows are valid. The R edition (`slide_period`, `.complete = FALSE`) emits estimates from the **48th** month.

Consequences found in the cross-edition comparison:
- Python published **396,958 fewer** estimates (-8.5%)
- each stock's first 12 monthly estimates were missing (R doc: permno 10107 first estimate 1990-03-01; buggy Python: 1991-03-01)
- distribution tails trimmed (rendered monthly beta min **-9.02** vs R **-13.1**)

## Fix

Loop from `min_obs - 1`. The existing `estimate_capm` guard (`data.shape[0] < min_obs`) still rejects windows with too few observations, so the short early windows that qualify (48–59 months) now produce estimates, exactly as in R.

## Verification

Ran the fixed function on `data-python/crsp_monthly.parquet`:

| permno | first estimate (fixed) | R doc | data starts |
|---|---|---|---|
| 10107 | **1990-03-01** | 1990-03-01 ✓ | 1986-04 |
| 10001 | **1990-01-01** | 1990-01-01 ✓ | 1986-02 |

## Follow-ups

- The chapter re-render (multi-hour `smf.ols` loop over daily CRSP) is scheduled separately; it will regenerate `beta.parquet` with the corrected window set.
- The companion blog post (`blog/fast-beta-estimation`, vectorized version) uses `month_index >= look_back - 1` as its window gate and needs the analogous change to `>= min_obs - 1` in a follow-up so the two stay consistent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)