### PR TITLE
Remove negative book equity correction from wrds-crsp-and-compustat

### DIFF
--- a/python/fama-macbeth-regressions.qmd
+++ b/python/fama-macbeth-regressions.qmd
@@ -40,7 +40,7 @@ import statsmodels.formula.api as smf
 
 ## Data Preparation
 
-We illustrate @Fama1973 with the monthly CRSP sample and use three characteristics to explain the cross-section of returns: Market capitalization, the book-to-market ratio, and the CAPM beta (i.e., the covariance of the excess stock returns with the market excess returns). We collect the data from our Parquet files introduced in [Accessing and Managing Financial Data](accessing-and-managing-financial-data.qmd) and [WRDS, CRSP, and Compustat](wrds-crsp-and-compustat.qmd).\index{Data!CRSP}\index{Data!Compustat}\index{Beta}
+We illustrate @Fama1973 with the monthly CRSP sample and use three characteristics to explain the cross-section of returns: Market capitalization, the book-to-market ratio, and the CAPM beta (i.e., the covariance of the excess stock returns with the market excess returns). We collect the data from our Parquet files introduced in [Accessing and Managing Financial Data](accessing-and-managing-financial-data.qmd) and [WRDS, CRSP, and Compustat](wrds-crsp-and-compustat.qmd). As in the previous chapters, we keep only firms with positive book equity, which is a common practice when working with book-to-market ratios [see @Fama1992 for details].\index{Data!CRSP}\index{Data!Compustat}\index{Beta}\index{Book equity}
 
 ```{python}
 crsp_monthly = (
@@ -51,6 +51,7 @@ crsp_monthly = (
 compustat_annual = (
     pd.read_parquet("data-python/compustat_annual.parquet")
     .get(["datadate", "gvkey", "be"])
+    .query("be > 0")
 )
 
 beta = (

--- a/python/replicating-fama-and-french-factors.qmd
+++ b/python/replicating-fama-and-french-factors.qmd
@@ -32,7 +32,7 @@ from regtabletotext import prettify_result
 
 ## Data Preparation
 
-We use CRSP and Compustat as data sources, as we need exactly the same variables to compute the size and value factors in the way Fama and French do it. Hence, there is nothing new below, and we only load data from our Parquet files introduced in [Accessing and Managing Financial Data](accessing-and-managing-financial-data.qmd) and [WRDS, CRSP, and Compustat](wrds-crsp-and-compustat.qmd).^[Note that @Fama1992 claim to exclude financial firms. To a large extent this happens through using industry format "INDL", as we do in [WRDS, CRSP, and Compustat](wrds-crsp-and-compustat.qmd). Neither the original paper, nor Ken French's website, or the WRDS replication contains any indication that financial companies are excluded using additional filters such as industry codes.] \index{Data!CRSP}\index{Data!Compustat}\index{Data!Fama-French factors}
+We use CRSP and Compustat as data sources, as we need exactly the same variables to compute the size and value factors in the way Fama and French do it. Hence, we only load data from our Parquet files introduced in [Accessing and Managing Financial Data](accessing-and-managing-financial-data.qmd) and [WRDS, CRSP, and Compustat](wrds-crsp-and-compustat.qmd).^[Note that @Fama1992 claim to exclude financial firms. To a large extent this happens through using industry format "INDL", as we do in [WRDS, CRSP, and Compustat](wrds-crsp-and-compustat.qmd). Neither the original paper, nor Ken French's website, or the WRDS replication contains any indication that financial companies are excluded using additional filters such as industry codes.] \index{Data!CRSP}\index{Data!Compustat}\index{Data!Fama-French factors} The only addition is that we keep only firms with positive book equity, which is a common practice when working with book-to-market ratios [see @Fama1992 for details].\index{Book equity}
 
 ```{python}
 crsp_monthly = (
@@ -45,8 +45,9 @@ crsp_monthly = (
 compustat_annual = (
     pd.read_parquet("data-python/compustat_annual.parquet")
     .get(["gvkey", "datadate", "be", "op", "inv"])
+    .query("be > 0")
     .dropna()
-) 
+)
 
 factors_ff3_monthly = (
     pd.read_parquet("data-python/factors_ff3_monthly.parquet")

--- a/python/value-and-bivariate-sorts.qmd
+++ b/python/value-and-bivariate-sorts.qmd
@@ -41,11 +41,12 @@ crsp_monthly = (
 )
 ```
 
-Further, we utilize accounting data. The most common source of accounting data is Compustat. We only need book equity data in this application, which we select from our local folder. Additionally, we convert the variable `datadate` to its monthly value, as we only consider monthly returns here and do not need to account for the exact date.\index{Data!Compustat}
+Further, we utilize accounting data. The most common source of accounting data is Compustat. We only need book equity data in this application, which we select from our local folder. We keep only firms with positive book equity, which is a common practice when working with book-to-market ratios [see @Fama1992 for details].\index{Book equity} Additionally, we convert the variable `datadate` to its monthly value, as we only consider monthly returns here and do not need to account for the exact date.\index{Data!Compustat}
 
 ```{python}
 book_equity = (pd.read_parquet("data-python/compustat_annual.parquet")
     .get(["gvkey", "datadate", "be"])
+    .query("be > 0")
     .dropna()
     .assign(
         date=lambda x: (

--- a/python/wrds-crsp-and-compustat.qmd
+++ b/python/wrds-crsp-and-compustat.qmd
@@ -515,7 +515,7 @@ compustat_annual = pd.read_sql_query(
 )
 ```
 
-Next, we calculate the book value of preferred stock and equity `be` and the operating profitability `op` inspired by the [variable definitions in Kenneth French's data library.](https://mba.tuck.dartmouth.edu/pages/faculty/ken.french/data_library.html) Note that we set negative or zero equity to missing, which is a common practice when working with book-to-market ratios [see @Fama1992 for details].\index{Book equity}\index{Preferred stock}\index{Operating profitability}
+Next, we calculate the book value of preferred stock and equity `be` and the operating profitability `op` inspired by the [variable definitions in Kenneth French's data library.](https://mba.tuck.dartmouth.edu/pages/faculty/ken.french/data_library.html)\index{Book equity}\index{Preferred stock}\index{Operating profitability}
 
 ```{python}
 #| eval: false
@@ -529,10 +529,7 @@ compustat_annual = (compustat_annual
         .combine_first(x["pstk"]).fillna(0))
     )
     .assign(
-        be=lambda x: x["be"].apply(lambda y: np.nan if y <= 0 else y)
-    )
-    .assign(
-        op=lambda x: 
+        op=lambda x:
         ((x["sale"]-x["cogs"].fillna(0)- 
             x["xsga"].fillna(0)-x["xint"].fillna(0))/x["be"])
     )

--- a/r/fama-macbeth-regressions.qmd
+++ b/r/fama-macbeth-regressions.qmd
@@ -40,7 +40,7 @@ library(broom)
 
 ## Data Preparation
 
-We illustrate @Fama1973 with the monthly CRSP sample and use three characteristics to explain the cross-section of returns: market capitalization, the book-to-market ratio, and the CAPM beta (i.e., the covariance of the excess stock returns with the market excess returns). We collect the data from our Parquet files introduced in [Accessing and Managing Financial Data](accessing-and-managing-financial-data.qmd) and [WRDS, CRSP, and Compustat](wrds-crsp-and-compustat.qmd).\index{Data!CRSP}\index{Data!Compustat}\index{Beta}
+We illustrate @Fama1973 with the monthly CRSP sample and use three characteristics to explain the cross-section of returns: market capitalization, the book-to-market ratio, and the CAPM beta (i.e., the covariance of the excess stock returns with the market excess returns). We collect the data from our Parquet files introduced in [Accessing and Managing Financial Data](accessing-and-managing-financial-data.qmd) and [WRDS, CRSP, and Compustat](wrds-crsp-and-compustat.qmd). As in the previous chapters, we keep only firms with positive book equity, which is a common practice when working with book-to-market ratios [see @Fama1992 for details].\index{Data!CRSP}\index{Data!Compustat}\index{Beta}\index{Book equity}
 
 ```{r}
 crsp_monthly <- read_parquet("data-r/crsp_monthly.parquet") |>
@@ -48,7 +48,8 @@ crsp_monthly <- read_parquet("data-r/crsp_monthly.parquet") |>
   collect()
 
 compustat_annual <- read_parquet("data-r/compustat_annual.parquet") |>
-  select(datadate, gvkey, be)
+  select(datadate, gvkey, be) |>
+  filter(be > 0)
 
 beta <- read_parquet("data-r/beta.parquet") |>
   filter(return_type == "monthly") |>

--- a/r/replicating-fama-and-french-factors.qmd
+++ b/r/replicating-fama-and-french-factors.qmd
@@ -28,7 +28,7 @@ library(arrow)
 
 ## Data Preparation
 
-We use CRSP and Compustat as data sources, as we need the same variables to compute the factors in the way Fama and French do it. Hence, there is nothing new below, and we only load data from our Parquet files introduced in [Accessing and Managing Financial Data](accessing-and-managing-financial-data.qmd) and [WRDS, CRSP, and Compustat](wrds-crsp-and-compustat.qmd).^[Note that @Fama1992 claim to exclude financial firms. To a large extent this happens through using industry format "INDL", as we do in [WRDS, CRSP, and Compustat](wrds-crsp-and-compustat.qmd). Neither the original paper, nor Ken French's website, or the WRDS replication contains any indication that financial companies are excluded using additional filters such as industry codes.] \index{Data!CRSP}\index{Data!Compustat}
+We use CRSP and Compustat as data sources, as we need the same variables to compute the factors in the way Fama and French do it. Hence, we only load data from our Parquet files introduced in [Accessing and Managing Financial Data](accessing-and-managing-financial-data.qmd) and [WRDS, CRSP, and Compustat](wrds-crsp-and-compustat.qmd).^[Note that @Fama1992 claim to exclude financial firms. To a large extent this happens through using industry format "INDL", as we do in [WRDS, CRSP, and Compustat](wrds-crsp-and-compustat.qmd). Neither the original paper, nor Ken French's website, or the WRDS replication contains any indication that financial companies are excluded using additional filters such as industry codes.] \index{Data!CRSP}\index{Data!Compustat} The only addition is that we keep only firms with positive book equity, which is a common practice when working with book-to-market ratios [see @Fama1992 for details].\index{Book equity}
 
 ```{r}
 crsp_monthly <- read_parquet("data-r/crsp_monthly.parquet") |>
@@ -43,7 +43,8 @@ crsp_monthly <- read_parquet("data-r/crsp_monthly.parquet") |>
   )
 
 compustat_annual <- read_parquet("data-r/compustat_annual.parquet") |>
-  select(gvkey, datadate, be, op, inv)
+  select(gvkey, datadate, be, op, inv) |>
+  filter(be > 0)
 
 factors_ff3_monthly <- read_parquet("data-r/factors_ff3_monthly.parquet") |>
   select(date, smb, hml)

--- a/r/value-and-bivariate-sorts.qmd
+++ b/r/value-and-bivariate-sorts.qmd
@@ -41,11 +41,12 @@ crsp_monthly <- read_parquet("data-r/crsp_monthly.parquet") |>
   drop_na()
 ```
 
-Further, we utilize accounting data. The most common source of accounting data is Compustat. We only need book equity data in this application, which we select from our database. Additionally, we convert the variable `datadate` to its monthly value, as we only consider monthly returns here and do not need to account for the exact date. To achieve this, we use the function `floor_date()`.\index{Data!Compustat}
+Further, we utilize accounting data. The most common source of accounting data is Compustat. We only need book equity data in this application, which we select from our database. We keep only firms with positive book equity, which is a common practice when working with book-to-market ratios [see @Fama1992 for details].\index{Book equity} Additionally, we convert the variable `datadate` to its monthly value, as we only consider monthly returns here and do not need to account for the exact date. To achieve this, we use the function `floor_date()`.\index{Data!Compustat}
 
 ```{r}
 book_equity <- read_parquet("data-r/compustat_annual.parquet") |>
   select(gvkey, datadate, be) |>
+  filter(be > 0) |>
   drop_na() |>
   mutate(date = floor_date(ymd(datadate), "month"))
 ```

--- a/r/wrds-crsp-and-compustat.qmd
+++ b/r/wrds-crsp-and-compustat.qmd
@@ -504,7 +504,7 @@ compustat_annual <- funda_db |>
   collect()
 ```
 
-Next, we calculate the book value of preferred stock and equity `be` and the operating profitability `op` inspired by the [variable definitions in Ken French's data library.](https://mba.tuck.dartmouth.edu/pages/faculty/ken.french/Data_Library/variable_definitions.html) Note that we set negative or zero equity to missing which is a common practice when working with book-to-market ratios [see @Fama1992 for details].\index{Book equity}\index{Preferred stock}\index{Operating profitability}
+Next, we calculate the book value of preferred stock and equity `be` and the operating profitability `op` inspired by the [variable definitions in Ken French's data library.](https://mba.tuck.dartmouth.edu/pages/faculty/ken.french/Data_Library/variable_definitions.html)\index{Book equity}\index{Preferred stock}\index{Operating profitability}
 
 ```{r}
 #| eval: !expr params$download_data
@@ -513,7 +513,6 @@ compustat_annual <- compustat_annual |>
     be = coalesce(seq, ceq + pstk, at - lt) +
       coalesce(txditc, txdb + itcb, 0) -
       coalesce(pstkrv, pstkl, pstk, 0),
-    be = if_else(be <= 0, NA, be),
     op = (sale - coalesce(cogs, 0) - coalesce(xsga, 0) - coalesce(xint, 0)) /
       be,
   )


### PR DESCRIPTION
Closes #212.

## What & why

To align the website with `r-tidyfinance`, we no longer set negative or zero book equity to missing in the **WRDS, CRSP, and Compustat** chapter. As discussed in the issue, this correction is needed to make the value factor work in later chapters, so it is moved to the data preparation step of the chapters that actually compute the book-to-market ratio — which is more honest anyway.

## Changes

**`wrds-crsp-and-compustat` (R + Python)**
- Removed the `be = if_else(be <= 0, NA, be)` / `np.nan if y <= 0` correction.
- Removed the accompanying sentence and the `@Fama1992` reference that justified it.

**Chapters computing the book-to-market ratio (R + Python)** — added a positive book equity filter (`filter(be > 0)` / `.query("be > 0")`) at the data preparation step, together with a short note citing `@Fama1992`:
- Value and Bivariate Sorts
- Replicating Fama and French Factors
- Fama-MacBeth Regressions

## Note

The `_freeze` cache is not updated here since re-rendering requires the WRDS/Compustat data, which isn't available in this environment. The render pipeline will regenerate the cached output.

https://claude.ai/code/session_01XJ3D8yKzJ6UQj6ryHeMWG3

---
_Generated by [Claude Code](https://claude.ai/code/session_01XJ3D8yKzJ6UQj6ryHeMWG3)_