### PR TITLE
Fix optimizer tolerance and equal-weight benchmark in parametric portfolios

### DIFF
--- a/python/parametric-portfolio-policies.qmd
+++ b/python/parametric-portfolio-policies.qmd
@@ -165,7 +165,7 @@ def compute_portfolio_weights(theta,
       .with_columns(
         weight_benchmark=(
           pl.col("relative_mktcap") if value_weighting
-          else pl.lit(1/data.shape[0])
+          else (1/pl.len()).over("date")
         )
       )
       .with_columns(
@@ -379,7 +379,7 @@ def evaluate_optimal_performance(data,
       x0=[1.5]*n_parameters,
       args=(data, objective_measure, value_weighting, allow_short_selling),
       method="Nelder-Mead",
-      tol=10e-2
+      tol=1e-3
     ).x
 
     processed_data = compute_portfolio_weights(


### PR DESCRIPTION
## Problem

Two defects in `parametric-portfolio-policies.qmd`, found in the R↔Python output comparison:

1. **Optimizer tolerance typo.** `evaluate_optimal_performance` passed `tol=10e-2` (= 0.1) to `scipy.optimize.minimize`, so Nelder-Mead stalled at the start value `theta=(1.5, 1.5)`. The rendered VW-optimal Sharpe was **0.453** vs the R edition's 0.639.
2. **Equal-weight benchmark weight.** `compute_portfolio_weights` used `pl.lit(1/data.shape[0])` — one over the **total** panel rows (~3e-7) — instead of `1/N_t` per month. The printed EW weight statistics showed **0.000** (vs R's 0.0249) and the "EW Optimal" tilt column became economically meaningless (avg return **-4563**).

## Fix

1. `tol=10e-2` → `tol=1e-3`.
2. `pl.lit(1/data.shape[0])` → `(1/pl.len()).over("date")` (per-date equal weights).

## Verification (ran the chapter's pipeline on `data-python/crsp_monthly`)

Rebuilt `performance_table` end-to-end with the fixes:

| | VW Optimal | EW | EW Optimal |
|---|---|---|---|
| **Sharpe ratio** | **0.660** (R: 0.639; was 0.453) | 0.489 | 0.514 |
| **Average return** | 12.68 | 9.996 | **11.0** (was −4563) |
| **Mean abs. weight** | 0.047 | **0.036** (was 0.000) | 0.036 |

The optimizer now moves off `(1.5, 1.5)` and recovers a Sharpe matching the R edition; the EW benchmark weights are a sensible constant per-date `1/N_t`; the EW-Optimal column is economically sane. Residual R/Python differences (0.660 vs 0.639 Sharpe, 0.036 vs 0.0249 weight) are data-vintage/sample-period.

## Follow-ups

- Re-render (batched separately) to refresh `_freeze`/`docs`.
- The R edition has an independent, related defect (`evaluate_optimal_performance` hard-codes `optim()` arguments) — fixed in #231 on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)