### PR TITLE
Add portfolio composition heat maps to value-and-bivariate-sorts

### DIFF
--- a/python/value-and-bivariate-sorts.qmd
+++ b/python/value-and-bivariate-sorts.qmd
@@ -24,9 +24,17 @@ The current chapter relies on this set of Python packages.
 import pandas as pd
 import numpy as np
 import datetime as dt
+
+from plotnine import *
+from mizani.formatters import percent_format
 ```
 
-Compared to previous chapters, we introduce the `datetime` module that is part of the Python standard library for manipulating dates. 
+```{python}
+#| echo: false
+exec(open("python/render-plotnine-custom.py").read())
+```
+
+Compared to previous chapters, we introduce the `datetime` module that is part of the Python standard library for manipulating dates. We also rely on `plotnine` for visualization.
 
 ## Data Preparation
 
@@ -239,12 +247,140 @@ The monthly value premium from dependent sorts is `{python} round(value_premium.
 
 Overall, we show how to conduct bivariate portfolio sorts in this chapter. In one case, we sort the portfolios independently of each other. Yet we also discuss how to create dependent portfolio sorts. Along the lines of [Size Sorts and P-Hacking](size-sorts-and-p-hacking.qmd), we see how many choices a researcher has to make to implement portfolio sorts, and bivariate sorts increase the number of choices.
 
+## Portfolio Composition
+
+So far, we have focused exclusively on the returns of our portfolios. Yet the way stocks are distributed across the size–value grid is itself informative, and it differs systematically between independent and dependent sorts. In this section, we visualize two characteristics for each of the 25 portfolios and for both sorting methods: the number of stocks and the aggregate market capitalization.
+
+We start with the independent assignment. As before, we group by month and assign the size and book-to-market portfolios separately.
+
+```{python}
+assignments_independent = (data_for_sorts
+    .groupby("date")
+    .apply(lambda x: x.assign(
+        portfolio_size=assign_portfolio(
+            data=x, sorting_variable="size", n_portfolios=5, exchanges=["NYSE"]
+        ),
+        portfolio_bm=assign_portfolio(
+            data=x, sorting_variable="bm", n_portfolios=5, exchanges=["NYSE"]
+        )
+        )
+    )
+    .reset_index(drop=True)
+    .assign(sorting_method="Independent")
+)
+```
+
+For the dependent assignment, we again first form the size portfolios and then assign book-to-market portfolios within each size bucket, so that the book-to-market breakpoints are specific to each size group.
+
+```{python}
+assignments_dependent = (data_for_sorts
+    .groupby("date")
+    .apply(lambda x: x.assign(
+        portfolio_size=assign_portfolio(
+            data=x, sorting_variable="size", n_portfolios=5, exchanges=["NYSE"]
+        )
+        )
+    )
+    .reset_index(drop=True)
+    .groupby(["date", "portfolio_size"])
+    .apply(lambda x: x.assign(
+        portfolio_bm=assign_portfolio(
+            data=x, sorting_variable="bm", n_portfolios=5, exchanges=["NYSE"]
+        )
+        )
+    )
+    .reset_index(drop=True)
+    .assign(sorting_method="Dependent")
+)
+```
+
+Next, we stack both assignments and compute the characteristics of interest. For each month and portfolio, we count the number of stocks and sum their lagged market capitalization. We then average these monthly figures across the whole sample to obtain one value per portfolio. Finally, we express market capitalization as a share of the total within each sorting method, which makes the concentration of market value across the grid directly comparable.
+
+```{python}
+portfolio_characteristics = (
+    pd.concat([assignments_independent, assignments_dependent])
+    .groupby(
+        ["sorting_method", "date", "portfolio_size", "portfolio_bm"],
+        observed=True
+    )
+    .agg(n_stocks=("permno", "count"), mktcap=("mktcap_lag", "sum"))
+    .reset_index()
+    .groupby(["sorting_method", "portfolio_size", "portfolio_bm"], observed=True)
+    .agg(n_stocks=("n_stocks", "mean"), mktcap=("mktcap", "mean"))
+    .reset_index()
+    .assign(
+        mktcap_share=lambda x: (
+            x["mktcap"]/x.groupby("sorting_method")["mktcap"].transform("sum")
+        )
+    )
+    .assign(
+        sorting_method=lambda x: pd.Categorical(
+            x["sorting_method"],
+            categories=["Independent", "Dependent"],
+            ordered=True
+        ),
+        n_stocks_label=lambda x: x["n_stocks"].round().astype(int),
+        mktcap_share_label=lambda x: (
+            (x["mktcap_share"]*100).round(1).astype(str)+"%"
+        )
+    )
+)
+```
+
+We are now ready to visualize the results. We use `geom_tile()` to draw the 25 portfolios as a heatmap spanned by the size and book-to-market portfolios, and facet by the sorting method. @fig-901 shows the average number of stocks per portfolio.
+
+```{python}
+#| label: fig-901
+#| fig-cap: "Average number of stocks per portfolio for independent and dependent bivariate sorts. Breakpoints are based on NYSE stocks. Portfolio 1 (5) contains the smallest (largest) firms along each dimension."
+#| fig-alt: "Two heatmaps of a five-by-five size and book-to-market grid, one for independent and one for dependent sorts. Stock counts are highest in the small-size portfolios and decline toward the large-size portfolios."
+plot_counts = (
+    ggplot(
+        portfolio_characteristics,
+        aes(x="portfolio_size", y="portfolio_bm", fill="n_stocks")
+    )
+    + geom_tile()
+    + geom_text(aes(label="n_stocks_label"))
+    + facet_wrap("sorting_method")
+    + labs(
+        x="Size portfolio", y="Book-to-market portfolio", fill="Avg. stocks",
+        title="Average number of stocks per portfolio across sorting methods"
+    )
+)
+plot_counts.show()
+```
+
+@fig-902 shows each portfolio's average market capitalization as a share of the total.
+
+```{python}
+#| label: fig-902
+#| fig-cap: "Average market capitalization per portfolio, expressed as a share of total market capitalization within each sorting method. Breakpoints are based on NYSE stocks."
+#| fig-alt: "Two heatmaps of a five-by-five size and book-to-market grid, one for independent and one for dependent sorts. Market capitalization concentrates heavily in the large-size, low-book-to-market portfolios."
+plot_mktcap = (
+    ggplot(
+        portfolio_characteristics,
+        aes(x="portfolio_size", y="portfolio_bm", fill="mktcap_share")
+    )
+    + geom_tile()
+    + geom_text(aes(label="mktcap_share_label"))
+    + facet_wrap("sorting_method")
+    + scale_fill_continuous(labels=percent_format())
+    + labs(
+        x="Size portfolio", y="Book-to-market portfolio", fill="Market cap (%)",
+        title="Market capitalization share per portfolio across sorting methods"
+    )
+)
+plot_mktcap.show()
+```
+
+The two figures highlight a tension that is invisible when looking at returns alone. Because the breakpoints are based on NYSE stocks, while the bulk of small firms trade on NASDAQ and AMEX, the small-size portfolios absorb a large number of stocks under both sorting schemes. The difference between the methods shows up along the book-to-market dimension: independent sorts apply the same NYSE book-to-market cutoffs to every size group, so the counts within a size column are uneven, whereas dependent sorts recompute the book-to-market breakpoints inside each size bucket and therefore distribute stocks more evenly across book-to-market within a given size group. Market capitalization tells the mirror-image story: regardless of the sorting method, aggregate market value concentrates in the large-size, low-book-to-market corner, where comparatively few stocks account for the lion's share of total market capitalization. This is a useful reminder that value-weighting lets a handful of large firms dominate portfolio returns, even when most of the stocks sit elsewhere in the grid.
+
 ## Key Takeaways
 
 - Bivariate portfolio sorts assign stocks based on two characteristics, such as firm size and book-to-market ratio, to better capture return patterns in asset pricing.
 - Independent sorts treat each variable separately, while dependent sorts condition the second sort on the first.
 - Proper handling of accounting data, especially lagging the book-to-market ratio, is essential to avoid look-ahead bias and ensure valid backtesting.
 - Value premiums are derived by comparing returns of high versus low book-to-market portfolios, with results sensitive to sorting choices and weighting schemes.
+- Visualizing portfolio composition shows that NYSE breakpoints push many stocks into the small-size portfolios, while market capitalization concentrates in the large-size, low-book-to-market corner—a reminder that value-weighting lets a few large firms dominate returns.
 
 ## Exercises
 

--- a/r/value-and-bivariate-sorts.qmd
+++ b/r/value-and-bivariate-sorts.qmd
@@ -235,12 +235,140 @@ The monthly value premium from dependent sorts is `{r} round(value_premium$value
 
 Overall, we show how to conduct bivariate portfolio sorts in this chapter. In one case, we sort the portfolios independently of each other. Yet we also discuss how to create dependent portfolio sorts. Along the lines of [Size Sorts and P-Hacking](size-sorts-and-p-hacking.qmd), we see how many choices a researcher has to make to implement portfolio sorts, and bivariate sorts increase the number of choices.
 
+## Portfolio Composition
+
+So far, we have focused exclusively on the returns of our portfolios. Yet the way stocks are distributed across the size–value grid is itself informative, and it differs systematically between independent and dependent sorts. In this section, we visualize two characteristics for each of the 25 portfolios and for both sorting methods: the number of stocks and the aggregate market capitalization.
+
+We start with the independent assignment. As before, we group by month and assign the size and book-to-market portfolios separately.
+
+```{r}
+assignments_independent <- data_for_sorts |>
+  group_by(date) |>
+  mutate(
+    portfolio_size = assign_portfolio(
+      data = pick(everything()),
+      sorting_variable = "size",
+      n_portfolios = 5,
+      exchanges = c("NYSE")
+    ),
+    portfolio_bm = assign_portfolio(
+      data = pick(everything()),
+      sorting_variable = "bm",
+      n_portfolios = 5,
+      exchanges = c("NYSE")
+    )
+  ) |>
+  ungroup() |>
+  mutate(sorting_method = "Independent")
+```
+
+For the dependent assignment, we again first form the size portfolios and then assign book-to-market portfolios within each size bucket, so that the book-to-market breakpoints are specific to each size group.
+
+```{r}
+assignments_dependent <- data_for_sorts |>
+  group_by(date) |>
+  mutate(
+    portfolio_size = assign_portfolio(
+      data = pick(everything()),
+      sorting_variable = "size",
+      n_portfolios = 5,
+      exchanges = c("NYSE")
+    )
+  ) |>
+  group_by(date, portfolio_size) |>
+  mutate(
+    portfolio_bm = assign_portfolio(
+      data = pick(everything()),
+      sorting_variable = "bm",
+      n_portfolios = 5,
+      exchanges = c("NYSE")
+    )
+  ) |>
+  ungroup() |>
+  mutate(sorting_method = "Dependent")
+```
+
+Next, we stack both assignments and compute the characteristics of interest. For each month and portfolio, we count the number of stocks and sum their lagged market capitalization. We then average these monthly figures across the whole sample to obtain one value per portfolio. Finally, we express market capitalization as a share of the total within each sorting method, which makes the concentration of market value across the grid directly comparable.
+
+```{r}
+portfolio_characteristics <- bind_rows(
+  assignments_independent,
+  assignments_dependent
+) |>
+  group_by(sorting_method, date, portfolio_size, portfolio_bm) |>
+  summarize(
+    n_stocks = n(),
+    mktcap = sum(mktcap_lag),
+    .groups = "drop"
+  ) |>
+  group_by(sorting_method, portfolio_size, portfolio_bm) |>
+  summarize(
+    n_stocks = mean(n_stocks),
+    mktcap = mean(mktcap),
+    .groups = "drop"
+  ) |>
+  group_by(sorting_method) |>
+  mutate(mktcap_share = mktcap / sum(mktcap)) |>
+  ungroup() |>
+  mutate(
+    sorting_method = factor(
+      sorting_method,
+      levels = c("Independent", "Dependent")
+    )
+  )
+```
+
+We are now ready to visualize the results. We use `geom_tile()` to draw the 25 portfolios as a heatmap spanned by the size and book-to-market portfolios, and facet by the sorting method. @fig-901 shows the average number of stocks per portfolio.
+
+```{r}
+#| label: fig-901
+#| fig-cap: "Average number of stocks per portfolio for independent and dependent bivariate sorts. Breakpoints are based on NYSE stocks. Portfolio 1 (5) contains the smallest (largest) firms along each dimension."
+#| fig-alt: "Two heatmaps of a five-by-five size and book-to-market grid, one for independent and one for dependent sorts. Stock counts are highest in the small-size portfolios and decline toward the large-size portfolios."
+portfolio_characteristics |>
+  ggplot(aes(x = portfolio_size, y = portfolio_bm, fill = n_stocks)) +
+  geom_tile() +
+  geom_text(aes(label = round(n_stocks))) +
+  facet_wrap(~sorting_method) +
+  scale_x_continuous(breaks = 1:5) +
+  scale_y_continuous(breaks = 1:5) +
+  labs(
+    x = "Size portfolio",
+    y = "Book-to-market portfolio",
+    fill = "Avg. stocks",
+    title = "Average number of stocks per portfolio across sorting methods"
+  )
+```
+
+@fig-902 shows each portfolio's average market capitalization as a share of the total.
+
+```{r}
+#| label: fig-902
+#| fig-cap: "Average market capitalization per portfolio, expressed as a share of total market capitalization within each sorting method. Breakpoints are based on NYSE stocks."
+#| fig-alt: "Two heatmaps of a five-by-five size and book-to-market grid, one for independent and one for dependent sorts. Market capitalization concentrates heavily in the large-size, low-book-to-market portfolios."
+portfolio_characteristics |>
+  ggplot(aes(x = portfolio_size, y = portfolio_bm, fill = mktcap_share)) +
+  geom_tile() +
+  geom_text(aes(label = scales::percent(mktcap_share, 0.1))) +
+  facet_wrap(~sorting_method) +
+  scale_x_continuous(breaks = 1:5) +
+  scale_y_continuous(breaks = 1:5) +
+  labs(
+    x = "Size portfolio",
+    y = "Book-to-market portfolio",
+    fill = "Market cap (%)",
+    title = "Market capitalization share per portfolio across sorting methods"
+  )
+```
+
+The two figures highlight a tension that is invisible when looking at returns alone. Because the breakpoints are based on NYSE stocks, while the bulk of small firms trade on NASDAQ and AMEX, the small-size portfolios absorb a large number of stocks under both sorting schemes. The difference between the methods shows up along the book-to-market dimension: independent sorts apply the same NYSE book-to-market cutoffs to every size group, so the counts within a size column are uneven, whereas dependent sorts recompute the book-to-market breakpoints inside each size bucket and therefore distribute stocks more evenly across book-to-market within a given size group. Market capitalization tells the mirror-image story: regardless of the sorting method, aggregate market value concentrates in the large-size, low-book-to-market corner, where comparatively few stocks account for the lion's share of total market capitalization. This is a useful reminder that value-weighting lets a handful of large firms dominate portfolio returns, even when most of the stocks sit elsewhere in the grid.
+
 ## Key Takeaways
 
 - Bivariate portfolio sorts assign stocks based on two characteristics, such as firm size and book-to-market ratio, to better capture return patterns in asset pricing.
 - Independent sorts treat each variable separately, while dependent sorts condition the second sort on the first.
 - Proper handling of accounting data, especially lagging the book-to-market ratio, is essential to avoid look-ahead bias and ensure valid backtesting.
 - Value premiums are derived by comparing returns of high versus low book-to-market portfolios, with results sensitive to sorting choices and weighting schemes.
+- Visualizing portfolio composition shows that NYSE breakpoints push many stocks into the small-size portfolios, while market capitalization concentrates in the large-size, low-book-to-market corner—a reminder that value-weighting lets a few large firms dominate returns.
 
 ## Exercises
 


### PR DESCRIPTION
Closes #200.

## What

Adds a new **Portfolio Composition** section at the end of the analytical content in both the R and Python `value-and-bivariate-sorts` chapters, implementing the visualizations requested in #200 and following Christoph's proposal in the issue thread.

For each of the 25 size–book-to-market portfolios, and for both independent and dependent sorts, the section visualizes two characteristics as faceted `geom_tile()` heat maps:

- **`fig-901`** – the average number of stocks per portfolio
- **`fig-902`** – each portfolio's average market capitalization as a share of the total within its sorting method

The accompanying prose explains why NYSE-based breakpoints concentrate stocks in the small-size portfolios while market value concentrates in the large-size, low-book-to-market corner — the value-weighting tension that motivated the issue.

## Details

- **R** (`r/value-and-bivariate-sorts.qmd`): follows Christoph's proposal, adapted to the chapter's existing `assign_portfolio(data = pick(everything()), ...)` calling style and the book's `fig-9xx` figure-label numbering (this is chapter 9). Market-cap labels use `scales::percent()` (namespaced, so no new attached package).
- **Python** (`python/value-and-bivariate-sorts.qmd`): mirrors the R logic with the chapter's existing pandas `groupby().apply()` patterns and `plotnine`. Adds `from plotnine import *` / `mizani` imports and the shared `render-plotnine-custom.py` theme hook (consistent with the sibling size-sorts chapter).
- Adds a matching **Key Takeaways** bullet in both chapters.

## Notes

- This environment has no R/Quarto/data, so the chapters were not re-rendered here — the `_freeze`/`docs` artifacts will need to be regenerated by the usual render pipeline.
- Exercise 3 ("compute the average characteristics ... across the 25 ... portfolios") is now partly worked through in the new section; I left the exercises unchanged, but happy to adjust if you'd prefer to drop or reword it.

https://claude.ai/code/session_01JdYkkSLu2jGzNnu8XyQTRH

---
_Generated by [Claude Code](https://claude.ai/code/session_01JdYkkSLu2jGzNnu8XyQTRH)_