### PR TITLE
Proofread Python chapters and tighten tidyfinance usage

### DIFF
--- a/python/accessing-and-managing-financial-data.qmd
+++ b/python/accessing-and-managing-financial-data.qmd
@@ -145,7 +145,7 @@ All of these steps are doable, but none of them are really about finance - they 
 import tidyfinance as tf
 ```
 
-For example, we can use the `tf.download_data()` function of the package to download monthly Fama-French factors. The set *Fama/French 3 Factors* contains the return time series of the market (`mkt_excess`), size (`smb`), and value (`hml`) factors alongside the risk-free rates (`risk_free`). Note that the `tf.download_data()` function parses all the columns correctly and already scale them appropriately, as the raw Fama-French data comes in a unique data format. For precise descriptions of the variables, we suggest consulting Prof. Kenneth French's finance data library directly. If you are on the website, check the raw data files to appreciate the time you can save thanks to the `tidyfinance` package.\index{Factor!Market}\index{Factor!Size}\index{Factor!Value}\index{Factor!Profitability}\index{Factor!Investment}\index{Risk-free rate}
+For example, we can use the `tf.download_data()` function of the package to download monthly Fama-French factors. The set *Fama/French 3 Factors* contains the return time series of the market (`mkt_excess`), size (`smb`), and value (`hml`) factors alongside the risk-free rates (`risk_free`). Note that the `tf.download_data()` function parses all the columns correctly and already scales them appropriately, as the raw Fama-French data comes in a unique data format. For precise descriptions of the variables, we suggest consulting Prof. Kenneth French's finance data library directly. If you are on the website, check the raw data files to appreciate the time you can save thanks to the `tidyfinance` package.\index{Factor!Market}\index{Factor!Size}\index{Factor!Value}\index{Factor!Profitability}\index{Factor!Investment}\index{Risk-free rate}
 
 Because the downloaded data arrives with timestamp columns, we cast the `date` column to the polars `Date` type — calendar dates rather than timestamps — a convention we use for all tables we store in this book.
 
@@ -245,7 +245,7 @@ tf.download_data(
 
 ## Macroeconomic Predictors
 
-Our next data source is a set of macroeconomic variables often used as predictors for the equity premium. @Goyal2008 comprehensively reexamine the performance of variables suggested by the academic literature to be good predictors of the equity premium. The authors host the data on [Amit Goyal's website.](https://sites.google.com/view/agoyal145) Since the data is an XLSX-file stored on a public Google Drive location, we need additional packages to access the data directly from our Python session. Usually, you need to authenticate if you interact with Google drive directly in Python. Since the data is stored via a public link, we can proceed without any authentication.\index{Google Drive}
+Our next data source is a set of macroeconomic variables often used as predictors for the equity premium. @Goyal2008 comprehensively reexamine the performance of variables suggested by the academic literature to be good predictors of the equity premium. The authors host the data on [Amit Goyal's website.](https://sites.google.com/view/agoyal145) Since the data is an XLSX-file stored on a public Google Drive location, we need additional packages to access the data directly from our Python session. Usually, you need to authenticate if you interact with Google Drive directly in Python. Since the data is stored via a public link, we can proceed without any authentication.\index{Google Drive}
 
 ```{python}
 sheet_id = "1bM7vCWd3WOt95Sf9qjLPZjoiafgF_8EG"
@@ -267,7 +267,7 @@ Next, we read in the new data and transform the columns into the variables that 
 1. Net equity expansion (`ntis`), the ratio of 12-month moving sums of net issues by NYSE listed stocks divided by the total end-of-year market capitalization of NYSE stocks [@Campbell2008].
 1. Treasury bills (`tbl`), the 3-Month Treasury Bill: Secondary Market Rate from the economic research database at the Federal Reserve Bank at St. Louis [@Campbell1987].
 1. Long-term yield (`lty`), the long-term government bond yield from Ibbotson's Stocks, Bonds, Bills, and Inflation Yearbook [@Goyal2008].
-1. Long-term rate of returns (`ltr`), the long-term government bond returns from Ibbotson's Stocks, Bonds, Bills, and Inflation Yearbook [@Goyal2008].
+1. Long-term rate of return (`ltr`), the long-term government bond returns from Ibbotson's Stocks, Bonds, Bills, and Inflation Yearbook [@Goyal2008].
 1. Term spread (`tms`), the difference between the long-term yield on government bonds and the Treasury bill [@Campbell1987].
 1. Default yield spread (`dfy`), the difference between BAA and AAA-rated corporate bond yields [@Fama1989]. 
 1. Inflation (`infl`), the Consumer Price Index (All Urban Consumers) from the Bureau of Labor Statistics [@Campbell2004].
@@ -338,7 +338,7 @@ tf.download_data(
 
 ## Other Macroeconomic Data
 
-The Federal Reserve bank of St. Louis provides the Federal Reserve Economic Data (FRED), an extensive database for macroeconomic data. In total, there are 817,000 US and international time series from 108 different sources. As an illustration, we use the `tidyfinance` package to fetch consumer price index (CPI) data that can be found under the [CPIAUCNS](https://fred.stlouisfed.org/series/CPIAUCNS) key.\index{Data!FRED}\index{Data!CPI}
+The Federal Reserve Bank of St. Louis provides the Federal Reserve Economic Data (FRED), an extensive database for macroeconomic data. In total, there are 817,000 US and international time series from 108 different sources. As an illustration, we use the `tidyfinance` package to fetch consumer price index (CPI) data that can be found under the [CPIAUCNS](https://fred.stlouisfed.org/series/CPIAUCNS) key.\index{Data!FRED}\index{Data!CPI}
 
 ```{python}
 series = "CPIAUCNS"
@@ -382,7 +382,7 @@ To download other time series, we just have to look it up on the FRED website an
 
 ## Setting Up a Database
 
-Now that we have downloaded some (freely available) data from the web into the memory of our Python session let store that information for future use. We will use the data stored throughout the following chapters, but you could alternatively implement a different strategy and replace the respective code.
+Now that we have downloaded some (freely available) data from the web into the memory of our Python session, let us store that information for future use. We will use the data stored throughout the following chapters, but you could alternatively implement a different strategy and replace the respective code.
 
 There are many ways to set up and organize your data, depending on the use case. Storing data as Parquet files creates a universal data format that seamlessly works across different programming languages and platforms. Unlike CSV files that often lose data types when shared between R, Python, Julia, or other languages, Parquet files maintain perfect data integrity regardless of which tool reads them. A dataset saved as Parquet in Python can be opened directly in Python's pandas, or Julia's DataFrames.jl.^[In previous editions of this book, we suggested using SQLite databases. However, Parquet files are more versatile and easier to handle across different programming languages. Should you still prefer using SQLite, you can find the relevant code snippets in a separate blog post.]
 ```{python}
@@ -428,7 +428,7 @@ for key, value in data_dict.items():
 
 - Importing Fama-French factors, q-factors, macroeconomic indicators, and CPI data is simplified through API calls, CSV parsing, and web scraping techniques.
 - The `tidyfinance` Python package offers pre-processed access to financial datasets, reducing manual data cleaning and saving valuable time.
-- Creating a centralized SQLite database helps manage and organize data efficiently across projects, while maintaining reproducibility.
+- Storing data as Parquet files helps manage and organize data efficiently across projects, while maintaining reproducibility.
 - Structured database storage supports scalable data access, which is essential for long-term academic projects and collaborative work in finance.
 
 ## Exercises

--- a/python/beta-estimation.qmd
+++ b/python/beta-estimation.qmd
@@ -174,12 +174,12 @@ capm_examples = (pl.concat([
 capm_examples
 ```
 
-@fig-601 displays the resulting beta estimates, focusing exclusively on the coefficient fo `"mkt_excess"`.
+@fig-601 displays the resulting beta estimates, focusing exclusively on the coefficient for `"mkt_excess"`.
 
 ```{python}
 #| label: fig-601
 #| fig-cap: "The figure shows monthly beta estimates for example stocks using five years of data. The CAPM betas are estimated with monthly data and a rolling window of length five years based on adjusted excess returns from CRSP. We use market excess returns from Kenneth French data library."
-#| fig-alt: "Title: Monthly beta estimates for example stocks using five years of data. The figure shows a time series of beta estimates based on five years of monthly data for Apple, Berkshire Hathaway, Microsoft, and Tesla. The estimated betas vary over time and across varies but are always positive for each stock."
+#| fig-alt: "Title: Monthly beta estimates for example stocks using five years of data. The figure shows a time series of beta estimates based on five years of monthly data for Apple, Berkshire Hathaway, Microsoft, and Tesla. The estimated betas vary over time and across stocks but are always positive for each stock."
 #| fig-pos: "htb"
 beta_examples_sub = (capm_examples
     .join(examples, how="left", on="permno")
@@ -208,7 +208,7 @@ beta_figure.show()
 
 Even though we could now just apply the function to each group on the whole CRSP sample, we advise against doing it as it is computationally quite expensive. Remember that we have to perform rolling-window estimations across all stocks and time periods. However, this estimation problem is an ideal scenario to employ the power of parallelization. Parallelization means that we split the tasks which perform rolling-window estimations across different workers (or cores on your local machine). 
 
-If you have a Windows or Mac machine, it makes most sense use the default parallelization backend of `joblib`, which means that separate Python processes are running in the background on the same machine to perform the individual jobs. If you check out the documentation of `joblib.parallel_config()`, you can also see other ways to resolve the parallelization in different environments. Note that we use `availableCores()` to determine the number of cores available for parallelization, but keep one core free for other tasks. Some machines might freeze if all cores are busy with Python jobs. \index{Parallelization}
+If you have a Windows or Mac machine, it makes most sense to use the default parallelization backend of `joblib`, which means that separate Python processes are running in the background on the same machine to perform the individual jobs. If you check out the documentation of `joblib.parallel_config()`, you can also see other ways to resolve the parallelization in different environments. Note that we use `cpu_count()` to determine the number of cores available for parallelization, but keep one core free for other tasks. Some machines might freeze if all cores are busy with Python jobs. \index{Parallelization}
 
 ```{python}
 n_cores = cpu_count() - 1
@@ -416,7 +416,7 @@ beta_daily = (capm_daily
 beta = pl.concat([beta_monthly, beta_daily])
 ```
 
-To compare the difference between daily and monthly data, we combine beta estimates to a single table. Then, we use the table to plot a comparison of beta estimates for our example stocks in @fig-604. 
+Then, we use the table to plot a comparison of beta estimates for our example stocks in @fig-604.
 
 ```{python} 
 #| label: fig-604
@@ -530,9 +530,9 @@ Indeed, we find a positive correlation between our beta estimates. In the subseq
 
 ## Key Takeaways
 
-- CAPM betas can be estimated using rolling-window estimation  and processed in parallel via `joblib`.
+- CAPM betas can be estimated using rolling-window estimation and processed in parallel via `joblib`.
 - Both monthly and daily return data can be used to estimate betas with different frequencies and window lengths, depending on the application.
--  Summary statistics, visualization, and plausibility checks help to validate beta estimates across time and industries.
+- Summary statistics, visualization, and plausibility checks help to validate beta estimates across time and industries.
 
 ## Exercises
 

--- a/python/capital-asset-pricing-model.qmd
+++ b/python/capital-asset-pricing-model.qmd
@@ -72,7 +72,7 @@ returns_monthly = (prices_daily
 )
 ```
 
-The relationship between risk and return is central to the CAPM. Intuitively, one may expect that assets with higher volatility should also deliver higher expected returns. Instead, the CAPM's key insight states that not all risks are rewarded in equilibrium. Only so-called systematic risk of an asset will determine the assets expected return. To understand this, we need to distinguish between systematic and idiosyncratic risk.
+The relationship between risk and return is central to the CAPM. Intuitively, one may expect that assets with higher volatility should also deliver higher expected returns. Instead, the CAPM's key insight states that not all risks are rewarded in equilibrium. Only so-called systematic risk of an asset will determine the asset's expected return. To understand this, we need to distinguish between systematic and idiosyncratic risk.
 
 Company-specific events might affect individual stock prices, e.g., CEO resignations, product launches, and earnings reports. These idiosyncratic events don't necessarily impact the overall market and this asset-specific risk can be eliminated through diversification. Therefore, we call this risk idiosyncratic. Systematic risk, on the other hand, affects all assets in the market at the same time and investors really dislike it because it cannot be diversified away.
 
@@ -84,7 +84,7 @@ To recap, we considered a portfolio weight vector $\omega\in\mathbb{R}^N$ which 
 
 $$\mu_\omega = \omega^{\prime}\mu + (1-\iota^{\prime}\omega)r_f = r_f + \omega^{\prime}\underbrace{(\mu-r_f)}_{\tilde\mu}.$$
 
-where $\mu$ is the the vector of expected return of assets and $r_f$ is the risk-free rate. In what follows, we refer to $\tilde\mu$ as the vector of expected *excess* returns. 
+where $\mu$ is the vector of expected return of assets and $r_f$ is the risk-free rate. In what follows, we refer to $\tilde\mu$ as the vector of expected *excess* returns. 
 
 By assumption, the risk-free asset has zero volatility. Therefore, the volatility of the portfolio is given by
 
@@ -126,12 +126,12 @@ $$
 
 is central to the CAPM and is typically called the efficient tangency portfolio.
 
-For illustrative purposes, we compute the efficient tangency portfolio for our hypothetical asset universe. As a realistic proxy for the risk-free rate, we use the average13-week T-bill rate (traded with the symbol ^IRX). Since the prices are quoted in annualized percentage yields, we have to divide them by 100 and convert them to monthly rates. 
+For illustrative purposes, we compute the efficient tangency portfolio for our hypothetical asset universe. As a realistic proxy for the risk-free rate, we use the average 13-week T-bill rate (traded with the symbol ^IRX). Since the prices are quoted in annualized percentage yields, we have to divide them by 100 and convert them to monthly rates. 
 
 ```{python}
 risk_free_monthly = (
   pl.from_pandas(
-    tf.download_data("stock_prices", symbols="^IRX", start_date="2019-10-01", end_date="2024-09-30")
+    tf.download_data(domain="stock_prices", symbols="^IRX", start_date="2019-10-01", end_date="2024-09-30")
   )
   .with_columns(
     risk_free=(1 + pl.col("adjusted_close") / 100)**(1/12) - 1
@@ -174,7 +174,7 @@ We are ready to illustrate the resulting efficient frontier. Every investor choo
 
 $$\frac{\omega^{\prime}_\text{tan}\mu-r_f}{\omega_\text{tan}^{\prime}\Sigma\omega_\text{tan}^{\prime}}.$$
 
-Typically, the excess return of an asset scaled by its volatility, $\frac{\tilde\mu_i}{\sigma_i}$, is called the Sharpe ratio of the asset. Thus, the slope of the efficient frontier corresponds to the Sharpe ratio of the tangency portfolio returns. By construction, the tangency portfolio is the maximum Sharpe ratio portfolio.^[We proof in the Appendix [Proofs](proofs.qmd) that the efficient tangency portfolio $\omega_\text{tan}$ can also be derived as a solution to the optimization problem $\max_{\omega} \frac{\omega^{\prime}\tilde\mu}{\sqrt{\omega^{\prime}\Sigma\omega}} \text{ s.t. } \omega^{\prime}\iota=1.$]
+Typically, the excess return of an asset scaled by its volatility, $\frac{\tilde\mu_i}{\sigma_i}$, is called the Sharpe ratio of the asset. Thus, the slope of the efficient frontier corresponds to the Sharpe ratio of the tangency portfolio returns. By construction, the tangency portfolio is the maximum Sharpe ratio portfolio.^[We prove in the Appendix [Proofs](proofs.qmd) that the efficient tangency portfolio $\omega_\text{tan}$ can also be derived as a solution to the optimization problem $\max_{\omega} \frac{\omega^{\prime}\tilde\mu}{\sqrt{\omega^{\prime}\Sigma\omega}} \text{ s.t. } \omega^{\prime}\iota=1.$]
 
 ```{python}
 w_tan = np.linalg.solve(sigma, mu - rf)
@@ -193,7 +193,7 @@ efficient_portfolios = pl.DataFrame(
 sharpe_ratio = (mu_w - rf) / sigma_w
 ```
 
-@fig-300 shows the resulting efficient frontiert with the efficient portfolio and a risk-free asset. 
+@fig-300 shows the resulting efficient frontier with the efficient portfolio and a risk-free asset. 
 
 ```{python}
 #| label: fig-300
@@ -232,7 +232,7 @@ Now, note the following three simple derivations:
 
 1. The expected excess return of the efficient tangency portfolio, $\tilde\mu_\text{tan}$ is given by $E(\omega_\text{tan}^{\prime} r - r_f) = \omega_\text{tan} \tilde\mu = \frac{\tilde\mu^{\prime}\Sigma^{-1}\tilde\mu}{\iota^{\prime}\Sigma^{-1}\tilde\mu}$.
 2. The variance of the returns of the efficient tangency portfolio $\sigma_\text{tan}^2$ is given by $\text{Var}(\omega_\text{tan}^{\prime} r) = \omega_\text{tan}^{\prime} \Sigma \omega_\text{tan}^{\prime} = \frac{\tilde\mu^{\prime}\Sigma^{-1}\tilde\mu}{(\iota^{\prime}\Sigma^{-1}\tilde\mu)^2}$. It follows that $\frac{\tilde\mu_\text{tan}}{\sigma_\text{tan}^2} = \iota^{\prime}\Sigma^{-1}\tilde\mu$
-3. The $i$-th element of the vector $\Sigma\omega_\text{tan}$ is $\sum\limits_{j=1}^N \sigma_{ij}\omega_{j,\text{tan}}= \text{Cov}\left(r_i, \sum\limits_{j=1}^N r_i'\omega_{j,\text{tan}}\right) = \text{Cov}\left(r_i, r_\text{tan}\right)$, which is the covariance of assets $i$ returns with the returns of the efficient tangency portfolio. 
+3. The $i$-th element of the vector $\Sigma\omega_\text{tan}$ is $\sum\limits_{j=1}^N \sigma_{ij}\omega_{j,\text{tan}}= \text{Cov}\left(r_i, \sum\limits_{j=1}^N r_i'\omega_{j,\text{tan}}\right) = \text{Cov}\left(r_i, r_\text{tan}\right)$, which is the covariance of asset $i$'s returns with the returns of the efficient tangency portfolio. 
   
 Putting everything together yields for the expected excess return of asset $i$: 
 
@@ -240,7 +240,7 @@ $$
 \tilde{\mu}_i = \frac{E(\omega_\text{tan}^{\prime}r - r_f)}{\sigma_{\text{tan}}^2} \text{Cov}\left(r_i,r_\text{tan}\right) = \beta_i \tilde{\mu}_\text{tan}.
 $$
 
-The equation above is the famous CAPM equation and central to asset pricing. It states that an assets expected excess return is proportional to the assets return covariance with the efficient portfolio excess returns. The price of risk is the excess return of the efficient tangency portfolio. An asset with 0 beta has the same expected return as the risk-free rate. An asset with a beta of 1 has the same expected return as the efficient tangency portfolio. An asset with a negative beta has expected returns lower than the risk-free asset - the very definition of an insurance. Therefore, the CAPM equation explains why some assets may have the same volatility but different returns: Because their systematic risk ($\beta_i$) is different.
+The equation above is the famous CAPM equation and central to asset pricing. It states that an asset's expected excess return is proportional to the asset's return covariance with the efficient portfolio excess returns. The price of risk is the excess return of the efficient tangency portfolio. An asset with 0 beta has the same expected return as the risk-free rate. An asset with a beta of 1 has the same expected return as the efficient tangency portfolio. An asset with a negative beta has expected returns lower than the risk-free asset - the very definition of an insurance. Therefore, the CAPM equation explains why some assets may have the same volatility but different returns: Because their systematic risk ($\beta_i$) is different.
 
 We derived the CAPM equation as a consequence of efficient wealth allocation. Suppose an asset delivers high expected returns. The investor will increase her holdings of the assets in order to benefit from the high promised returns. As a consequence, the covariance of the asset with the efficient tangency portfolio will increase (mechanically, as the asset gradually becomes a larger part of the efficient tangency portfolio). At some point, the weight of the asset is so high that gain of $\tilde\mu_i$ of marginally increasing the holding does not offset the implied increase in systematic risk. The investor will stop increasing her holdings and the asset's expected return will be proportional to its systematic risk. 
 
@@ -372,7 +372,7 @@ Another crucial limitation concerns the stability of beta over time. The model a
 
 Perhaps most importantly, empirical evidence suggests that systematic risk alone cannot fully explain asset returns. Numerous studies have documented patterns in stock returns that CAPM cannot explain. Small-cap stocks tend to outperform large-cap stocks, and value stocks (those with high book-to-market ratios) tend to outperform growth stocks, even after adjusting for market risk. These "anomalies" suggest that investors may care about multiple dimensions of risk beyond market sensitivity.
 
-These limitations have spawned a rich literature of alternative and extended models. The Fama-French three-factor model [@@Fama1992] represents a seminal extension, adding two factors to capture the size and value effects:
+These limitations have spawned a rich literature of alternative and extended models. The Fama-French three-factor model [@Fama1992] represents a seminal extension, adding two factors to capture the size and value effects:
 
 - The SMB (Small Minus Big) factor captures the tendency of small stocks to outperform large stocks, as we discuss in our chapter [Size Sorts and P-Hacking](size-sorts-and-p-hacking.qmd).
 - The HML (High Minus Low) factor captures the tendency of value stocks to outperform growth stocks, as we show in [Value and Bivariate Sorts](value-and-bivariate-sorts.qmd).

--- a/python/constrained-optimization-and-backtesting.qmd
+++ b/python/constrained-optimization-and-backtesting.qmd
@@ -11,7 +11,7 @@ exec(open("python/render-settings.py").read())
 ```
 
 ::: {.callout-note}
-You are reading **Tidy Finance with Python**. You can find the equivalent chapter for the sibling **Tidy Finance with R**[here](../r/constrained-optimization-and-backtesting.qmd).
+You are reading **Tidy Finance with Python**. You can find the equivalent chapter for the sibling **Tidy Finance with R** [here](../r/constrained-optimization-and-backtesting.qmd).
 :::
 
 \index{Backtesting} In this chapter, we conduct portfolio backtesting in a realistic setting by including transaction costs and investment constraints such as no-short-selling rules.\index{Short-selling} We start with standard mean-variance efficient portfolios and introduce constraints in a step-by-step manner. To do so, we rely on numerical optimization procedures in Python.\index{Efficient portfolio} We conclude the chapter by providing an out-of-sample backtesting procedure for the different strategies that we introduce in this chapter. 
@@ -91,7 +91,7 @@ $$
 \omega^*_{\gamma} = \frac{1}{\gamma}\left(\Sigma^{-1} - \frac{1}{\iota' \Sigma^{-1}\iota }\Sigma^{-1}\iota\iota' \Sigma^{-1} \right) \mu + \frac{1}{\iota' \Sigma^{-1} \iota }\Sigma^{-1} \iota.
 $${#eq-analytical-solution-mv}
 
-To proof this statement, we refer to the derivations in [Proofs](proofs.qmd). Empirically, this classical solution imposes many problems. In particular, the estimates of $\mu$ are noisy over short horizons, the ($N \times N$) matrix $\Sigma$ contains $N(N-1)/2$ distinct elements and thus, estimation error is huge. Seminal papers on the effect of ignoring estimation uncertainty, among others, are @Brown1976, @Jobson1980, @Jorion1986, and @Chopra1993.
+To prove this statement, we refer to the derivations in [Proofs](proofs.qmd). Empirically, this classical solution imposes many problems. In particular, the estimates of $\mu$ are noisy over short horizons, the ($N \times N$) matrix $\Sigma$ contains $N(N-1)/2$ distinct elements and thus, estimation error is huge. Seminal papers on the effect of ignoring estimation uncertainty, among others, are @Brown1976, @Jobson1980, @Jorion1986, and @Chopra1993.
 
 Even worse, if the asset universe contains more assets than available time periods $(N > T)$, the sample covariance matrix is no longer positive definite such that the inverse $\Sigma^{-1}$ does not exist anymore. To address estimation issues for vast-dimensional covariance matrices, regularization techniques [see, e.g., @Ledoit2003; @Ledoit2004; @Ledoit2012; @Fan2008] and the parametric approach from the previous chapter are popular tools.\index{Covariance}
 

--- a/python/discounted-cash-flow-analysis.qmd
+++ b/python/discounted-cash-flow-analysis.qmd
@@ -264,7 +264,7 @@ The model estimates two parameters: (i) an intercept that captures the company's
 
 ```{python}
 #| label: fig-502
-#| fig-cap: "Realized revenue growth rates are based on financial statements provided through the FMP API, while forecasts are modeled unsing IMF WEO forecasts." 
+#| fig-cap: "Realized revenue growth rates are based on financial statements provided through the FMP API, while forecasts are modeled using IMF WEO forecasts." 
 #| fig-alt: "Title: GDP growth and Microsoft's revenue growth and modeled forecasts between 2021 and 2030. The figure shows a line chart with years on the horizontal axis and GDP growth, revenue growth, and their projections on the vertical axis."
 revenue_growth = (dcf_data
   .filter(pl.col("year") >= 2021)
@@ -352,7 +352,7 @@ The most common approach is the Perpetuity Growth Model (or Gordon Growth Model)
 
 $$TV_{T} = \frac{FCF_{T+1}}{r - g},$$
 
-where $TV_{T}$ is the terminal value at time $T$, $FCF_{T+1}$ is the free cash flow in the first year after our forecast period, $r$ is the discount rate (typically WACC, see below), and $g$ is the perpetual growth rate. A common mistake is to ignore the time shift in the model. You must compute $FCF_{T+1}$, which is equal to $FCF_{T}\cdot(1+g)$
+where $TV_{T}$ is the terminal value at time $T$, $FCF_{T+1}$ is the free cash flow in the first year after our forecast period, $r$ is the discount rate (typically WACC, see below), and $g$ is the perpetual growth rate. A common mistake is to ignore the time shift in the model. You must compute $FCF_{T+1}$, which is equal to $FCF_{T}\cdot(1+g)$.
 
 The perpetual growth rate $g$ should reflect the long-term economic growth potential. A common benchmark is the long-term GDP growth rate, as few companies can sustainably grow faster than the overall economy indefinitely.\index{Growth rate!Perpetual} Exceeding GDP growth indefinitely also implies that the whole economy eventually consists of one company. For example, the last 20 years of GDP growth is a sensible assumption (the nominal growth rate is 4% for the US).
 
@@ -370,7 +370,7 @@ terminal_value = compute_terminal_value(
 print(np.round(terminal_value / 1e9))
 ```
 
-Note that while we use the Perpetuity Growth Model here, practitioners often cross-check their estimates with alternative methods like the exit multiple approach, which bases the terminal value on comparable company valuations.^[See (corporatefinanceinstitute.com/)[https://corporatefinanceinstitute.com/resources/valuation/exit-multiple/)] for an intuitive explanation of the exit multiple approach.]
+Note that while we use the Perpetuity Growth Model here, practitioners often cross-check their estimates with alternative methods like the exit multiple approach, which bases the terminal value on comparable company valuations.^[See [corporatefinanceinstitute.com](https://corporatefinanceinstitute.com/resources/valuation/exit-multiple/) for an intuitive explanation of the exit multiple approach.]
 \index{Valuation methods!Exit multiple}
 
 ## Discount Rate

--- a/python/factor-selection-via-machine-learning.qmd
+++ b/python/factor-selection-via-machine-learning.qmd
@@ -50,9 +50,9 @@ $$
 \hat{\beta}^\text{ridge} = \left(X'X + \lambda I\right)^{-1}X'y,
 $${#eq-ridge} 
 
-where $I$ is the identity matrix of dimension $K$. A couple of observations are worth noting: $\hat\beta^\text{ridge} = \hat\beta^\text{ols}$ for $\lambda = 0$ and $\hat\beta^\text{ridge} \rightarrow 0$ for $\lambda\rightarrow \infty$. Also for $\lambda > 0$, $\left(X'X + \lambda I\right)$ is non-singular even if $X'X$ is which means that $\hat\beta^\text{ridge}$ exists even if $\hat\beta$ is not defined. However, note also that the Ridge estimator requires careful choice of the hyperparameter $\lambda$ which controls the *amount of regularization*: a larger value of $\lambda$ implies *shrinkage* of the regression coefficient toward 0; a smaller value of $\lambda$ reduces the bias of the resulting estimator. 
+where $I$ is the identity matrix of dimension $K$. A couple of observations are worth noting: $\hat\beta^\text{ridge} = \hat\beta^\text{ols}$ for $\lambda = 0$ and $\hat\beta^\text{ridge} \rightarrow 0$ for $\lambda\rightarrow \infty$. Also for $\lambda > 0$, $\left(X'X + \lambda I\right)$ is non-singular even if $X'X$ is singular, which means that $\hat\beta^\text{ridge}$ exists even if $\hat\beta$ is not defined. However, note also that the Ridge estimator requires careful choice of the hyperparameter $\lambda$ which controls the *amount of regularization*: a larger value of $\lambda$ implies *shrinkage* of the regression coefficient toward 0; a smaller value of $\lambda$ reduces the bias of the resulting estimator. 
 
-::: {.calloutnote}
+::: {.callout-note}
 Note that $X$ usually contains an intercept column with ones. As a general rule, the associated intercept coefficient is not penalized. In practice, this often implies that $y$ is simply demeaned before computing $\hat\beta^\text{ridge}$.
 ::: 
 
@@ -331,7 +331,7 @@ coefficients_ridge = (pd.DataFrame(coefficients_ridge)
 )
 ```
 
-The dataframes `lasso_coefficients` and `ridge_coefficients` contain an entire sequence of estimated coefficients for multiple values of the penalty factor $\lambda$. @fig-1403 illustrates the trajectories of the regression coefficients as a function of the penalty factor. Both Lasso and Ridge coefficients converge to zero as the penalty factor increases.\index{Graph!Coefficient path}
+The dataframes `coefficients_lasso` and `coefficients_ridge` contain an entire sequence of estimated coefficients for multiple values of the penalty factor $\lambda$. @fig-1403 illustrates the trajectories of the regression coefficients as a function of the penalty factor. Both Lasso and Ridge coefficients converge to zero as the penalty factor increases.\index{Graph!Coefficient path}
 
 ```{python}
 #| label: fig-1403 
@@ -531,7 +531,7 @@ selected_factors_figure = (
 selected_factors_figure.show()
 ```
 
-The heat map in @fig-1405 conveys two main insights: first, we see that many factors, macroeconomic variables, and interaction terms are not relevant for explaining the cross-section of returns across the industry portfolios. In fact, only `factor_ff_mkt_excess` and its interaction with `macro_bm` a role for several industries. Second, there seems to be quite some heterogeneity across different industries. While barely any variable is selected by Lasso for Utilities, many factors are selected for, e.g., Durable and Manufacturing, but the selected factors do not necessarily coincide. In other words, there seems to be a clear picture that we do not need many factors, but Lasso does not provide a factor that consistently provides pricing abilities across industries.
+The heat map in @fig-1405 conveys two main insights: first, we see that many factors, macroeconomic variables, and interaction terms are not relevant for explaining the cross-section of returns across the industry portfolios. In fact, only `factor_ff_mkt_excess` and its interaction with `macro_bm` play a role for several industries. Second, there seems to be quite some heterogeneity across different industries. While barely any variable is selected by Lasso for Utilities, many factors are selected for, e.g., Durable and Manufacturing, but the selected factors do not necessarily coincide. In other words, there seems to be a clear picture that we do not need many factors, but Lasso does not provide a factor that consistently provides pricing abilities across industries.
 
 ## Key Takeaways
 

--- a/python/fama-macbeth-regressions.qmd
+++ b/python/fama-macbeth-regressions.qmd
@@ -188,6 +188,6 @@ tf.estimate_fama_macbeth(
 
 ## Exercises
 
-1. Estimate stock-specific value and size risk factors to similar to the CAPM-beta using rolling estimation based on Fama-French 3 Factors. Use these estimates instead of the stock characteristics in the Fama-MacBeth regression from above. How do the coefficient estimates differ?
+1. Estimate stock-specific value and size risk factors similar to the CAPM-beta using rolling estimation based on Fama-French 3 Factors. Use these estimates instead of the stock characteristics in the Fama-MacBeth regression from above. How do the coefficient estimates differ?
 1. Download the 49 Industry Portfolios from Ken French data library. Use these industry portfolios instead of the stocks to estimate the three rolling risk-factors (beta, value, size). Replicate the Fama-MacBeth regression from above. Are the coefficient estimates similar?
 1. Use individual stocks with weighted-least squares based on a firm's size as suggested by @Hou2020. Then, repeat the Fama-MacBeth regressions without the weighting-scheme adjustment but drop the smallest 20 percent of firms each month. Compare the results of the three approaches. 

--- a/python/financial-statement-analysis.qmd
+++ b/python/financial-statement-analysis.qmd
@@ -19,9 +19,9 @@ Financial statements and ratios are fundamental tools for understanding and eval
 
 Building on this standardized information, financial ratios transform raw accounting data into meaningful metrics that facilitate analysis across companies and over time. These ratios serve multiple purposes in both academic research and practical applications. They enable investors to benchmark companies against their peers, identify industry trends, and screen for investment opportunities. In academic finance, ratios play a crucial role in asset pricing models (e.g., the book-to-market ratio in the Fama-French three-factor model) and corporate finance (e.g., capital structure research). In many practical applications, ratios help assess a company's financial health and performance.
 
-This chapter demonstrates how to access, process, and analyze financial statements using R. We start by reviewing the financial statements balance sheet, income statement, and cash flow statement. Then, we download publicly available statements to calculate key financial ratios, implement common screening strategies, and evaluate companies. Our analysis combines theoretical frameworks with practical implementation, providing tools for both academic research and investment practice.
+This chapter demonstrates how to access, process, and analyze financial statements using Python. We start by reviewing the financial statements balance sheet, income statement, and cash flow statement. Then, we download publicly available statements to calculate key financial ratios, implement common screening strategies, and evaluate companies. Our analysis combines theoretical frameworks with practical implementation, providing tools for both academic research and investment practice.
 
-For the purpose of this chapter, we use financial statements provided by the US Securities and Exchange Commission (i.e., SEC). While the SEC provides a web interface to search filings, programmatic access to financial statements greatly facilitates systematic analyses as ours. The Financial Modeling Prep (FMP) API offers such programmatic access, which we can leverage through the R package `fmpapi`.
+For the purpose of this chapter, we use financial statements provided by the US Securities and Exchange Commission (i.e., SEC). While the SEC provides a web interface to search filings, programmatic access to financial statements greatly facilitates systematic analyses as ours. The Financial Modeling Prep (FMP) API offers such programmatic access, which we can leverage through the Python package `fmpapi`.
 
 The FMP API's free tier provides access to:
 
@@ -143,7 +143,7 @@ pl.from_pandas(
 )
 ```
 
-In later sections, we will use income statement items to calculate important profitability ratios and examine how they compare across companies and industries. The income statement's focus on performance complements the balance sheet's position snapshot, providing a more complete picture of a company's core business operations
+In later sections, we will use income statement items to calculate important profitability ratios and examine how they compare across companies and industries. The income statement's focus on performance complements the balance sheet's position snapshot, providing a more complete picture of a company's core business operations.
 
 ## Cash Flow Statements
 
@@ -229,7 +229,7 @@ The most conservative liquidity measure is the Cash Ratio:
 
 $$\text{Cash Ratio} = \frac{\text{Cash and Cash Equivalents}}{\text{Current Liabilities}}$$
 
-This ratio focuses solely on the most liquid assets - cash and cash equivalents. While a ratio of one indicates robust liquidity, most companies maintain lower cash ratios to avoid holding excessive non-productive assets. Afterall, all that cash could also be distributed to equity or pay down costly debt.
+This ratio focuses solely on the most liquid assets - cash and cash equivalents. While a ratio of one indicates robust liquidity, most companies maintain lower cash ratios to avoid holding excessive non-productive assets. After all, all that cash could also be distributed to equity or pay down costly debt.
 
 Next, we calculate these ratios for all stocks, focusing on three major technology companies:
 
@@ -278,7 +278,7 @@ liquidity_ratios_figure = (
 liquidity_ratios_figure.show()
 ```
 
-While we are not commenting on the ratios in detail here, the liquidity ratios for Microsoft, Apple, and Amazon in 2023 reveal distinct patterns. Generally, higher liquidity ratios signal a more convervative approach by holding larger liquidity buffers in the company. 
+While we are not commenting on the ratios in detail here, the liquidity ratios for Microsoft, Apple, and Amazon in 2023 reveal distinct patterns. Generally, higher liquidity ratios signal a more conservative approach by holding larger liquidity buffers in the company. 
 
 ## Leverage Ratios
 
@@ -467,7 +467,7 @@ combined_statements = (combined_statements
 )
 ```
 
-We leave the visualization and interpretation of these figures as an exercise and move on the the last category of financial ratios. 
+We leave the visualization and interpretation of these figures as an exercise and move on to the last category of financial ratios. 
 
 ## Profitability Ratios
 
@@ -623,7 +623,7 @@ These combined rankings highlight how different business models and strategies l
 The Fama-French five-factor model aims to explain stock returns by incorporating specific financial metrics ratios. We provide more details in [Replicating Fama-French Factors](replicating-fama-and-french-factors.qmd), but here is an intuitive overview:
 
 - Size: Calculated as the logarithm of a company’s market capitalization, which is the total market value of its outstanding shares. This factor captures the tendency for smaller firms to outperform larger ones over time.
-- Book-to-market ratio: Determined by dividing the company’s book equity by its market capitalization. A higher ratio indicates a 'value' stock, while a lower ratio suggests a 'growth'’' stock. This metric helps differentiate between undervalued and overvalued companies.
+- Book-to-market ratio: Determined by dividing the company’s book equity by its market capitalization. A higher ratio indicates a 'value' stock, while a lower ratio suggests a 'growth' stock. This metric helps differentiate between undervalued and overvalued companies.
 - Profitability: Measured as the ratio of operating profit to book equity, where operating profit is calculated as revenue minus cost of goods sold (COGS), selling, general, and administrative expenses (SG&A), and interest expense. This factor assesses a company’s efficiency in generating profits from its equity base.
 - Investment: Calculated as the percentage change in total assets from the previous period. This factor reflects the company’s growth strategy, indicating whether it is investing aggressively or conservatively.
 

--- a/python/fixed-effects-and-clustered-standard-errors.qmd
+++ b/python/fixed-effects-and-clustered-standard-errors.qmd
@@ -198,7 +198,7 @@ model_fe_firmyear.summary()
 
 The inclusion of time fixed effects did only marginally affect the R-squared and the coefficients, which we can interpret as a good thing as it indicates that the coefficients are not driven by an omitted variable that varies over time. 
 
-How can we further improve the robustness of our regression results? Ideally, we want to get rid of unexplained variation at the firm-year level, which means we need to include more variables that vary across firm *and* time and are likely correlated with investment. Note that we cannot include firm-year fixed effects in our setting because then cash flows and Tobin's q are colinear with the fixed effects, and the estimation becomes void. 
+How can we further improve the robustness of our regression results? Ideally, we want to get rid of unexplained variation at the firm-year level, which means we need to include more variables that vary across firm *and* time and are likely correlated with investment. Note that we cannot include firm-year fixed effects in our setting because then cash flows and Tobin's q are collinear with the fixed effects, and the estimation becomes void. 
 
 Before we discuss the properties of our estimation errors, we want to point out that regression tables are at the heart of every empirical analysis, where you compare multiple models. Fortunately, the `results.compare()` function provides a convenient way to tabulate the regression output (with many parameters to customize and even print the output in LaTeX). We recommend printing $t$-statistics rather than standard errors in regression tables because the latter are typically very hard to interpret across coefficients that vary in size. We also do not print p-values because they are sometimes misinterpreted to signal the importance of observed effects [@Wasserstein2016]. The $t$-statistics provide a consistent way to interpret changes in estimation uncertainty across different model specifications.
 
@@ -240,7 +240,7 @@ Inspired by @AbadieEtAl2017, we want to close this chapter by highlighting that 
 ## Key Takeaways
 
 - Fixed effects regressions control for unobserved firm and time-specific factors, reducing omitted variable bias in panel data models.
--	The `pyfixest` Python package streamlines the estimation of fixed effects and supports clustering standard errors for robust inference.
+- The `pyfixest` Python package streamlines the estimation of fixed effects and supports clustering standard errors for robust inference.
 - Clustered standard errors adjust for residual dependence across firms or years, leading to more accurate $t$-statistics and confidence in significance tests.
 - Two-way clustering by firm and year is commonly used in finance to address both time-series and cross-sectional correlation in residuals.
 - Careful model specification, including winsorization and proper clustering choices, enhances the credibility and reliability of empirical finance results.

--- a/python/modern-portfolio-theory.qmd
+++ b/python/modern-portfolio-theory.qmd
@@ -18,7 +18,7 @@ In the previous chapter, we show how to download and analyze stock market data w
 
 MPT relies on the fact that portfolio risk depends on individual asset volatilities as well as on the correlations between asset returns. This insight highlights the power of diversification: Combining assets with low or negative correlations with a given portfolio reduces the overall portfolio risk. This principle is often illustrated with the analogy of a fruit basket: If all you have are apples and they spoil, you lose everything. With a variety of fruits, some fruits may spoil, but others will stay fresh.
 
-At the heart of MPT is mean-variance analysis, which evaluates portfolios based on two dimensions: expected return and risk, defined as the variance of the portfolio returns. By balancing these two components, investors can construct portfolios that either maximize their expected return for a given level of risk or minimize their taken risk for a desired level of return. In this chapter, we first derive the optimal portfolio decisions and implement the mean-variance approach in R.
+At the heart of MPT is mean-variance analysis, which evaluates portfolios based on two dimensions: expected return and risk, defined as the variance of the portfolio returns. By balancing these two components, investors can construct portfolios that either maximize their expected return for a given level of risk or minimize their taken risk for a desired level of return. In this chapter, we first derive the optimal portfolio decisions and implement the mean-variance approach in Python.
 
 We use the following packages throughout this chapter: 
 
@@ -43,7 +43,7 @@ We introduce the `adjustText` package for adding text labels to the figures in t
 
 Suppose that $N$ different risky assets are available to the investor. Each asset $i$ delivers expected returns $\mu_i$, representing the anticipated profit from holding the asset for one period. The investor can allocate their wealth across these assets by choosing the portfolio weights $\omega_i$ for each asset $i$. We impose that the portfolio weights sum up to one to ensure that the investor is fully invested. There is no outside option, such as keeping your money under a mattress. The overarching question of this chapter is: How should the investor allocate their wealth across these assets to optimize their portfolio's performance?
 
-According to @Markowitz1952, portfolio selection involves two stages: First, forming expectations about future security performance based on observations and experience. Second, using these expectations to choose a portfolio. In practice, these two steps cannot be separated. You need historical data or other considerations to generate estimates of the distribution of future returns. Only then can one proceed proceed to optimal decision-making *conditional* on your estimation. 
+According to @Markowitz1952, portfolio selection involves two stages: First, forming expectations about future security performance based on observations and experience. Second, using these expectations to choose a portfolio. In practice, these two steps cannot be separated. You need historical data or other considerations to generate estimates of the distribution of future returns. Only then can one proceed to optimal decision-making *conditional* on your estimation. 
 
 To keep things conceptually simple, we focus on the latter part for now and assume that the actual distribution of the asset returns is known. In later chapters, we discuss the issues that arise once we take estimation uncertainty into account. To provide some meaningful illustrations, we rely on historical data to compute reasonable proxies for the expected returns and the variance-covariance of the assets returns, but we will work under the assumption that these are the true parameters of the return distribution.  
 
@@ -282,8 +282,8 @@ Figure @fig-205 shows the average return and volatility of the minimum-variance 
 
 ```{python}
 #| label: fig-205
-#| fig-cap: "The big dots indicate the location of the minimum-variance and the efficient portfolio that delivers the expected return of the stock with the higehst return, respectively. The small dots indicate the location of the individual constituents."
-#| fig-alt: "Title: Efficient & minimum-variance portfolios. The figure shows big dots indicating the location of the minimum-variance and the efficient portfolio that delivers the expected return of the stock with the higehst return, respectively. The small dots indicate the location of the individual constituents."
+#| fig-cap: "The big dots indicate the location of the minimum-variance and the efficient portfolio that delivers the expected return of the stock with the highest return, respectively. The small dots indicate the location of the individual constituents."
+#| fig-alt: "Title: Efficient & minimum-variance portfolios. The figure shows big dots indicating the location of the minimum-variance and the efficient portfolio that delivers the expected return of the stock with the highest return, respectively. The small dots indicate the location of the individual constituents."
 #| warning: false
 summaries = pl.concat(
     [assets, summary_mvp, summary_efp], how="diagonal"
@@ -373,7 +373,7 @@ summaries_figure.show()
 
 ## Key Takeaways
 
-- Modern Portfolio Theory provides a an intuitive framework to allocate capital by balancing expected return against risk.
+- Modern Portfolio Theory provides an intuitive framework to allocate capital by balancing expected return against risk.
 - Mean-variance optimization allows investors to construct portfolios that either minimize risk or maximize return based on historical return and volatility data.
 - Portfolio risk is not only determined by individual asset volatility but also by the correlation between assets, which highlights the value of diversification.
 - The minimum-variance portfolio identifies the asset allocation that yields the lowest possible volatility while remaining fully invested.

--- a/python/option-pricing-via-machine-learning.qmd
+++ b/python/option-pricing-via-machine-learning.qmd
@@ -93,7 +93,7 @@ $${#eq-black-scholes}
 
 where $C(S, T)$ is the price of the option as a function of today's stock price of the underlying, $S$, with time to maturity $T$, $r_f$ is the risk-free interest rate, and $\sigma$ is the volatility of the underlying stock return. $\Phi$ is the cumulative distribution function of a standard normal random variable.
 
-The Black-Scholes equation provides a way to compute the arbitrage-free price of a call option once the parameters $S, K, r_f, T$, and $\sigma$ are specified (arguably, in a realistic context, all parameters are easy to specify except for $\sigma$ which has to be estimated). A simple R function allows computing the price as we do below. 
+The Black-Scholes equation provides a way to compute the arbitrage-free price of a call option once the parameters $S, K, r_f, T$, and $\sigma$ are specified (arguably, in a realistic context, all parameters are easy to specify except for $\sigma$ which has to be estimated). A simple Python function allows computing the price as we do below. 
 
 ```{python}
 def black_scholes_price(S, K, r, T, sigma):
@@ -312,7 +312,7 @@ In the lines above, we use each of the fitted models to generate predictions for
 
 ```{python}
 #| label: fig-151
-#| fig-cap: "The figure shows absolut prediction error in USD for the different fitted methods. The prediction error is evaluated on a sample of call options that were not used for training."
+#| fig-cap: "The figure shows absolute prediction error in USD for the different fitted methods. The prediction error is evaluated on a sample of call options that were not used for training."
 #| fig-alt: "Title: Prediction errors of call option prices for different models. The figure shows the pricing error of the different machine learning methods for call options for different levels of moneyness (strike price minus stock price). The figure indicates variation across the models and across moneyness. The random forest approach performs worst, in particular out of the money."
 #| fig-pos: "htb"
 predictive_performance_figure = (
@@ -323,7 +323,7 @@ predictive_performance_figure = (
     + geom_point(alpha=0.05)
     + facet_wrap("Model")
     + labs(
-        x="Moneyness (S - K)", y="Absolut prediction error (USD)",
+        x="Moneyness (S - K)", y="Absolute prediction error (USD)",
         title="Prediction errors of call options for different models"
         )
     + theme(legend_position="")

--- a/python/size-sorts-and-p-hacking.qmd
+++ b/python/size-sorts-and-p-hacking.qmd
@@ -212,7 +212,7 @@ def assign_portfolio(data, exchanges, sorting_variable, n_portfolios):
     return assigned_portfolios
 ```
 
-Note that the `tidyfinance` package also provides a `assing_portfolio()` function, albeit with more flexibility. For the sake of simplicity, we continue to use the function that we just defined.
+Note that the `tidyfinance` package also provides an `assign_portfolio()` function, albeit with more flexibility. For the sake of simplicity, we continue to use the function that we just defined.
 
 ## Weighting Schemes for Portfolios
 

--- a/python/trace-and-fisd.qmd
+++ b/python/trace-and-fisd.qmd
@@ -82,7 +82,7 @@ The following chunk connects to the data and selects the bond sample to remove c
 1. Exclude bonds denominated in foreign currency (`foreign_currency = 'N'`).
 1. Keep only fixed (`F`) and zero (`Z`) coupon bonds with additional requirements of `fix_frequency IS NULL`, `coupon_change_indicator = 'N'` and annual, semi-annual, quarterly, or monthly interest frequencies. 
 1. Exclude bonds that were issued under SEC Rule 144A (`rule_144a = 'N'`).
-1. Exlcude privately placed bonds (`private_placement = 'N' OR private_placement IS NULL`).
+1. Exclude privately placed bonds (`private_placement = 'N' OR private_placement IS NULL`).
 1. Exclude defaulted bonds (`defaulted = 'N' AND filing_date IS NULL AND settlement IS NULL`).
 1. Exclude convertible (`convertible = 'N'`), putable (`putable = 'N' OR putable IS NULL`), exchangeable (`exchangeable = 'N' OR exchangeable IS NULL`), perpetual (`perpetual = 'N'`), or preferred bonds (`preferred_security = 'N' OR preferred_security IS NULL`).
 1. Exclude unit deal bonds (`(unit_deal = 'N' OR unit_deal IS NULL)`).

--- a/python/univariate-portfolio-sorts.qmd
+++ b/python/univariate-portfolio-sorts.qmd
@@ -333,7 +333,7 @@ Overall, this chapter shows how functional programming can be leveraged to form 
 - Univariate portfolio sorts assess whether a single firm characteristic, like lagged market beta, can predict future excess returns.
 - Portfolios are formed each month using quantile breakpoints, with returns computed using value-weighted averages to reflect realistic investment strategies.
 - A long-short strategy based on beta-sorted portfolios fails to generate significant positive excess returns, contradicting CAPM predictions that higher beta should yield higher returns.
-- The analysis highlights the “betting against beta” anomaly, where low-beta portfolios deliver higher alphas than high-beta portfolios, providing evidence against the CAPM
+- The analysis highlights the “betting against beta” anomaly, where low-beta portfolios deliver higher alphas than high-beta portfolios, providing evidence against the CAPM.
 - The functional programming capabilities of Python enable scalable and flexible portfolio sorting, making it easy to analyze multiple characteristics and portfolio configurations.
 
 ## Exercises

--- a/python/value-and-bivariate-sorts.qmd
+++ b/python/value-and-bivariate-sorts.qmd
@@ -139,13 +139,13 @@ def assign_portfolio(data, exchanges, sorting_variable, n_portfolios):
     return assigned_portfolios
 ```
 
-Note that the `tidyfinance` package also provides an `assing_portfolio()` function, albeit with more flexibility. For ease of exposition, we continue to use the function that we just defined.
+Note that the `tidyfinance` package also provides an `assign_portfolio()` function, albeit with more flexibility. For ease of exposition, we continue to use the function that we just defined.
 
 After these data preparation steps, we present bivariate portfolio sorts on an independent and dependent basis.
 
 ## Independent Sorts
 
-Bivariate sorts create portfolios within a two-dimensional space spanned by two sorting variables. It is then possible to assess the return impact of either sorting variable by the return differential from a trading strategy that invests in the portfolios at either end of the respective variables spectrum. We create a five-by-five matrix using book-to-market and firm size as sorting variables in our example below. We end up with 25 portfolios. Since we are interested in the *value premium* (i.e., the return differential between high and low book-to-market firms), we go long the five portfolios of the highest book-to-market firms and short the five portfolios of the lowest book-to-market firms.\index{Value premium} The five portfolios at each end are due to the size splits we employed alongside the book-to-market splits.\index{Long-short}
+Bivariate sorts create portfolios within a two-dimensional space spanned by two sorting variables. It is then possible to assess the return impact of either sorting variable by the return differential from a trading strategy that invests in the portfolios at either end of the respective variable's spectrum. We create a five-by-five matrix using book-to-market and firm size as sorting variables in our example below. We end up with 25 portfolios. Since we are interested in the *value premium* (i.e., the return differential between high and low book-to-market firms), we go long the five portfolios of the highest book-to-market firms and short the five portfolios of the lowest book-to-market firms.\index{Value premium} The five portfolios at each end are due to the size splits we employed alongside the book-to-market splits.\index{Long-short}
 
 To implement the independent bivariate portfolio sort, we assign monthly portfolios for each of our sorting variables separately to create the variables `portfolio_bm` and `portfolio_size`, respectively.\index{Portfolio sorts!Independent bivariate} Then, these separate portfolios are combined to the final sort stored in `portfolio_combined`. After assigning the portfolios, we compute the average return within each portfolio for each month. Additionally, we keep the book-to-market portfolio as it makes the computation of the value premium easier. The alternative would be to disaggregate the combined portfolio in a separate step. Notice that we weigh the stocks within each portfolio by their market capitalization, i.e., we decide to value-weight our returns.
 
@@ -193,7 +193,7 @@ The resulting monthly value premium is `{python} round(value_premium * 100, 2)` 
 
 In the previous exercise, we assigned the portfolios without considering the second variable in the assignment. This protocol is called independent portfolio sorts. The alternative, i.e., dependent sorts, creates portfolios for the second sorting variable within each bucket of the first sorting variable.\index{Portfolio sorts!Dependent bivariate} In our example below, we sort firms into five size buckets, and within each of those buckets, we assign firms to five book-to-market portfolios. Hence, we have monthly breakpoints that are specific to each size group. The decision between independent and dependent portfolio sorts is another choice for the researcher. Notice that dependent sorts guarantee that portfolios have roughly equal numbers of stocks when breakpoints are computed from all exchanges. However, if breakpoints are based only on NYSE stocks, portfolio counts will generally be uneven — reflecting the large presence of small-cap stocks on NASDAQ and AMEX (see Exercise below).
 
-To implement the dependent sorts, we first create the size portfolios by calling `assign_portfolio()` with `sorting_variable="me"`. Then, we group our data again by month and by the size portfolio before assigning the book-to-market portfolio. The rest of the implementation is the same as before. Finally, we compute the value premium.
+To implement the dependent sorts, we first create the size portfolios by calling `assign_portfolio()` with `sorting_variable="size"`. Then, we group our data again by month and by the size portfolio before assigning the book-to-market portfolio. The rest of the implementation is the same as before. Finally, we compute the value premium.
 
 ```{python}
 value_portfolios = (

--- a/python/working-with-stock-returns.qmd
+++ b/python/working-with-stock-returns.qmd
@@ -151,7 +151,7 @@ As a next step, we generalize the previous code so that all computations can han
 
 This is where the `tidyverse` magic starts: Tidy data makes it extremely easy to generalize the computations from before to as many assets or groups as you like. The following code takes any number of symbols, e.g., `symbol = ["AAPL", "MMM", "BA"]`, and automates the download as well as the plot of the price time series. In the end, we create the table of summary statistics for all assets at once. For this example, we analyze data from all current constituents of the [Dow Jones Industrial Average index.](https://en.wikipedia.org/wiki/Dow_Jones_Industrial_Average)\index{Data!Dow Jones Index}
 
-We first download a table with DOW Jones constituents again using `tf.download_data()`, but this time with `domain="constituents"`.
+We first download a table with Dow Jones constituents again using `tf.download_data()`, but this time with `domain="constituents"`.
 
 ```{python}
 symbols = pl.from_pandas(
@@ -191,7 +191,7 @@ prices_figure = (
 prices_figure.show()
 ```
 
-Do you notice the small differences relative to the code we used before? All we needed to do to illustrate all stock symbols simultaneously is to include `color = symbol` in the `ggplot` aesthetics. In this way, we generate a separate line for each symbol. Of course, there are simply too many lines on this graph to identify the individual stocks properly, but it illustrates our point of how to generalize a specific analysis to an arbitrage number of subjects quite well.
+Do you notice the small differences relative to the code we used before? All we needed to do to illustrate all stock symbols simultaneously is to include `color = symbol` in the `ggplot` aesthetics. In this way, we generate a separate line for each symbol. Of course, there are simply too many lines on this graph to identify the individual stocks properly, but it illustrates our point of how to generalize a specific analysis to an arbitrary number of subjects quite well.
 
 The same holds for stock returns. Before computing the returns, we sort by symbol and date and add `.over("symbol")` to the `pct_change()` expression, so that returns are computed within each symbol individually without bleeding across symbol boundaries. The same logic also applies to the computation of summary statistics: `group_by("symbol")` is the key to aggregating the time series into symbol-specific variables of interest.\index{Summary statistics}
 

--- a/python/wrds-crsp-and-compustat.qmd
+++ b/python/wrds-crsp-and-compustat.qmd
@@ -16,7 +16,7 @@ You are reading **Tidy Finance with Python**. You can find the equivalent chapte
 
 This chapter shows how to connect to [Wharton Research Data Services (WRDS),](https://wrds-www.wharton.upenn.edu/) a popular provider of financial and economic data for research applications. We use this connection to download the most commonly used data for stock and firm characteristics, CRSP and Compustat. Unfortunately, this data is not freely available, but most students and researchers typically have access to WRDS through their university libraries. Assuming that you have access to WRDS, we show you how to prepare and merge the datasets and store them as Parquet-files introduced in the previous chapter. We conclude this chapter by providing some tips for working with the WRDS database.\index{WRDS}
 
-If you don't have access to WRDS but still want to run the code in this book, we refer to [WRDS Pseudo Data](wrds-dummy-data.qmd), where we show how to create a pseudo versions of the WRDS tables and corresponding columns. With this pseudo data at hand, all code chunks in this book can be executed.
+If you don't have access to WRDS but still want to run the code in this book, we refer to [WRDS Pseudo Data](wrds-dummy-data.qmd), where we show how to create pseudo versions of the WRDS tables and corresponding columns. With this pseudo data at hand, all code chunks in this book can be executed.
 
 First, we load the Python packages that we use throughout this chapter. Later on, we load more packages in the sections where we need them. The last two packages are used for plotting.
 
@@ -466,13 +466,13 @@ crsp_daily = pl.from_pandas(tf.download_data(
 ))
 ```
 
-Note that you need at least 16 GB of memory to hold all the daily CRSP returns in memory. We hence recommend to use loop the function over different date periods and store the results. 
+Note that you need at least 16 GB of memory to hold all the daily CRSP returns in memory. We hence recommend looping the function over different date periods and storing the results. 
 
 ## Preparing Compustat Data
 
 Firm accounting data are an important source of information that we use in portfolio analyses in subsequent chapters. The commonly used source for firm financial information is Compustat provided by [S&P Global Market Intelligence,](https://www.spglobal.com/marketintelligence/en/) which is a global data vendor that provides financial, statistical, and market information on active and inactive companies throughout the world.\index{Data!Compustat} For US and Canadian companies, annual history is available back to 1950 and quarterly as well as monthly histories date back to 1962. We refer to @LyleEtAl2025 for a detailed account of the Compustat data collection process and ongoing readjustments, which may pose challenges for replicating prior research and may introduce look-ahead bias in archival data analyses.
 
-To access Compustat data, we can again tap WRDS, which hosts the `funda` table that contains annual firm-level information on North American companies. We follow the typical filter conventions and pull only data that we actually need: (i) we get only records in industrial data format, which includes companies that are primarily involved in manufacturing, services, and other non-financial business activities,^[Companies that operate in the banking, insurance, or utilities sector typically report in different industry formats that reflect their specific regulatory requirements.], (ii) in the standard format (i.e., consolidated information in standard presentation), (iii) reported in USD,^[Compustat also contains reports in CAD, which can lead a currency mismatch, e.g., when relating book equity to market equity.] and (iv) only data in the desired time window.\index{Gvkey}
+To access Compustat data, we can again tap WRDS, which hosts the `funda` table that contains annual firm-level information on North American companies. We follow the typical filter conventions and pull only data that we actually need: (i) we get only records in industrial data format, which includes companies that are primarily involved in manufacturing, services, and other non-financial business activities,^[Companies that operate in the banking, insurance, or utilities sector typically report in different industry formats that reflect their specific regulatory requirements.], (ii) in the standard format (i.e., consolidated information in standard presentation), (iii) reported in USD,^[Compustat also contains reports in CAD, which can lead to a currency mismatch, e.g., when relating book equity to market equity.] and (iv) only data in the desired time window.\index{Gvkey}
 
 ```{python}
 #| eval: false

--- a/python/wrds-dummy-data.qmd
+++ b/python/wrds-dummy-data.qmd
@@ -6,7 +6,7 @@ metadata:
 eval: false
 ---
 
-In this appendix chapter, we alleviate the constraints of readers who don’t have access to WRDS and hence cannot run the code that we provide. We show how to create a pseudo data that contains the WRDS tables and corresponding columns such that all code chunks in this book can be executed with this psueod data. We do not create pseudo data for tables of open-source data sources because they can be freely downloaded from the original sources; check out [Accessing and Managing Financial Data](accessing-and-managing-financial-data.qmd).\index{WRDS}
+In this appendix chapter, we alleviate the constraints of readers who don’t have access to WRDS and hence cannot run the code that we provide. We show how to create pseudo data that contains the WRDS tables and corresponding columns such that all code chunks in this book can be executed with this pseudo data. We do not create pseudo data for tables of open-source data sources because they can be freely downloaded from the original sources; check out [Accessing and Managing Financial Data](accessing-and-managing-financial-data.qmd).\index{WRDS}
 
 We deliberately use the pseudo label because the data is not meaningful in the sense that it allows readers to actually replicate the results of the book. For legal reasons, the data does not contain any samples of the original data. We merely generate random numbers for all columns of the tables that we use throughout the books.
 


### PR DESCRIPTION
## Summary

A documentation review of the Python edition chapters (`python/`) updated by the Polars transition. This PR targets `explore/polars-translation` so it merges on top of that work.

Two areas were addressed:

### 1. Typos, grammar, and inconsistencies
Fixed across 18 chapters. Highlights:

- **R→Python copy-paste leftovers** (this is the Python book):
  - `financial-statement-analysis.qmd`: "using R" → "using Python"; "the R package `fmpapi`" → "the Python package `fmpapi`"
  - `modern-portfolio-theory.qmd`: "approach in R" → "approach in Python"
  - `option-pricing-via-machine-learning.qmd`: "A simple R function" → "A simple Python function"
  - `beta-estimation.qmd`: `availableCores()` (R) → `cpu_count()` (matches the code)
- **Code/prose mismatches:**
  - `factor-selection-via-machine-learning.qmd`: prose `lasso_coefficients`/`ridge_coefficients` → `coefficients_lasso`/`coefficients_ridge` (matches code); restored missing word "singular"; fixed `.calloutnote` → `.callout-note`; added missing verb ("play a role")
  - `value-and-bivariate-sorts.qmd`: `sorting_variable="me"` → `"size"` (matches code); `assing_portfolio` → `assign_portfolio`
  - `size-sorts-and-p-hacking.qmd`: `assing_portfolio` → `assign_portfolio`
- **Plain typos:** "convervative" → "conservative", "Afterall" → "After all", "colinear" → "collinear", "Exlcude" → "Exclude", "psueod"/"unsing" → "pseudo"/"using", "arbitrage number" → "arbitrary number", "frontiert" → "frontier", "higehst" → "highest", "absolut" → "absolute", doubled words ("the the", "proceed proceed", "a an"), "proof" → "prove" (verb), missing possessives, "average13-week" → "average 13-week", broken Markdown footnote link in the DCF chapter, and a stale "centralized SQLite database" takeaway (the chapter now uses Parquet).

### 2. `tidyfinance` `download_data()` usage
Verified every `download_data()` call against the library's documented signature (`domain`, `dataset`; `type` is deprecated). All calls already used explicit `domain=`/`dataset=` keywords **except** one positional call in `capital-asset-pricing-model.qmd`, which is now `domain="stock_prices"` so it cannot be misread as the legacy first-positional `type` argument. Domain/dataset values were checked against the package README and supported-datasets table and are consistent.

## Flagged, not changed
- **Current Ratio formula** (`financial-statement-analysis.qmd`): the prose ("current liabilities"), the LaTeX formula ("Total Liabilities"), and the code (`total_assets`) disagree. This discrepancy is **identical in the R sibling chapter**, i.e., it predates the Polars transition and spans both editions. Because correcting it is a substantive definition/code decision (and would change rendered output), it is left for the maintainers rather than silently diverging the two editions.

https://claude.ai/code/session_0128hRp8ZHSmmPELM5NGa7mq

---
_Generated by [Claude Code](https://claude.ai/code/session_0128hRp8ZHSmmPELM5NGa7mq)_