### PR TITLE
Fix rolling-beta loop start so daily estimation is non-empty

### DIFF
--- a/python/beta-estimation.qmd
+++ b/python/beta-estimation.qmd
@@ -115,7 +115,7 @@ def roll_capm_estimation(data, look_back=60, min_obs=48):
     results = []
     dates = data["date"].unique().sort()
 
-    for i in range(min_obs - 1, len(dates)):
+    for i in range(len(dates)):
         end_date = dates[i]
         start_date = end_date - relativedelta(months=look_back - 1)
 


### PR DESCRIPTION
## Problem

#230 fixed the **monthly** rolling-beta windowing by changing the loop to `for i in range(min_obs - 1, len(dates))` so estimates begin at the 48th month (matching the R edition). That is correct when `min_obs` and `dates` share a unit (months).

But `roll_capm_estimation` is **also** used for the **daily** section with `min_obs = 1000` on data truncated to monthly dates. There the loop became `range(999, ~780)` — an empty range — so **the daily beta estimation produced no rows at all**. This is latent (the chapter's daily section hasn't been re-rendered since #230; precomputed `beta.parquet` predates it), but it would break the next daily re-render, the daily figures, and `beta.parquet`'s daily rows.

Found while making the companion blog post bilingual, which hit the identical issue.

## Fix

Start the loop at 0 and let `estimate_capm`'s existing `min_obs` guard gate the output by **observation count** rather than month-index:

```python
for i in range(len(dates)):
```

This is correct for both frequencies — monthly drops windows with < 48 observations, daily with < 1000 — and matches the R edition's `slide_period(.complete = FALSE)`. The early windows are cheap because `estimate_capm` returns an empty frame before fitting whenever `shape[0] < min_obs`.

## Verification (run on `data-python`)

| | result |
|---|---|
| Monthly, AAPL first estimate | **1984-12** (48th month — unchanged from #230's intent) |
| Daily, AAPL | **482 beta rows, mean β 1.3** (was empty); matches the R daily estimate |

## Follow-ups

- The pending overnight beta re-render will now produce correct daily estimates.
- The companion blog post (`blog/fast-beta-estimation`) already uses the equivalent `n >= min_obs` gate in its vectorized version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)