### PR TITLE
Pass optimization arguments through in evaluate_optimal_performance (R)

### DIFF
--- a/r/parametric-portfolio-policies.qmd
+++ b/r/parametric-portfolio-policies.qmd
@@ -320,9 +320,9 @@ evaluate_optimal_performance <- function(data,
     par = theta,
     fn = compute_objective_function,
     data = data,
-    objective_measure = "Expected utility",
-    value_weighting = TRUE,
-    allow_short_selling = TRUE,
+    objective_measure = objective_measure,
+    value_weighting = value_weighting,
+    allow_short_selling = allow_short_selling,
     method = "Nelder-Mead"
   )
 


### PR DESCRIPTION
## Problem

In `r/parametric-portfolio-policies.qmd`, the function

```r
evaluate_optimal_performance <- function(data, objective_measure,
                                         value_weighting, allow_short_selling)
```

hard-codes three arguments inside its `optim()` call:

```r
optimal_theta <- optim(
  par = theta, fn = compute_objective_function, data = data,
  objective_measure = "Expected utility",   # ignores the argument
  value_weighting   = TRUE,                 # ignores the argument
  allow_short_selling = TRUE,               # ignores the argument
  method = "Nelder-Mead"
)
```

So the optimal `theta` is **always** estimated for the value-weighted, unconstrained, expected-utility objective — regardless of what the caller requested. The later `compute_portfolio_weights()` / `evaluate_portfolio()` steps *do* use the passed arguments, so every "optimal" column of the performance table (incl. "no short selling" and the equal-weighted variants) applies weights derived from a `theta` optimized under the wrong objective.

Found via the systematic R↔Python rendered-output comparison.

## Fix

Pass the function's own `objective_measure` / `value_weighting` / `allow_short_selling` arguments through to `optim()`.

## Verification

Verified by code reading: the three literals become the corresponding parameters. The Python edition exhibits the analogous behavior — once its optimizer is corrected (separate PR on the polars branch), the optimal `theta` differs across `value_weighting` / `allow_short_selling` settings as expected, which corroborates the intended behavior. A full re-render of the R chapter (heavy `optim()` over the full CRSP sample) is left to the authors' standard render workflow.

## Follow-ups

- Re-render `r/parametric-portfolio-policies.qmd` to refresh the performance table.
- The Python edition's separate defects (optimizer tolerance, equal-weight benchmark) are fixed in a PR on `explore/polars-translation`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)