### PR TITLE
Add portfolio composition heat maps to value-and-bivariate-sorts (polars edition)

### DIFF
--- a/python/value-and-bivariate-sorts.qmd
+++ b/python/value-and-bivariate-sorts.qmd
@@ -23,9 +23,17 @@ The current chapter relies on this set of Python packages.
 ```{python}
 import polars as pl
 import numpy as np
+
+from plotnine import *
+from mizani.formatters import percent_format
 ```
 
-Compared to previous chapters, we rely on `numpy` to construct evenly spaced breakpoints for the portfolio sorts later in this chapter.
+```{python}
+#| echo: false
+exec(open("python/render-plotnine-custom.py").read())
+```
+
+Compared to previous chapters, we rely on `numpy` to construct evenly spaced breakpoints for the portfolio sorts later in this chapter. We also rely on `plotnine` for visualization.
 
 ## Data Preparation
 
@@ -249,12 +257,138 @@ The monthly value premium from dependent sorts is `{python} round(value_premium*
 
 Overall, we show how to conduct bivariate portfolio sorts in this chapter. In one case, we sort the portfolios independently of each other. Yet we also discuss how to create dependent portfolio sorts. Along the lines of [Size Sorts and P-Hacking](size-sorts-and-p-hacking.qmd), we see how many choices a researcher has to make to implement portfolio sorts, and bivariate sorts increase the number of choices.
 
+## Portfolio Composition
+
+So far, we have focused exclusively on the returns of our portfolios. Yet the way stocks are distributed across the size–value grid is itself informative, and it differs systematically between independent and dependent sorts. In this section, we visualize two characteristics for each of the 25 portfolios and for both sorting methods: the number of stocks and the aggregate market capitalization.
+
+We start with the independent assignment. As before, we group by month and assign the size and book-to-market portfolios separately.
+
+```{python}
+assignments_independent = (data_for_sorts
+    .group_by("date")
+    .map_groups(lambda x: x.with_columns(
+        portfolio_size=assign_portfolio(
+            data=x, sorting_variable="size", n_portfolios=5, exchanges=["NYSE"]
+        ),
+        portfolio_bm=assign_portfolio(
+            data=x, sorting_variable="bm", n_portfolios=5, exchanges=["NYSE"]
+        )
+        )
+    )
+    .with_columns(sorting_method=pl.lit("Independent"))
+)
+```
+
+For the dependent assignment, we again first form the size portfolios and then assign book-to-market portfolios within each size bucket, so that the book-to-market breakpoints are specific to each size group.
+
+```{python}
+assignments_dependent = (data_for_sorts
+    .group_by("date")
+    .map_groups(lambda x: x.with_columns(
+        portfolio_size=assign_portfolio(
+            data=x, sorting_variable="size", n_portfolios=5, exchanges=["NYSE"]
+        )
+        )
+    )
+    .group_by("date", "portfolio_size")
+    .map_groups(lambda x: x.with_columns(
+        portfolio_bm=assign_portfolio(
+            data=x, sorting_variable="bm", n_portfolios=5, exchanges=["NYSE"]
+        )
+        )
+    )
+    .with_columns(sorting_method=pl.lit("Dependent"))
+)
+```
+
+Next, we stack both assignments and compute the characteristics of interest. For each month and portfolio, we count the number of stocks and sum their lagged market capitalization. We then average these monthly figures across the whole sample to obtain one value per portfolio. Finally, we express market capitalization as a share of the total within each sorting method, which makes the concentration of market value across the grid directly comparable.
+
+```{python}
+portfolio_characteristics = (
+    pl.concat([assignments_independent, assignments_dependent])
+    .group_by(["sorting_method", "date", "portfolio_size", "portfolio_bm"])
+    .agg(
+        n_stocks=pl.len(),
+        mktcap=pl.col("mktcap_lag").sum()
+    )
+    .group_by(["sorting_method", "portfolio_size", "portfolio_bm"])
+    .agg(
+        n_stocks=pl.col("n_stocks").mean(),
+        mktcap=pl.col("mktcap").mean()
+    )
+    .with_columns(
+        mktcap_share=pl.col("mktcap") / pl.col("mktcap").sum().over("sorting_method")
+    )
+    .with_columns(
+        sorting_method=pl.col("sorting_method").cast(
+            pl.Enum(["Independent", "Dependent"])
+        ),
+        n_stocks_label=pl.col("n_stocks").round().cast(pl.Int64),
+        mktcap_share_label=pl.format(
+            "{}%", (pl.col("mktcap_share") * 100).round(1)
+        )
+    )
+)
+```
+
+We are now ready to visualize the results. We use `geom_tile()` to draw the 25 portfolios as a heatmap spanned by the size and book-to-market portfolios, and facet by the sorting method. @fig-901 shows the average number of stocks per portfolio.
+
+```{python}
+#| label: fig-901
+#| fig-cap: "Average number of stocks per portfolio for independent and dependent bivariate sorts. Breakpoints are based on NYSE stocks. Portfolio 1 (5) contains the smallest (largest) firms along each dimension."
+#| fig-alt: "Two heatmaps of a five-by-five size and book-to-market grid, one for independent and one for dependent sorts. Stock counts are highest in the small-size portfolios and decline toward the large-size portfolios."
+plot_counts = (
+    ggplot(
+        portfolio_characteristics,
+        aes(x="portfolio_size", y="portfolio_bm", fill="n_stocks")
+    )
+    + geom_tile()
+    + geom_text(aes(label="n_stocks_label"))
+    + facet_wrap("sorting_method")
+    + scale_x_continuous(breaks=list(range(1, 6)))
+    + scale_y_continuous(breaks=list(range(1, 6)))
+    + labs(
+        x="Size portfolio", y="Book-to-market portfolio", fill="Avg. stocks",
+        title="Average number of stocks per portfolio across sorting methods"
+    )
+)
+plot_counts.show()
+```
+
+@fig-902 shows each portfolio's average market capitalization as a share of the total.
+
+```{python}
+#| label: fig-902
+#| fig-cap: "Average market capitalization per portfolio, expressed as a share of total market capitalization within each sorting method. Breakpoints are based on NYSE stocks."
+#| fig-alt: "Two heatmaps of a five-by-five size and book-to-market grid, one for independent and one for dependent sorts. Market capitalization concentrates heavily in the large-size, low-book-to-market portfolios."
+plot_mktcap = (
+    ggplot(
+        portfolio_characteristics,
+        aes(x="portfolio_size", y="portfolio_bm", fill="mktcap_share")
+    )
+    + geom_tile()
+    + geom_text(aes(label="mktcap_share_label"))
+    + facet_wrap("sorting_method")
+    + scale_x_continuous(breaks=list(range(1, 6)))
+    + scale_y_continuous(breaks=list(range(1, 6)))
+    + scale_fill_continuous(labels=percent_format())
+    + labs(
+        x="Size portfolio", y="Book-to-market portfolio", fill="Market cap (%)",
+        title="Market capitalization share per portfolio across sorting methods"
+    )
+)
+plot_mktcap.show()
+```
+
+The two figures highlight a tension that is invisible when looking at returns alone. Because the breakpoints are based on NYSE stocks, while the bulk of small firms trade on NASDAQ and AMEX, the small-size portfolios absorb a large number of stocks under both sorting schemes. The difference between the methods shows up along the book-to-market dimension: independent sorts apply the same NYSE book-to-market cutoffs to every size group, so the counts within a size column are uneven, whereas dependent sorts recompute the book-to-market breakpoints inside each size bucket and therefore distribute stocks more evenly across book-to-market within a given size group. Market capitalization tells the mirror-image story: regardless of the sorting method, aggregate market value concentrates in the large-size, low-book-to-market corner, where comparatively few stocks account for the lion's share of total market capitalization. This is a useful reminder that value-weighting lets a handful of large firms dominate portfolio returns, even when most of the stocks sit elsewhere in the grid.
+
 ## Key Takeaways
 
 - Bivariate portfolio sorts assign stocks based on two characteristics, such as firm size and book-to-market ratio, to better capture return patterns in asset pricing.
 - Independent sorts treat each variable separately, while dependent sorts condition the second sort on the first.
 - Proper handling of accounting data, especially lagging the book-to-market ratio, is essential to avoid look-ahead bias and ensure valid backtesting.
 - Value premiums are derived by comparing returns of high versus low book-to-market portfolios, with results sensitive to sorting choices and weighting schemes.
+- Visualizing portfolio composition shows that NYSE breakpoints push many stocks into the small-size portfolios, while market capitalization concentrates in the large-size, low-book-to-market corner—a reminder that value-weighting lets a few large firms dominate returns.
 
 ## Exercises
 


### PR DESCRIPTION
Part of #200 (heat maps for bivariate sorts) for the **polars** Python edition.

This PR targets the polars-translation branch so the new section lands in the polars rewrite alongside the umbrella migration in #220. The pandas/`main` version of the same change is in #241.

## What

Adds the new **Portfolio Composition** section to the polars edition of `python/value-and-bivariate-sorts.qmd`, mirroring the pandas and R additions. For each of the 25 size–book-to-market portfolios, and for both independent and dependent sorts, it draws two faceted `geom_tile()` heat maps:

- **`fig-901`** — average number of stocks per portfolio
- **`fig-902`** — average market-cap share per portfolio (within each sorting method)

Plus the explanatory prose on why NYSE breakpoints concentrate *stocks* in the small-size portfolios while *market value* concentrates in the large-size/low-BM corner, and a matching Key Takeaways bullet.

## polars-specific notes

- Assignments use the chapter's existing `group_by(...).map_groups(...)` + `assign_portfolio()` pattern; the two assignment frames are stacked with `pl.concat` and aggregated with `pl.len()` / `pl.col("mktcap_lag").sum()`.
- `mktcap_share` is computed with a windowed `.sum().over("sorting_method")`; `sorting_method` is cast to `pl.Enum(["Independent", "Dependent"])` to fix facet order.
- Figures pass the polars frame straight into `ggplot()` (plotnine 0.15 / narwhals), consistent with the other polars chapters; adds the `plotnine`/`mizani` imports and the shared `render-plotnine-custom.py` theme hook.

## Notes

- No R/Quarto/polars/data in this environment, so the chapter was **not** re-rendered — the `_freeze`/`docs` artifacts need regeneration by the normal pipeline. Python code blocks were syntax-checked via `ast.parse`.

https://claude.ai/code/session_01JdYkkSLu2jGzNnu8XyQTRH

---
_Generated by [Claude Code](https://claude.ai/code/session_01JdYkkSLu2jGzNnu8XyQTRH)_