### PR TITLE
Add meaningful code chunk labels to all R and Python chapters

### DIFF
--- a/python/accessing-and-managing-financial-data.qmd
+++ b/python/accessing-and-managing-financial-data.qmd
@@ -6,6 +6,7 @@ metadata:
 ---
 
 ```{python}
+#| label: accessing-and-managing-financial-data-setup
 #| echo: false
 exec(open("python/render-settings.py").read())
 ```
@@ -21,6 +22,7 @@ This chapter shows how to import different open-source datasets. Specifically, o
 First, we load the Python packages that we use throughout this chapter. Later on, we load more packages in the sections where we need them. 
 
 ```{python}
+#| label: accessing-and-managing-financial-data-packages
 import polars as pl
 import io
 import re
@@ -31,6 +33,7 @@ from curl_cffi import requests
 Moreover, we initially define the date range for which we fetch and store the financial data, making future data updates tractable. In case you need another time frame, you can adjust the dates below. Our data starts with 1960 since most asset pricing studies use data from 1962 on.
 
 ```{python}
+#| label: accessing-and-managing-financial-data-date-range
 start_date = "1960-01-01"
 end_date = "2024-12-31"
 ```
@@ -53,6 +56,7 @@ Doing this once is fine; doing it repeatedly across projects is exactly the type
 A minimal download script mirrors the manual steps one by one. For example, to fetch a Fama–French dataset you first construct the URL:
 
 ```{python}
+#| label: accessing-and-managing-financial-data-ff-url
 dataset = "F-F_Research_Data_Factors"
 base_url = "http://mba.tuck.dartmouth.edu/pages/faculty/ken.french/ftp/"
 url = f"{base_url}{dataset}_CSV.zip"
@@ -61,6 +65,7 @@ url = f"{base_url}{dataset}_CSV.zip"
 Next, you replace the browser download with an HTTP request and extract the ZIP in memory:
 
 ```{python}
+#| label: accessing-and-managing-financial-data-ff-download-zip
 resp = requests.get(url)
 resp.raise_for_status()
 
@@ -74,6 +79,7 @@ The most important part of this chunk is the `requests.get()` call. This is the 
 The raw file contains documentation text followed by the actual data table(s). To emulate *scrolling down until the numbers start*, you can split the file into blocks and keep the long one that contains the table:
 
 ```{python}
+#| label: accessing-and-managing-financial-data-ff-extract-table
 chunks = raw_text.split("\r\n\r\n")
 table_text = max(chunks, key=len)
 ```
@@ -81,6 +87,7 @@ table_text = max(chunks, key=len)
 Within this block, the first CSV header line starts at the first line beginning with a comma. We add a “Date” label for the first column and pass everything to `pl.read_csv()`, which accepts the raw bytes directly. The numeric fields in the raw file carry leading spaces (e.g., `  2.89`), which `polars` does not strip automatically — such values are read as strings. We therefore trim the whitespace and cast all non-date columns to floats:
 
 ```{python}
+#| label: accessing-and-managing-financial-data-ff-read-csv
 match = re.search(r"^\s*,", table_text, flags=re.M)
 start = match.start()
 csv_text = "Date" + table_text[start:]
@@ -93,6 +100,7 @@ factors_ff_raw = pl.read_csv(csv_text.encode("latin1")).with_columns(
 At this point, the `Date` column still consists of integer date codes with different lengths depending on the frequency. We need a bit of logic to convert them into a proper date column:
 
 ```{python}
+#| label: accessing-and-managing-financial-data-ff-parse-dates
 s = factors_ff_raw["Date"].cast(pl.String)
 n = s.str.len_chars()
 
@@ -118,6 +126,7 @@ Finally, we still have to clean the data:
 This all could look like this:
 
 ```{python}
+#| label: accessing-and-managing-financial-data-ff-clean-data
 # start and end dates
 if start_date:
     factors_ff_raw = factors_ff_raw.filter(
@@ -142,6 +151,7 @@ All of these steps are doable, but none of them are really about finance - they 
 # Using `tidyfinance` instead of reimplementing the plumbing
 
 ```{python}
+#| label: accessing-and-managing-financial-data-import-tidyfinance
 import tidyfinance as tf
 ```
 
@@ -150,6 +160,7 @@ For example, we can use the `tf.download_data()` function of the package to down
 Because the downloaded data arrives with timestamp columns, we cast the `date` column to the polars `Date` type — calendar dates rather than timestamps — a convention we use for all tables we store in this book.
 
 ```{python}
+#| label: accessing-and-managing-financial-data-download-ff3-monthly
 factors_ff3_monthly = pl.from_pandas(
     tf.download_data(
         domain="famafrench",
@@ -163,6 +174,7 @@ factors_ff3_monthly = pl.from_pandas(
 We also download the set *5 Factors (2x3)*, which additionally includes the return time series of the profitability (`rmw`) and investment (`cma`) factors. We demonstrate how the monthly factors are constructed in [Replicating Fama and French Factors](replicating-fama-and-french-factors.qmd).
 
 ```{python}
+#| label: accessing-and-managing-financial-data-download-ff5-monthly
 factors_ff5_monthly = pl.from_pandas(
     tf.download_data(
         domain="famafrench",
@@ -176,6 +188,7 @@ factors_ff5_monthly = pl.from_pandas(
 It is straightforward to download the corresponding *daily* Fama-French factors with the same function. 
 
 ```{python}
+#| label: accessing-and-managing-financial-data-download-ff3-daily
 factors_ff3_daily = pl.from_pandas(
     tf.download_data(
         domain="famafrench",
@@ -189,6 +202,7 @@ factors_ff3_daily = pl.from_pandas(
 In a subsequent chapter, we also use the monthly returns from ten industry portfolios, so let us fetch that data, too.\index{Data!Industry portfolios}
 
 ```{python}
+#| label: accessing-and-managing-financial-data-download-industries
 industries_ff_monthly = pl.from_pandas(
     tf.download_data(
         domain="famafrench",
@@ -210,6 +224,7 @@ We also need to adjust this data. First, we discard information we will not use 
 We download the CSV with `requests` and pass the response body directly to `pl.read_csv()`:
 
 ```{python}
+#| label: accessing-and-managing-financial-data-download-q-factors
 factors_q_monthly_link = (
     "https://global-q.org/uploads/1/2/2/6/122679606/q5_factors_monthly_2024.csv"
 )
@@ -234,6 +249,7 @@ factors_q_monthly = (
 Again, you can use the `tidyfinance` package for a shortcut:
 
 ```{python}
+#| label: accessing-and-managing-financial-data-q-factors-tidyfinance
 #| eval: false
 tf.download_data(
     domain="factors_q",
@@ -248,6 +264,7 @@ tf.download_data(
 Our next data source is a set of macroeconomic variables often used as predictors for the equity premium. @Goyal2008 comprehensively reexamine the performance of variables suggested by the academic literature to be good predictors of the equity premium. The authors host the data on [Amit Goyal's website.](https://sites.google.com/view/agoyal145) Since the data is an XLSX-file stored on a public Google Drive location, we need additional packages to access the data directly from our Python session. Usually, you need to authenticate if you interact with Google Drive directly in Python. Since the data is stored via a public link, we can proceed without any authentication.\index{Google Drive}
 
 ```{python}
+#| label: accessing-and-managing-financial-data-macro-link
 sheet_id = "1bM7vCWd3WOt95Sf9qjLPZjoiafgF_8EG"
 sheet_name = "macro_predictors.xlsx"
 macro_predictors_link = (
@@ -277,6 +294,7 @@ For variable definitions and the required data transformations, you can consult 
 Some numeric columns in the raw file contain thousands separators (e.g., `4,769.83`), so we read all columns as strings, strip the commas, and cast to floats before the actual transformations. In addition to the predictors, we compute the one-month-ahead excess market return (`rp_div`), which serves as the prediction target for the equity premium predictors:
 
 ```{python}
+#| label: accessing-and-managing-financial-data-macro-predictors
 macro_predictors = (
     pl.read_csv(requests.get(macro_predictors_link).content, infer_schema=False)
     .with_columns(
@@ -327,6 +345,7 @@ macro_predictors = (
 To get the equivalent data through `tidyfinance`, you can call:
 
 ```{python}
+#| label: accessing-and-managing-financial-data-macro-tidyfinance
 #| eval: false
 tf.download_data(
     domain="macro_predictors",
@@ -341,6 +360,7 @@ tf.download_data(
 The Federal Reserve Bank of St. Louis provides the Federal Reserve Economic Data (FRED), an extensive database for macroeconomic data. In total, there are 817,000 US and international time series from 108 different sources. As an illustration, we use the `tidyfinance` package to fetch consumer price index (CPI) data that can be found under the [CPIAUCNS](https://fred.stlouisfed.org/series/CPIAUCNS) key.\index{Data!FRED}\index{Data!CPI}
 
 ```{python}
+#| label: accessing-and-managing-financial-data-fred-series
 series = "CPIAUCNS"
 url = f"https://fred.stlouisfed.org/graph/fredgraph.csv?id={series}"
 ```
@@ -348,6 +368,7 @@ url = f"https://fred.stlouisfed.org/graph/fredgraph.csv?id={series}"
 We can then use the `requests` module to request the CSV, extract the data from the response body, and convert the columns to a tidy format. Note that we pass `impersonate="chrome"` so that the request mimics a regular browser; FRED rejects downloads that do not look like they come from a browser.
 
 ```{python}
+#| label: accessing-and-managing-financial-data-download-cpi
 resp = requests.get(url, impersonate="chrome")
 
 cpi_monthly = (
@@ -371,6 +392,7 @@ The last line sets the current (latest) price level as the reference price level
 The `tidyfinance` package can, of course, also fetch the same index data and many more data series:
 
 ```{python}
+#| label: accessing-and-managing-financial-data-cpi-tidyfinance
 pl.from_pandas(
     tf.download_data(
         domain="fred", series="CPIAUCNS", start_date=start_date, end_date=end_date
@@ -386,6 +408,7 @@ Now that we have downloaded some (freely available) data from the web into the m
 
 There are many ways to set up and organize your data, depending on the use case. Storing data as Parquet files creates a universal data format that seamlessly works across different programming languages and platforms. Unlike CSV files that often lose data types when shared between R, Python, Julia, or other languages, Parquet files maintain perfect data integrity regardless of which tool reads them. A dataset saved as Parquet in Python can be opened directly in Python's pandas, or Julia's DataFrames.jl.^[In previous editions of this book, we suggested using SQLite databases. However, Parquet files are more versatile and easier to handle across different programming languages. Should you still prefer using SQLite, you can find the relevant code snippets in a separate blog post.]
 ```{python}
+#| label: accessing-and-managing-financial-data-create-directory
 import os
 
 if not os.path.exists("data-python"):
@@ -395,6 +418,7 @@ if not os.path.exists("data-python"):
 Next, we create a remote table with the monthly Fama-French factor data. We do so with the `polars` function `write_parquet()`, which stores the data to parquet files.
 
 ```{python}
+#| label: accessing-and-managing-financial-data-write-ff3-monthly
 #| output: false
 factors_ff3_monthly.write_parquet("data-python/factors_ff3_monthly.parquet")
 ```
@@ -402,6 +426,7 @@ factors_ff3_monthly.write_parquet("data-python/factors_ff3_monthly.parquet")
 Now, if we want to have the whole table in memory, we need to call `pl.read_parquet()` with the corresponding query.\index{Database!Read}
 
 ```{python}
+#| label: accessing-and-managing-financial-data-read-ff3-monthly
 pl.read_parquet("data-python/factors_ff3_monthly.parquet")
 ```
 
@@ -410,6 +435,7 @@ The last couple of code chunks are really all there is to organizing a simple da
 Before we move on to the next data source, let us also store the other six tables in our new database. 
 
 ```{python}
+#| label: accessing-and-managing-financial-data-write-all-tables
 data_dict = {
     "factors_ff5_monthly": factors_ff5_monthly,
     "factors_ff3_daily": factors_ff3_daily,

--- a/python/beta-estimation.qmd
+++ b/python/beta-estimation.qmd
@@ -6,6 +6,7 @@ metadata:
 ---
 
 ```{python}
+#| label: beta-estimation-setup
 #| echo: false
 exec(open("python/render-settings.py").read())
 ```
@@ -19,6 +20,7 @@ In this chapter, we introduce an important concept in financial economics: The e
 We use the following Python packages throughout this chapter:
 
 ```{python}
+#| label: beta-estimation-packages
 import polars as pl
 import numpy as np
 import statsmodels.formula.api as smf
@@ -33,6 +35,7 @@ from dateutil.relativedelta import relativedelta
 ```
 
 ```{python}
+#| label: beta-estimation-render-plotnine
 #| echo: false
 exec(open("python/render-plotnine-custom.py").read())
 ```
@@ -44,6 +47,7 @@ Compared to previous chapters, we introduce `statsmodels` [@seabold2010statsmode
 The estimation procedure is based on a rolling-window estimation, where we may use either monthly or daily returns and different window lengths. First, let us start with loading the monthly CRSP data from our Parquet files introduced in [Accessing and Managing Financial Data](accessing-and-managing-financial-data.qmd) and [WRDS, CRSP, and Compustat](wrds-crsp-and-compustat.qmd).\index{Data!CRSP}\index{Data!Fama-French factors}
 
 ```{python}
+#| label: beta-estimation-load-crsp-monthly
 crsp_monthly = (pl.read_parquet("data-python/crsp_monthly.parquet")
     .select(["permno", "date", "industry", "ret_excess"])
     .drop_nulls()
@@ -69,6 +73,7 @@ we regress stock excess returns `ret_excess` on excess returns of the market por
 Python provides a simple solution to estimate (linear) models with the function `smf.ols()`. The function requires a formula as input that is specified in a compact symbolic form. An expression of the form `y ~ model` is interpreted as a specification that the response `y` is modeled by a linear predictor specified symbolically by `model`. Such a model consists of a series of terms separated by `+` operators. In addition to standard linear models, `smf.ols()` provides a lot of flexibility. You should check out the documentation for more information. To start, we restrict the data only to the time series of observations in CRSP that correspond to Apple’s stock (i.e., to `permno` 14593 for Apple) and compute $\hat\alpha_i$ as well as $\hat\beta_i$.\index{Linear regression}
 
 ```{python}
+#| label: beta-estimation-capm-apple
 model_fit = smf.ols(
     formula="ret_excess ~ mkt_excess",
     data=crsp_monthly.filter(pl.col("permno") == 14593).to_pandas()
@@ -84,6 +89,7 @@ coefficients
 After we estimated the regression coefficients on an example, we scale the estimation of  $\beta_i$ to a whole different level and perform rolling-window estimations for the entire CRSP sample.\index{Rolling-window estimation} The following function implements the CAPM regression for a data frame (or a part thereof) containing at least `min_obs` observations to avoid huge fluctuations if the time series is too short. The function conveniently returns the regression results as a data frame, which ensures that our approach is scalable. If the `min_obs`-condition is violated, that is, the time series is too short, the function returns an empty data frame for consistency. 
 
 ```{python}
+#| label: beta-estimation-define-estimate-capm
 def estimate_capm(data, min_obs=1):
     if data.shape[0] < min_obs:
         capm = pl.DataFrame()
@@ -111,6 +117,7 @@ def estimate_capm(data, min_obs=1):
 Next, we define a function that does the rolling estimation. We use a simple for-loop to implement the sliding window estimation in a straightforward manner. The following function takes input data and slides across the `date` vector, considering only a total of `look_back` months. The function essentially performs three steps: (i) arrange all rows, (ii) compute betas by sliding across months, and (iii) return a tibble with dates and corresponding parameter estimates. As we demonstrate further below, we can also apply the same function to daily return data.
 
 ```{python}
+#| label: beta-estimation-define-roll-capm
 def roll_capm_estimation(data, look_back=60, min_obs=48):
     results = []
     dates = data["date"].unique().sort()
@@ -146,6 +153,7 @@ def roll_capm_estimation(data, look_back=60, min_obs=48):
 Before we approach the whole CRSP sample, let us focus on a couple of examples for well-known firms.
 
 ```{python}
+#| label: beta-estimation-example-stocks
 examples = pl.DataFrame({
     "permno": [14593, 10107, 93436, 17778],
     "company": ["Apple", "Microsoft", "Tesla", "Berkshire Hathaway"]
@@ -155,6 +163,7 @@ examples = pl.DataFrame({
 The main idea is to apply the function to each stock individually and then combine the results into a single data frame. First, we restrict the sample to the example stocks and split it by `permno`. Splitting the data means we now have a list of frames, one per `permno`, each holding the corresponding time series data. We get one block of output for each unique value of `permno`.\index{Data!Nested}
 
 ```{python}
+#| label: beta-estimation-nest-examples
 capm_examples_nested = (crsp_monthly
     .filter(pl.col("permno").is_in(examples["permno"]))
     .partition_by("permno")
@@ -165,6 +174,7 @@ capm_examples_nested
 Next, we want to apply the `roll_capm_estimation()` function to each stock. We iterate over the list of per-stock frames, call the function on each, attach the corresponding `permno`, and concatenate the results into a single tidy data frame with a time series of beta estimates for each stock.
 
 ```{python}
+#| label: beta-estimation-estimate-examples
 capm_examples = (pl.concat([
         roll_capm_estimation(group).with_columns(permno=group["permno"][0])
         for group in capm_examples_nested
@@ -215,12 +225,14 @@ Even though we could now just apply the function to each group on the whole CRSP
 If you have a Windows or Mac machine, it makes most sense to use the default parallelization backend of `joblib`, which means that separate Python processes are running in the background on the same machine to perform the individual jobs. If you check out the documentation of `joblib.parallel_config()`, you can also see other ways to resolve the parallelization in different environments. Note that we use `cpu_count()` to determine the number of cores available for parallelization, but keep one core free for other tasks. Some machines might freeze if all cores are busy with Python jobs. \index{Parallelization}
 
 ```{python}
+#| label: beta-estimation-n-cores
 n_cores = cpu_count() - 1
 ```
 
 Using eight cores, the estimation for our sample of around 25k stocks takes around 20 minutes. Of course, you can speed up things considerably by having more cores available to share the workload or by having more powerful cores. Instead of looping over groups, we use `Parallel()` to execute multiple tasks concurrently and `delayed()` to wrap each function call, allowing the calls to be queued and distributed to worker processes rather than executed immediately.
 
 ```{python}
+#| label: beta-estimation-parallel-monthly
 #| eval: false
 crsp_monthly_nested = crsp_monthly.partition_by("permno")
 
@@ -244,6 +256,7 @@ Before we provide some descriptive statistics of our beta estimates, we implemen
 First, we load the daily Fama-French market excess returns and extract the vector of dates.
 
 ```{python}
+#| label: beta-estimation-load-ff3-daily
 factors_ff3_daily = (pl.read_parquet("data-python/factors_ff3_daily.parquet")
     .select(["date", "mkt_excess"])
 )
@@ -252,6 +265,7 @@ factors_ff3_daily = (pl.read_parquet("data-python/factors_ff3_daily.parquet")
 We then create a connection to the daily CRSP data, but we don't load the whole table into our memory. We only extract all distinct `permno` because we loop the beta estimation over batches of stocks with size 500. To estimate the CAPM over a consistent lookback window while accommodating different return frequencies, we adjust the minimum required number of observations accordingly. Specifically, we require at least 1,000 daily returns over a five‑year period for a valid estimation. This threshold is consistent with the monthly requirement of 48 observations out of 60 months, given that there are roughly 252 trading days in a year.
 
 ```{python}
+#| label: beta-estimation-crsp-daily-connection
 crsp_daily_db = ds.dataset(
     "data-python/crsp_daily", format="parquet", partitioning="hive"
 )
@@ -270,8 +284,9 @@ min_obs = 1_000
 We then proceed to perform the same steps as with the monthly CRSP data, just in batches: Load in daily returns, nest the data by stock, and parallelize the beta estimation across stocks. Note that we also convert the daily date to the beginning of the month so that we can still look back over 60 months and get one beta estimate per month, even though we are using daily data.
 
 ```{python}
+#| label: beta-estimation-estimate-daily-batches
 #| output: false
-#| eval: false 
+#| eval: false
 capm_daily = []
 
 for j in range(1, batches + 1):
@@ -322,6 +337,7 @@ capm_daily = pl.concat(capm_daily)
 What is a typical value for stock betas? First, let us extract the relevant estimates from our CAPM results based on monthly returns.
 
 ```{python}
+#| label: beta-estimation-load-beta-monthly
 #| echo: false
 beta_monthly = pl.read_parquet("data-python/beta.parquet").filter(
     pl.col("return_type") == "monthly"
@@ -329,6 +345,7 @@ beta_monthly = pl.read_parquet("data-python/beta.parquet").filter(
 ```
 
 ```{python}
+#| label: beta-estimation-prepare-beta-monthly
 #| eval: false
 beta_monthly = (capm_monthly
     .filter(pl.col("coefficient") == "mkt_excess")
@@ -420,6 +437,7 @@ beta_quantiles_figure.show()
 To compare the difference between daily and monthly data, we combine beta estimates to a single table. 
 
 ```{python}
+#| label: beta-estimation-prepare-beta-daily
 #| eval: false
 beta_daily = (capm_daily
     .filter(pl.col("coefficient") == "mkt_excess")
@@ -431,6 +449,7 @@ beta_daily = (capm_daily
 beta = pl.concat([beta_monthly, beta_daily])
 ```
 ```{python}
+#| label: beta-estimation-load-beta
 #| echo: false
 beta = pl.read_parquet("data-python/beta.parquet")
 ```
@@ -469,6 +488,7 @@ The estimates in @fig-604 look as expected. As you can see, it really depends on
 Finally, we write the estimates to our local folder so that we can use them in later chapters. 
 
 ```{python}
+#| label: beta-estimation-write-beta
 #| output: false
 beta.write_parquet("data-python/beta.parquet")
 ```
@@ -513,6 +533,7 @@ beta_coverage_figure.show()
 We also encourage everyone to always look at the distributional summary statistics of variables. You can easily spot outliers or weird distributions when looking at such tables.\index{Summary statistics}
 
 ```{python}
+#| label: beta-estimation-summary-statistics
 (beta
     .group_by("return_type")
     .agg(
@@ -535,6 +556,7 @@ The summary statistics also look plausible for the two estimation procedures.
 Finally, since we have two different estimators for the same theoretical object, we expect the estimators to be at least positively correlated (although not perfectly as the estimators are based on different sample periods and frequencies).
 
 ```{python}
+#| label: beta-estimation-correlation
 (beta
     .pivot(index=["permno", "date"], on="return_type", values="beta")
     .select(["monthly", "daily"])

--- a/python/capital-asset-pricing-model.qmd
+++ b/python/capital-asset-pricing-model.qmd
@@ -6,6 +6,7 @@ metadata:
 ---
 
 ```{python}
+#| label: capital-asset-pricing-model-setup
 #| echo: false
 exec(open("python/render-settings.py").read())
 ```
@@ -19,6 +20,7 @@ The Capital Asset Pricing Model (CAPM) is one of the most influential theories i
 We use the following packages throughout this chapter:
 
 ```{python}
+#| label: capital-asset-pricing-model-packages
 import polars as pl
 import numpy as np
 import tidyfinance as tf
@@ -29,6 +31,7 @@ from adjustText import adjust_text
 ```
 
 ```{python}
+#| label: capital-asset-pricing-model-render-plotnine
 #| echo: false
 exec(open("python/render-plotnine-custom.py").read())
 ```
@@ -38,6 +41,7 @@ exec(open("python/render-plotnine-custom.py").read())
 Building on our analysis from the previous chapter on [Modern Portfolio Theory](modern-portfolio-theory.qmd), we again examine the Dow Jones Industrial Average constituents as an exemplary asset universe. We download and prepare our monthly return data:
 
 ```{python}
+#| label: capital-asset-pricing-model-download-returns
 symbols = pl.from_pandas(
     tf.download_data(
         domain="constituents",
@@ -129,6 +133,7 @@ is central to the CAPM and is typically called the efficient tangency portfolio.
 For illustrative purposes, we compute the efficient tangency portfolio for our hypothetical asset universe. As a realistic proxy for the risk-free rate, we use the average 13-week T-bill rate (traded with the symbol ^IRX). Since the prices are quoted in annualized percentage yields, we have to divide them by 100 and convert them to monthly rates. 
 
 ```{python}
+#| label: capital-asset-pricing-model-risk-free-rate
 risk_free_monthly = (
   pl.from_pandas(
     tf.download_data(domain="stock_prices", symbols="^IRX", start_date="2019-10-01", end_date="2024-09-30")
@@ -145,6 +150,7 @@ rf = risk_free_monthly["risk_free"].mean()
 Next, we define the core parameters governing the distribution of asset returns, $\Sigma$ and $\tilde\mu$.
 
 ```{python}
+#| label: capital-asset-pricing-model-moments
 assets = (returns_monthly
     .group_by("symbol")
     .agg(
@@ -177,6 +183,7 @@ $$\frac{\omega^{\prime}_\text{tan}\mu-r_f}{\omega_\text{tan}^{\prime}\Sigma\omeg
 Typically, the excess return of an asset scaled by its volatility, $\frac{\tilde\mu_i}{\sigma_i}$, is called the Sharpe ratio of the asset. Thus, the slope of the efficient frontier corresponds to the Sharpe ratio of the tangency portfolio returns. By construction, the tangency portfolio is the maximum Sharpe ratio portfolio.^[We prove in the Appendix [Proofs](proofs.qmd) that the efficient tangency portfolio $\omega_\text{tan}$ can also be derived as a solution to the optimization problem $\max_{\omega} \frac{\omega^{\prime}\tilde\mu}{\sqrt{\omega^{\prime}\Sigma\omega}} \text{ s.t. } \omega^{\prime}\iota=1.$]
 
 ```{python}
+#| label: capital-asset-pricing-model-tangency-portfolio
 w_tan = np.linalg.solve(sigma, mu - rf)
 w_tan = w_tan / np.sum(w_tan)
 
@@ -247,6 +254,7 @@ We derived the CAPM equation as a consequence of efficient wealth allocation. Su
 We can illustrate the relationship between systematic risk and expected returns in the so-called security market line.
 
 ```{python}
+#| label: capital-asset-pricing-model-security-market-line
 betas = (sigma @ w_tan) / (w_tan.T @ sigma @ w_tan)
 assets = assets.with_columns(beta=pl.Series(betas))
 
@@ -292,6 +300,7 @@ where $r_{i,t}$ and $r_{m,t}$ are the realized returns of the asset and market p
 Let's turn to estimating CAPM parameters using real market data. Instead of using our previously constructed tangency portfolio, we employ the Fama-French market excess returns, which provide a widely accepted proxy for the market portfolio. These returns are already adjusted to represent excess returns over the risk-free rate, simplifying our analysis.
 
 ```{python}
+#| label: capital-asset-pricing-model-famafrench-factors
 import tidyfinance as tf
 
 factors = pl.from_pandas(
@@ -307,6 +316,7 @@ factors = pl.from_pandas(
 For our regression analysis, we first prepare the data by calculating excess returns for each stock. We join our monthly returns with the Fama-French factors and subtract the risk-free rate to obtain excess returns. The `estimate_capm()` function then implements the regression equation we previously discussed. We partition the data by symbol and run these regressions for all assets, looping over the symbol-specific sub-frames. Because `statsmodels` expects a `pandas` data frame, we convert each sub-frame at the boundary with `to_pandas()`. Collecting the coefficients gives us a clean data frame of assets and their corresponding betas.
 
 ```{python}
+#| label: capital-asset-pricing-model-estimate-capm
 import statsmodels.formula.api as smf
 
 returns_excess_monthly = (returns_monthly

--- a/python/clean-enhanced-trace-with-python.qmd
+++ b/python/clean-enhanced-trace-with-python.qmd
@@ -8,6 +8,7 @@ metadata:
 This appendix contains code to clean enhanced TRACE with Python.\index{Data!TRACE} It is also available via the following GitHub [gist](https://gist.githubusercontent.com/patrick-weiss/86ddef6de978fbdfb22609a7840b5d8b).\index{GitHub!Gist} Hence, you could also source the file with the following chunk.
 
 ```{python}
+#| label: clean-enhanced-trace-with-python-source-gist
 #| eval: false
 gist_url = (
   "https://gist.githubusercontent.com/patrick-weiss/"
@@ -24,6 +25,7 @@ We need this function in [TRACE and FISD](trace-and-fisd.qmd) to download and cl
 The function takes a vector of CUSIPs (in `cusips`), a connection to WRDS (`connection`) explained in Chapter 3, and a start and end date (`start_date` and `end_date`, respectively). Specifying too many CUSIPs will result in very slow downloads and a potential failure due to the size of the request to WRDS. The dates should be within the coverage of TRACE itself, i.e., starting after 2002, and the dates should be supplied as a string indicating MM/DD/YYYY. The output of the function contains all valid trade messages for the selected CUSIPs over the specified period.\index{CUSIP}\index{Dick-Nielsen cleaning} 
 
 ```{python}
+#| label: clean-enhanced-trace-with-python-define-function
 #| eval: false
 def clean_enhanced_trace(cusips,
                          connection,

--- a/python/colophon.qmd
+++ b/python/colophon.qmd
@@ -2,12 +2,14 @@
 title: Colophon
 ---
 ```{python}
+#| label: colophon-setup
 #| echo: false
 exec(open("python/render-settings.py").read())
 ```
 
 In this appendix chapter, we provide details on the package versions used in this edition. The book was built with Python [@python] version 3.10.11 and the following packages:\index{Colophon}
 ```{python}
+#| label: colophon-package-versions
 #| echo: false
 import polars as pl
 from great_tables import GT

--- a/python/constrained-optimization-and-backtesting.qmd
+++ b/python/constrained-optimization-and-backtesting.qmd
@@ -6,6 +6,7 @@ metadata:
 ---
 
 ```{python}
+#| label: constrained-optimization-and-backtesting-setup
 #| echo: false
 exec(open("python/render-settings.py").read())
 ```
@@ -19,6 +20,7 @@ You are reading **Tidy Finance with Python**. You can find the equivalent chapte
 Throughout this chapter, we use the following Python packages:
 
 ```{python}
+#| label: constrained-optimization-and-backtesting-packages
 import polars as pl
 import numpy as np
 
@@ -30,6 +32,7 @@ from scipy.optimize import minimize
 ```
 
 ```{python}
+#| label: constrained-optimization-and-backtesting-render-plotnine
 #| echo: false
 exec(open("python/render-plotnine-custom.py").read())
 ```
@@ -41,6 +44,7 @@ Compared to previous chapters, we introduce `expon` from `scipy.stats` to calcul
 We start by loading the required data from our Parquet files introduced in [Accessing and Managing Financial Data](accessing-and-managing-financial-data.qmd) and [WRDS, CRSP, and Compustat](wrds-crsp-and-compustat.qmd). For simplicity, we restrict our investment universe to the monthly Fama-French industry portfolio returns in the following application. \index{Data!Industry portfolios}
 
 ```{python}
+#| label: constrained-optimization-and-backtesting-load-industries
 industry_returns = (
     pl.read_parquet("data-python/industries_ff_monthly.parquet")
     .drop("date")
@@ -59,6 +63,7 @@ $${#eq-recap-mvp}
 where $\Sigma$ is the $(N \times N)$ covariance matrix of the returns. The optimal weights $\omega_\text{mvp}$ can be found analytically and are $\omega_\text{mvp} = \frac{\Sigma^{-1}\iota}{\iota'\Sigma^{-1}\iota}$. In terms of code, the math is equivalent to the following chunk. \index{Minimum variance portfolio}
 
 ```{python}
+#| label: constrained-optimization-and-backtesting-minimum-variance
 n_industries = industry_returns.shape[1]
 
 industry_matrix = industry_returns.to_numpy()
@@ -140,6 +145,7 @@ The optimal weights correspond to a mean-variance portfolio, where the vector of
 The function below implements the efficient portfolio weights in its general form, allowing for transaction costs (conditional on the holdings *before* reallocation). For $\beta=0$, the computation resembles the standard mean-variance efficient framework. `gamma` denotes the coefficient of risk aversion $\gamma$, `beta` is the transaction cost parameter $\beta$ and `w_prev` are the weights before rebalancing $\omega_{t^+}$.
 
 ```{python}
+#| label: constrained-optimization-and-backtesting-efficient-weights
 def compute_efficient_weight(
     sigma, mu, gamma=2, beta=0, w_prev=np.ones(sigma.shape[1]) / sigma.shape[1]
 ):
@@ -178,6 +184,7 @@ weights_efficient.with_columns(pl.col(pl.Float64).round(3))
 The portfolio weights above indicate the efficient portfolio for an investor with risk aversion coefficient $\gamma=2$ in the absence of transaction costs. Some of the positions are negative, which implies short-selling, and most of the positions are rather extreme. For instance, a position of $-1$ implies that the investor takes a short position worth their entire wealth to lever long positions in other assets.\index{Short-selling} What is the effect of transaction costs or different levels of risk aversion on the optimal portfolio choice? The following few lines of code analyze the distance between the minimum variance portfolio and the portfolio implemented by the investor for different values of the transaction cost parameter $\beta$ and risk aversion $\gamma$.
 
 ```{python}
+#| label: constrained-optimization-and-backtesting-transaction-costs
 gammas = [2, 4, 8, 20]
 betas = 20*expon.ppf(np.arange(1, 100)/100, scale=1)
 
@@ -238,6 +245,7 @@ We rely on the powerful `scipy.optimize` package, which provides a common interf
 We illustrate the use of `minimize()` by replicating the analytical solutions for the minimum variance and efficient portfolio weights from above. Note that the equality constraint for both solutions is given by the requirement that the weights must sum up to one. In addition, we supply a vector of equal weights as an initial value for the algorithm in all applications. We verify that the output is equal to the above solution. Note that `np.allclose()` is a safe way to compare two vectors for pairwise equality. The alternative `==` is sensitive to small differences that may occur due to the representation of floating points on a computer, while `np.allclose()` has a built-in tolerance. It returns `True` if both are equal, which is the case in both applications below. 
 
 ```{python}
+#| label: constrained-optimization-and-backtesting-numerical-replication
 # | output: false
 w_initial = np.ones(n_industries) / n_industries
 
@@ -305,6 +313,7 @@ The result above shows that the numerical procedure indeed recovered the optimal
 Next, we approach problems where no analytical solutions exist. First, we additionally impose short-sale constraints, which implies $N$ inequality constraints of the form $\omega_i >=0$. We can implement the short-sale constraints by imposing a vector of lower bounds `lb = rep(0, n_industries)`.
 
 ```{python}
+#| label: constrained-optimization-and-backtesting-no-short-sale
 w_no_short_sale = minimize(
     x0=w_initial,
     fun=objective_efficient,
@@ -332,6 +341,7 @@ You can verify that `np.sum(w_no_short_sale.x)` returns 1. In other words, `mini
 The constraint enforces that a maximum of 50 percent of the allocated wealth can be allocated to short positions, thus implying an initial margin requirement of 50 percent. Imposing such a margin requirement reduces portfolio risks because extreme portfolio weights are not attainable anymore. The implementation of Regulation-T rules is numerically interesting because the margin constraints imply a non-linear constraint on the portfolio weights. \index{Regulation T}
 
 ```{python}
+#| label: constrained-optimization-and-backtesting-regulation-t
 reg_t = 1.5
 
 
@@ -407,6 +417,7 @@ The results clearly indicate the effect of imposing additional constraints: the 
 Before we move on, we want to propose a final allocation strategy, which reflects a somewhat more realistic structure of transaction costs instead of the quadratic specification used above. The function below computes efficient portfolio weights while adjusting for transaction costs of the form $\beta\sum_{i=1}^N |(\omega_{i, t+1} - \omega_{i, t^+})|$. No closed-form solution exists, and we rely on non-linear optimization procedures.
 
 ```{python}
+#| label: constrained-optimization-and-backtesting-l1-transaction-costs
 def compute_efficient_weight_L1_TC(mu, sigma, gamma, beta, initial_weights):
     """Compute efficient portfolio weights with L1 constraint."""
 
@@ -451,6 +462,7 @@ While interesting from a methodological point of view, we cannot evaluate the pe
 The few lines below define the general setup. We consider 120 periods from the past to update the parameter estimates before recomputing portfolio weights. Then, we update portfolio weights, which is costly and affects the performance. The portfolio weights determine the portfolio return. A period later, the current portfolio weights have changed and form the foundation for transaction costs incurred in the next period. We consider three different competing strategies: the mean-variance efficient portfolio, the mean-variance efficient portfolio with ex-ante adjustment for transaction costs, and the naive portfolio, which allocates wealth equally across the different assets.\index{Transaction cost}
 
 ```{python}
+#| label: constrained-optimization-and-backtesting-setup-backtest
 window_length = 120
 periods = industry_returns.shape[0] - window_length
 
@@ -472,6 +484,7 @@ w_prev_1 = w_prev_2 = w_prev_3 = np.ones(n_industries) / n_industries
 We also define two helper functions: One to adjust the weights due to returns and one for performance evaluation, where we compute realized returns net of transaction costs. 
 
 ```{python}
+#| label: constrained-optimization-and-backtesting-helper-functions
 def adjust_weights(w, next_return):
     w_prev = 1 + w * next_return
     return np.array(w_prev / np.sum(np.array(w_prev)))
@@ -490,6 +503,7 @@ def evaluate_performance(w, w_previous, next_return, beta=50):
 The following code chunk performs a rolling-window estimation, which we implement in a loop. In each period, the estimation window contains the returns available up to the current period. Note that we use the sample variance-covariance matrix and ignore the estimation of $\hat\mu$ entirely, but you might use more advanced estimators in practice. 
 
 ```{python}
+#| label: constrained-optimization-and-backtesting-rolling-window
 for p in range(periods):
     returns_window = industry_matrix[p : (p + window_length - 1), :]
     next_return = industry_matrix[p + window_length, :]
@@ -529,6 +543,7 @@ for p in range(periods):
 Finally, we get to the evaluation of the portfolio strategies *net-of-transaction costs*. Note that we compute annualized returns and standard deviations. \index{Sharpe ratio}
 
 ```{python}
+#| label: constrained-optimization-and-backtesting-performance-table
 performance = pl.concat([
     pl.DataFrame(
         values,

--- a/python/cover-image.qmd
+++ b/python/cover-image.qmd
@@ -2,7 +2,8 @@
 title: Cover Image
 ---
 
-```{python} 
+```{python}
+#| label: cover-image-setup
 #| echo: false
 exec(open("python/render-settings.py").read())
 ```
@@ -10,6 +11,7 @@ exec(open("python/render-settings.py").read())
 The cover of the book is inspired by the fast growing generative art community in R.\index{Generative art} Generative art refers to art that in whole or in part has been created with the use of an autonomous system. Instead of creating random dynamics, we rely on what is core to the book: The evolution of financial markets. Each circle corresponds to one of the twelve Fama-French industry portfolios, whereas each bar represents the average annual return between 1927 and 2022. The bar color is determined by the standard deviation of returns for each industry. The few lines of code below replicate the entire figure. 
 
 ```{python}
+#| label: cover-image-generate-art
 #| eval: false
 import polars as pl
 import numpy as np

--- a/python/difference-in-differences.qmd
+++ b/python/difference-in-differences.qmd
@@ -6,6 +6,7 @@ metadata:
 ---
 
 ```{python}
+#| label: difference-in-differences-setup
 #| echo: false
 exec(open("python/render-settings.py").read())
 ```
@@ -23,6 +24,7 @@ The approach we use here replicates the results of @Seltzer2022 partly. Specific
 The current chapter relies on this set of Python packages. 
 
 ```{python}
+#| label: difference-in-differences-packages
 import polars as pl
 import datetime as dt
 import pyfixest as pf
@@ -33,6 +35,7 @@ from scipy.stats import norm
 ```
 
 ```{python}
+#| label: difference-in-differences-render-plotnine
 #| echo: false
 exec(open("python/render-plotnine-custom.py").read())
 ```
@@ -44,6 +47,7 @@ Compared to previous chapters, we introduce the `scipy.stats` module from the `s
 We use TRACE and Mergent FISD as data sources from our Parquet files introduced in [Accessing and Managing Financial Data](accessing-and-managing-financial-data.qmd) and [TRACE and FISD](trace-and-fisd.qmd). \index{Data!TRACE}\index{Data!FISD}
 
 ```{python}
+#| label: difference-in-differences-load-data
 fisd = (pl.read_parquet("data-python/fisd.parquet")
     .drop_nulls()
 )
@@ -59,6 +63,7 @@ trace_enhanced = (pl.from_arrow(
 We start our analysis by preparing the sample of bonds. We only consider bonds with a time to maturity of more than one year to the signing of the PA, so that we have sufficient data to analyze the yield behavior after the treatment date. This restriction also excludes all bonds issued after the agreement. We also consider only the first two digits of the SIC industry code to identify the polluting industries [in line with @Seltzer2022].\index{Time to maturity}
 
 ```{python}
+#| label: difference-in-differences-prepare-bonds
 treatment_date = dt.datetime(2015, 12, 12)
 treatment_month = dt.datetime(2015, 12, 1)
 polluting_industries = [
@@ -83,6 +88,7 @@ Next, we aggregate the individual transactions as reported in TRACE to a monthly
 We consider bond yields for a bond's last trading day in a month. Therefore, we first aggregate bond data to daily frequency and apply common restrictions from the literature [see, e.g., @Bessembinder2008]. We weigh each transaction by volume to reflect a trade's relative importance and avoid emphasizing small trades. Moreover, we only consider transactions with reported prices `rptd_pr` larger than 25 (to exclude bonds that are close to default) and only bond-day observations with more than five trades on a corresponding day (to exclude prices based on too few, potentially non-representative transactions).\index{Yield aggregation} \index{Returns!Bonds}
 
 ```{python}
+#| label: difference-in-differences-aggregate-trace
 trace_enhanced = (trace_enhanced
     .filter(pl.col("rptd_pr") > 25)
     .with_columns(weight=pl.col("entrd_vol_qt")*pl.col("rptd_pr"))
@@ -114,6 +120,7 @@ trace_aggregated = (trace_aggregated
 By combining the bond-specific information from Mergent FISD for our bond sample with the aggregated TRACE data, we arrive at the main sample for our analysis.
 
 ```{python}
+#| label: difference-in-differences-build-panel
 bonds_panel = (bonds
     .join(trace_aggregated, how="inner", on="cusip_id")
     .drop_nulls()
@@ -123,6 +130,7 @@ bonds_panel = (bonds
 Before we can run the first regression, we need to define the `treated` indicator,^[Note that by using a generic name here, everybody can replace ours with their sample data and run the code to produce standard regression tables and illustrations.] which is the product of the `post_period` (i.e., all months after the signing of the PA) and the `polluter` indicator defined above.\index{Regression!Fixed effects} 
 
 ```{python}
+#| label: difference-in-differences-define-treated
 bonds_panel = (bonds_panel
     .with_columns(
         post_period=(pl.col("date") >= treatment_month)
@@ -134,6 +142,7 @@ bonds_panel = (bonds_panel
 As usual, we tabulate summary statistics of the variables that enter the regression to check the validity of our variable definitions.\index{Summary statistics}
 
 ```{python}
+#| label: difference-in-differences-summary-statistics
 bonds_panel_summary = (bonds_panel
     .unpivot(
         on=["avg_yield", "time_to_maturity", "log_offering_amt"],
@@ -163,6 +172,7 @@ The PA is a legally binding international treaty on climate change. It was adopt
 The second model follows the typical DiD regression approach by including individual (`cusip_id`) and time (`date`) fixed effects. In this model, we do not include any other variables from the simple model because the fixed effects subsume them, and we observe the coefficient of our main variable of interest: `treated`. 
 
 ```{python}
+#| label: difference-in-differences-panel-regressions
 model_without_fe = pf.feols(
     "avg_yield ~ treated + post_period + polluter + log_offering_amt + time_to_maturity",
     vcov = "iid",
@@ -238,6 +248,7 @@ model_without_fe_figure.show()
 Instead of plotting both groups using the simple model approach, we can also use the fixed-effects model and focus on the polluter's yield response to the signing relative to the non-polluters. To perform this estimation, we need to replace the `treated` indicator with separate time dummies for the polluters, each marking a one-month period relative to the treatment date.\index{Graph!Difference in differences}
 
 ```{python}
+#| label: difference-in-differences-prepare-time-dummies
 bonds_panel_alt = (bonds_panel
     .with_columns(
         diff_to_treatment=(
@@ -259,6 +270,7 @@ variables = (bonds_panel_alt
 In the next code chunk, we assemble the model formula and regress the monthly yields on the set of time dummies and `cusip_id` and `date` fixed effects. 
 
 ```{python}
+#| label: difference-in-differences-fe-time-regression
 bonds_panel_alt = bonds_panel_alt.to_pandas()
 variables = variables.to_pandas()
 
@@ -293,6 +305,7 @@ model_with_fe_time = pf.feols(
 We then collect the regression results into a dataframe that contains the estimates and corresponding 95 percent confidence intervals. Note that we also add a row with zeros for the (omitted) reference point of the time dummies. 
 
 ```{python}
+#| label: difference-in-differences-collect-coefficients
 lag0_row = pl.DataFrame({
     "term": ["lag0"],
     "estimate": [0.0],

--- a/python/discounted-cash-flow-analysis.qmd
+++ b/python/discounted-cash-flow-analysis.qmd
@@ -8,6 +8,7 @@ execute:
 ---
 
 ```{python}
+#| label: discounted-cash-flow-analysis-setup
 #| echo: false
 exec(open("python/render-settings.py").read())
 ```
@@ -37,6 +38,7 @@ We make a few simplifying assumptions due to the diverse nature of businesses, w
 In this chapter, we rely on the following packages to build a simple DCF analysis:
 
 ```{python}
+#| label: discounted-cash-flow-analysis-packages
 import polars as pl
 import numpy as np
 import statsmodels.formula.api as smf
@@ -48,6 +50,7 @@ from itertools import product
 ```
 
 ```{python}
+#| label: discounted-cash-flow-analysis-render-plotnine
 #| echo: false
 exec(open("python/render-plotnine-custom.py").read())
 ```
@@ -61,6 +64,7 @@ The `fmpapi` package is developed by Christoph Scheuch and is not sponsored by o
 Before we can perform a DCF analysis, we need historical financial data to inform our forecasts. We use the Financial Modeling Prep (FMP) API to download financial statements. The `fmpapi` package provides a convenient interface for accessing this data in a tidy format.\index{Data!FMP API}
 
 ```{python}
+#| label: discounted-cash-flow-analysis-download-statements
 symbol = "MSFT"
 
 income_statements = pl.from_pandas(fmp_get(
@@ -87,6 +91,7 @@ Each component of this formula serves a specific purpose in capturing the compan
 We can implement this calculation by combining and transforming our financial statement data. Note that we also arrange by year, which is important for some of the following code chunks.
 
 ```{python}
+#| label: discounted-cash-flow-analysis-compute-fcf
 dcf_data = (income_statements
   .with_columns(
     fiscal_year=pl.col("fiscal_year").cast(pl.Int64),
@@ -226,6 +231,7 @@ The final step in our FCF forecast is projecting revenue growth. While there are
 We use GDP growth forecasts from the [IMF World Economic Outlook (WEO)](https://www.imf.org/en/Publications/WEO/weo-database/2024/October/weo-report?c=111,&s=NGDP_RPCH,&sy=2020&ey=2029&ssm=0&scsm=1&scc=0&ssd=1&ssc=0&sic=1&sort=country&ds=.&br=1) database as our baseline. The WEO provides comprehensive economic projections, though it is important to note that these forecasts are periodically revised as new data becomes available.\index{Data!IMF WEO} We manually collect these forecasts and store them in a tibble.
 
 ```{python}
+#| label: discounted-cash-flow-analysis-gdp-growth
 gdp_growth = pl.DataFrame({
   "year": list(range(2021, 2031)),
   "gdp_growth": [
@@ -242,6 +248,7 @@ dcf_data = (dcf_data
 Our approach models revenue growth as a linear function of GDP growth. This relation captures the intuition that company revenues often move in tandem with broader economic activity, though usually with different sensitivity.\index{Growth modeling} Let us estimate the model with historical data.
 
 ```{python}
+#| label: discounted-cash-flow-analysis-revenue-growth-model
 revenue_growth_model = smf.ols(
   "revenue_growth ~ gdp_growth", data=dcf_data.to_pandas()
 ).fit().params
@@ -302,6 +309,7 @@ While more sophisticated approaches exist (e.g., proprietary analyst forecasts o
 With all components in place - revenue growth projections and forecast ratios - we can now calculate our FCF forecasts. We must first convert our growth rates into revenue projections and then apply our forecast ratios to compute each FCF component.\index{Free Cash Flow!Computation}
 
 ```{python}
+#| label: discounted-cash-flow-analysis-forecast-fcf
 dcf_data = (dcf_data
   .sort("year")
   .with_columns(
@@ -359,6 +367,7 @@ The perpetual growth rate $g$ should reflect the long-term economic growth poten
 Let us implement the Perpetuity Growth Model:
 
 ```{python}
+#| label: discounted-cash-flow-analysis-terminal-value
 def compute_terminal_value(last_fcf, growth_rate, discount_rate):
     return last_fcf * (1 + growth_rate) / (discount_rate - growth_rate)
 
@@ -393,6 +402,7 @@ While you can often find estimates of WACC from financial databases or analysts'
 If you would rather not estimate WACC manually, resources are available to help you find industry-specific discount rates. One of the most widely used sources is Aswath Damodaran’s [database](https://pages.stern.nyu.edu/~adamodar/New_Home_Page/datacurrent.html). He maintains an extensive database that provides a wealth of financial data, including estimated discount rates, cash flows, growth rates, multiples, and more. For example, if you are analyzing a company in the Computer Services sector, as we do here, you can look up the industry's average WACC and use it as a benchmark for your analysis. The following code chunk downloads the WACC data and extracts the value for this industry:
 
 ```{python}
+#| label: discounted-cash-flow-analysis-download-wacc
 import requests
 
 url = "https://pages.stern.nyu.edu/~adamodar/pc/datasets/wacc.xls"
@@ -433,6 +443,7 @@ $$
 where $T$ is the length of our forecast period. Let us implement this calculation in a simple function that takes the WACC and growth rate as input. Then, we present an example at the values discussed above.
 
 ```{python}
+#| label: discounted-cash-flow-analysis-enterprise-value
 def compute_dcf(wacc, growth_rate):
     free_cash_flow = dcf_data["fcf"].to_numpy()
     last_fcf = free_cash_flow[-1]

--- a/python/factor-selection-via-machine-learning.qmd
+++ b/python/factor-selection-via-machine-learning.qmd
@@ -6,6 +6,7 @@ metadata:
 ---
 
 ```{python}
+#| label: factor-selection-via-machine-learning-setup
 #| echo: false
 exec(open("python/render-settings.py").read())
 ```
@@ -79,6 +80,7 @@ The Elastic Net [@Zou2005] combines $L_1$ with $L_2$ penalization and encourages
 To get started, we load the required packages and data. The main focus is on the workflow behind the `scikit-learn` [@scikit-learn] package collection. 
 
 ```{python}
+#| label: factor-selection-via-machine-learning-packages
 import polars as pl
 import pandas as pd
 import numpy as np
@@ -96,6 +98,7 @@ from sklearn.linear_model import ElasticNet, Lasso, Ridge
 ```
 
 ```{python}
+#| label: factor-selection-via-machine-learning-render-plotnine
 #| echo: false
 exec(open("python/render-plotnine-custom.py").read())
 ```
@@ -115,6 +118,7 @@ Finally, we need a set of *test assets*. The aim is to understand which of the p
 In line with many existing papers, we use monthly portfolio returns from ten different industries according to the definition from [Kenneth French's homepage](https://mba.tuck.dartmouth.edu/pages/faculty/ken.french/Data_Library/det_10_ind_port.html) as test assets.\index{Data!Fama-French factors}\index{Data!q-factors}\index{Data!Macroeconomic predictors}\index{Data!Industry portfolios}
 
 ```{python, eval = TRUE}
+#| label: factor-selection-via-machine-learning-load-factor-data
 factors_ff3_monthly = (
     pl.read_parquet("data-python/factors_ff3_monthly.parquet")
     .rename(lambda c: f"factor_ff_{c}")
@@ -139,6 +143,7 @@ industries_ff_monthly = (
 We combine all the monthly observations into one dataframe.
 
 ```{python}
+#| label: factor-selection-via-machine-learning-combine-data
 data = (industries_ff_monthly
   .join(factors_ff3_monthly,
         how="left", left_on="date", right_on="factor_ff_date")
@@ -195,6 +200,7 @@ We hence perform the following pre-processing steps:
 Scaling is often necessary in machine learning applications, especially when combining variables of different magnitudes or units, or when using algorithms sensitive to feature scales (e.g., gradient descent-based algorithms). We use `ColumnTransformer()` to scale all regressors using `StandardScaler()`. The `remainder="drop"` ensures that only the specified columns are retained in the output, and others are dropped. The option `verbose_feature_names_out=False` ensures that the output feature names remain unchanged. We construct each interaction term as a `polars` expression that multiplies a macroeconomic predictor with a factor return and assigns it a descriptive name via `alias()`, and then add all of these columns to the data with `with_columns()`. Because `scikit-learn` operates on `pandas` objects, we convert the data frame with `to_pandas()` at the boundary before feeding it into the modeling pipeline.
 
 ```{python}
+#| label: factor-selection-via-machine-learning-preprocessor
 macro_variables = [c for c in data.columns if c.startswith("macro")]
 factor_variables = [c for c in data.columns if c.startswith("factor")]
 
@@ -230,6 +236,7 @@ In the application at hand, $X$ contains `{python} len(column_combinations)` col
 We want to emphasize that the workflow for *any* model is very similar, irrespective of the specific model. As you will see further below, it is straightforward to fit Ridge regression coefficients and, later, Neural networks or Random forests with similar code. For now, we start with the linear regression model with an arbitrarily chosen value for the penalty factor $\lambda$ (denoted as `alpha=0.007` in the code below). In the setup below, `l1_ratio` denotes the value of $1-\rho$, hence setting `l1_ratio=1` implies the Lasso.
 
 ```{python}
+#| label: factor-selection-via-machine-learning-build-model
 lm_model = ElasticNet(
   alpha=0.007,
   l1_ratio=1, 
@@ -250,6 +257,7 @@ That's it - we are done! The object `lm_model_pipeline` contains the definition 
 With the pipeline from above, we are ready to fit it to the data. Typically, we use training data to fit the model. The training data is pre-processed according to our recipe steps, and the Lasso regression coefficients are computed. For illustrative purposes, we focus on the manufacturing industry for now.
 
 ```{python}
+#| label: factor-selection-via-machine-learning-fit-model
 data_manufacturing = data.query("industry == 'manuf'")
 training_date = "2011-12-01"
 
@@ -304,6 +312,7 @@ predicted_values_figure.show()
 What do the estimated coefficients look like? To analyze these values, it is worth computing the coefficients $\hat\beta^\text{Lasso}$ directly. The code below estimates the coefficients for the Lasso and Ridge regression for the processed training data sample for a grid of different $\lambda$'s. 
 
 ```{python}
+#| label: factor-selection-via-machine-learning-coefficient-paths
 #| warning: false
 x = preprocessor.fit_transform(data_manufacturing)
 y = data_manufacturing["ret_excess"]
@@ -381,6 +390,7 @@ For our sample, we consider a time-series cross-validation sample. This means th
 Then, we evaluate the performance for a grid of different penalty values. `scikit-learn` provides functionalities to construct a suitable grid of hyperparameters with `GridSearchCV()`. The code chunk below creates a $10 \times 3$ hyperparameters grid. Then, the method `fit()` evaluates all the models for each fold.
 
 ```{python}
+#| label: factor-selection-via-machine-learning-tune-model
 #| warning: false
 initial_years = 5
 assessment_months = 48
@@ -460,6 +470,7 @@ We want to identify relevant variables by fitting Lasso models for each industry
 First, we define the Lasso model with one tuning parameter.
 
 ```{python}
+#| label: factor-selection-via-machine-learning-lasso-model
 lm_model = Lasso(fit_intercept=False, max_iter=5000)
 
 params = {"regressor__alpha": alphas}
@@ -473,6 +484,7 @@ lm_pipeline = Pipeline([
 The following task can be easily parallelized to reduce computing time, but we use a simple loop for ease of exposition.
 
 ```{python}
+#| label: factor-selection-via-machine-learning-all-industries
 #| warning: false
 #| output: false
 all_industries = data["industry"].drop_duplicates()

--- a/python/fama-macbeth-regressions.qmd
+++ b/python/fama-macbeth-regressions.qmd
@@ -6,6 +6,7 @@ metadata:
 ---
 
 ```{python}
+#| label: fama-macbeth-regressions-setup
 #| echo: false
 exec(open("python/render-settings.py").read())
 ```
@@ -33,6 +34,7 @@ Before we move to the implementation, we want to highlight that the characterist
 The current chapter relies on this set of Python packages. 
 
 ```{python}
+#| label: fama-macbeth-regressions-packages
 import polars as pl
 import statsmodels.formula.api as smf
 ```
@@ -42,6 +44,7 @@ import statsmodels.formula.api as smf
 We illustrate @Fama1973 with the monthly CRSP sample and use three characteristics to explain the cross-section of returns: Market capitalization, the book-to-market ratio, and the CAPM beta (i.e., the covariance of the excess stock returns with the market excess returns). We collect the data from our Parquet files introduced in [Accessing and Managing Financial Data](accessing-and-managing-financial-data.qmd) and [WRDS, CRSP, and Compustat](wrds-crsp-and-compustat.qmd). As in the previous chapters, we keep only firms with positive book equity, which is a common practice when working with book-to-market ratios [see @Fama1992 for details].\index{Data!CRSP}\index{Data!Compustat}\index{Beta}\index{Book equity}
 
 ```{python}
+#| label: fama-macbeth-regressions-load-data
 crsp_monthly = (
     pl.read_parquet("data-python/crsp_monthly.parquet")
     .select(["permno", "gvkey", "date", "ret_excess", "mktcap"])
@@ -63,6 +66,7 @@ beta = (
 We use the Compustat and CRSP data to compute the book-to-market ratio and the (log) market capitalization.\index{Book-to-market ratio}\index{Market capitalization} Furthermore, we also use the CAPM betas based on monthly returns we computed in the previous chapters.\index{Beta}\index{CAPM}
 
 ```{python}
+#| label: fama-macbeth-regressions-characteristics
 characteristics = (compustat_annual
     .with_columns(date=pl.col("datadate").dt.truncate("1mo"))
     .join(crsp_monthly, how="left", on=["gvkey", "date"])
@@ -105,6 +109,7 @@ data_fama_macbeth = (data_fama_macbeth
 Next, we run the cross-sectional regressions with the characteristics as explanatory variables for each month. We regress the returns of the test assets at a particular time point on the characteristics of each asset. By doing so, we get an estimate of the risk premiums $\hat\lambda^{f}_t$ for each point in time. \index{Regression!Cross-section}
 
 ```{python}
+#| label: fama-macbeth-regressions-cross-section
 def estimate_cross_section(group):
     params = smf.ols(
         formula="ret_excess_lead ~ beta + log_mktcap + bm",
@@ -125,6 +130,7 @@ risk_premiums = pl.concat([
 Now that we have the risk premiums' estimates for each period, we can average across the time-series dimension to get the expected risk premium for each characteristic. Similarly, we manually create the $t$-test statistics for each regressor, which we can then compare to usual critical values of 1.96 or 2.576 for two-tailed significance tests at a five percent and a one percent significance level.
 
 ```{python}
+#| label: fama-macbeth-regressions-price-of-risk
 price_of_risk = (risk_premiums
     .unpivot(index="date", variable_name="factor", value_name="estimate")
     .group_by("factor")
@@ -143,6 +149,7 @@ price_of_risk = (risk_premiums
 It is common to adjust for autocorrelation when reporting standard errors of risk premiums. As in [Univariate Portfolio Sorts](univariate-portfolio-sorts.qmd), the typical procedure for this is computing @Newey1987 standard errors.\index{Standard errors!Newey-West}
 
 ```{python}
+#| label: fama-macbeth-regressions-newey-west
 def estimate_newey_west(group):
     fit = smf.ols(
         "estimate ~ 1", group.to_pandas()
@@ -170,6 +177,7 @@ price_of_risk_newey_west = pl.concat([
 Finally, let us interpret the results. Stocks with higher book-to-market ratios earn higher expected future returns, which is in line with the value premium. The negative value for log market capitalization reflects the size premium for smaller stocks. Consistent with results from earlier chapters, we detect no relation between beta and future stock returns.
 
 ```{python}
+#| label: fama-macbeth-regressions-tidyfinance
 #| output: false
 import tidyfinance as tf
 

--- a/python/financial-statement-analysis.qmd
+++ b/python/financial-statement-analysis.qmd
@@ -7,6 +7,7 @@ cache: true
 ---
 
 ```{python}
+#| label: financial-statement-analysis-setup
 #| echo: false
 exec(open("python/render-settings.py").read())
 ```
@@ -37,6 +38,7 @@ The `fmpapi` package is developed by Christoph Scheuch and not sponsored by or a
 Next to `fmpapi`, we use the following packages throughout this chapter:
 
 ```{python}
+#| label: financial-statement-analysis-packages
 import polars as pl
 
 from fmpapi import fmp_get
@@ -46,6 +48,7 @@ from adjustText import adjust_text
 ```
 
 ```{python}
+#| label: financial-statement-analysis-render-plotnine
 #| echo: false
 exec(open("python/render-plotnine-custom.py").read())
 ```
@@ -98,6 +101,7 @@ While there are more details, the basic structure is exactly the same as in the 
 Let us examine Microsoft's balance sheet statements using the `fmp_get()` function. This function requires three main arguments: The type of financial data to retrieve (`resource`), the stock ticker symbol (`symbol`), and additional parameters like periodicity and number of periods (`params`).
 
 ```{python}
+#| label: financial-statement-analysis-msft-balance-sheet
 pl.from_pandas(
   fmp_get(
     resource="balance-sheet-statement",
@@ -133,6 +137,7 @@ Consider Microsoft's 2023 income statement in @fig-406, which exemplifies how a 
 We can also access this data programmatically using the FMP API:
 
 ```{python}
+#| label: financial-statement-analysis-msft-income-statement
 pl.from_pandas(
   fmp_get(
     resource="income-statement",
@@ -164,6 +169,7 @@ The statement reconciles accrual-based accounting (used in the income statement)
 Of course, we can access this data through the FMP API:
 
 ```{python}
+#| label: financial-statement-analysis-msft-cash-flow
 pl.from_pandas(
   fmp_get(
     resource="cash-flow-statement",
@@ -181,6 +187,7 @@ In subsequent sections, we will use cash flow data to calculate important cash f
 We now turn to downloading and processing statements for multiple companies. The next code chunk demonstrates how to retrieve financial data for selected stocks that are supported in the free tier of FMP.
 
 ```{python}
+#| label: financial-statement-analysis-download-statements
 sample = [
   "AAPL", "MSFT", "GOOGL", "AMZN", "TSLA", "NVDA", "META", "NFLX", "DIS", "NKE",
   "WMT", "KO", "JPM", "BAC", "V", "XOM", "CVX", "JNJ", "PFE", "INTC",
@@ -235,6 +242,7 @@ This ratio focuses solely on the most liquid assets - cash and cash equivalents.
 Next, we calculate these ratios for all stocks, focusing on three major technology companies:
 
 ```{python}
+#| label: financial-statement-analysis-liquidity-ratios
 selected_symbols = ["MSFT", "AAPL", "AMZN", "NVDA"]
 
 balance_sheet_statements = (balance_sheet_statements
@@ -300,6 +308,7 @@ $$\text{Interest Coverage} = \frac{\text{EBIT}}{\text{Interest Expense}}$$
 Let's calculate these ratios for our sample of companies:
 
 ```{python}
+#| label: financial-statement-analysis-leverage-ratios
 balance_sheet_statements = balance_sheet_statements.with_columns(
   debt_to_equity=pl.col("total_debt") / pl.col("total_equity"),
   debt_to_asset=pl.col("total_debt") / pl.col("total_assets")
@@ -434,6 +443,7 @@ A higher ratio indicates more efficient credit and collection processes, though 
 Here is how we can calculate these efficiency metrics across our sample of selected stocks:
 
 ```{python}
+#| label: financial-statement-analysis-efficiency-ratios
 combined_statements = (balance_sheet_statements
   .select(
     ["symbol", "fiscal_year", "label", "current_ratio", "quick_ratio",
@@ -493,6 +503,7 @@ This metric is particularly important for investors as it directly measures the 
 The next code chunk calculates these profitability metrics for our sample of companies, allowing us to analyze how different firms convert their revenue into various levels of profit and return on investment.
 
 ```{python}
+#| label: financial-statement-analysis-profitability-ratios
 combined_statements = combined_statements.with_columns(
   gross_margin=pl.col("gross_profit") / pl.col("revenue"),
   profit_margin=pl.col("net_income") / pl.col("revenue"),
@@ -631,6 +642,7 @@ The Fama-French five-factor model aims to explain stock returns by incorporating
 We can calculate these factors using the FMP API as follows. Since the free tier only supports historical data for the last couple of months, we use the earliest available data that is returned by default:
 
 ```{python}
+#| label: financial-statement-analysis-fama-french-factors
 market_cap = pl.concat(
   [pl.from_pandas(fmp_get(
       resource="historical-market-capitalization", symbol=x, to_pandas=True

--- a/python/fixed-effects-and-clustered-standard-errors.qmd
+++ b/python/fixed-effects-and-clustered-standard-errors.qmd
@@ -6,6 +6,7 @@ metadata:
 ---
 
 ```{python}
+#| label: fixed-effects-and-clustered-standard-errors-setup
 #| echo: false
 exec(open("python/render-settings.py").read())
 ```
@@ -23,6 +24,7 @@ Typically, this investment regression uses quarterly balance sheet data provided
 The current chapter relies on the following set of Python packages. 
 
 ```{python}
+#| label: fixed-effects-and-clustered-standard-errors-packages
 import polars as pl
 import pyfixest as pf
 ```
@@ -34,6 +36,7 @@ Compared to previous chapters, we introduce `pyfixest` [@pyfixest], which provid
 We use CRSP and annual Compustat as data sources from our Parquet files introduced in [Accessing and Managing Financial Data](accessing-and-managing-financial-data.qmd) and [WRDS, CRSP, and Compustat](wrds-crsp-and-compustat.qmd). In particular, Compustat provides balance sheet and income statement data on a firm level, while CRSP provides market valuations. \index{Data!CRSP}\index{Data!Compustat}
 
 ```{python}
+#| label: fixed-effects-and-clustered-standard-errors-load-data
 crsp_monthly = (
     pl.read_parquet("data-python/crsp_monthly.parquet")
     .select(["gvkey", "date", "mktcap"])
@@ -49,6 +52,7 @@ compustat_annual = (
 The classical investment regressions model is the capital investment of a firm as a function of operating cash flows and Tobin's q, a measure of a firm's investment opportunities.\index{Cash flows}\index{Regression!Investment} We start by constructing investment and cash flows which are usually normalized by lagged total assets of a firm. In the following code chunk, we construct a *panel* of firm-year observations, so we have both cross-sectional information on firms as well as time-series information for each firm.\index{Regression!Panel}
 
 ```{python}
+#| label: fixed-effects-and-clustered-standard-errors-investment-cashflows
 data_investment = (compustat_annual
     .with_columns(
         date=pl.col("datadate").cast(pl.Date).dt.truncate("1mo")
@@ -74,6 +78,7 @@ data_investment = (data_investment
 Tobin's q is the ratio of the market value of capital to its replacement costs.\index{Tobin's q} It is one of the most common regressors in corporate finance applications [e.g., @Fazzari1988; @Erickson2012]. We follow the implementation of @Gulen2015 and compute Tobin's q as the market value of equity (`mktcap`) plus the book value of assets (`at`) minus book value of equity (`be`) plus deferred taxes (`txdb`), all divided by book value of assets (`at`). Finally, we only keep observations where all variables of interest are non-missing, and the reported book value of assets is strictly positive.
 
 ```{python}
+#| label: fixed-effects-and-clustered-standard-errors-tobins-q
 data_investment = (data_investment
     .join(crsp_monthly, on=["gvkey", "date"], how="left")
     .with_columns(
@@ -89,6 +94,7 @@ data_investment = (data_investment
 As the variable construction typically leads to extreme values that are most likely related to data issues (e.g., reporting errors), many papers include winsorization of the variables of interest. Winsorization involves replacing values of extreme outliers with quantiles on the respective end. The following function implements the winsorization for any percentage cut that should be applied on either end of the distributions.\index{Winsorization} In the specific example, we winsorize the main variables (`investment`, `cash_flows`, and `tobins_q`) at the one percent level.^[Note that `polars` operations never modify a data frame in place; every expression returns a new data frame. Our `winsorize` function therefore returns a `polars` expression that we apply via `with_columns()`, so the original data frame is never altered unintentionally.]
 
 ```{python}
+#| label: fixed-effects-and-clustered-standard-errors-winsorize
 def winsorize(col, cut):
     """Winsorize a column at cut level."""
 
@@ -114,6 +120,7 @@ data_investment = (data_investment
 Before proceeding to any estimations, we highly recommend tabulating summary statistics of the variables that enter the regression. These simple tables allow you to check the plausibility of your numerical variables, as well as spot any obvious errors or outliers. Additionally, for panel data, plotting the time series of the variable's mean and the number of observations is a useful exercise to spot potential problems.\index{Summary statistics}
 
 ```{python}
+#| label: fixed-effects-and-clustered-standard-errors-summary-statistics
 data_investment_summary = (data_investment
     .unpivot(index=["gvkey", "year"], variable_name="measure",
              on=["investment_lead", "cash_flows", "tobins_q"])
@@ -146,6 +153,7 @@ $${#eq-tobin-q}
 where $\varepsilon_t$ is i.i.d. normally distributed across time and firms. We use the `PanelOLS()`-function to estimate the simple model so that the output has the same structure as the other regressions below. 
 
 ```{python}
+#| label: fixed-effects-and-clustered-standard-errors-model-ols
 data_investment_pd = data_investment.to_pandas()
 
 model_ols = pf.feols(
@@ -169,6 +177,7 @@ where $\alpha_i$ is the firm fixed effect and captures the firm-specific mean in
 To include the firm fixed effect, we use `gvkey` (Compustat's firm identifier) as follows:
 
 ```{python}
+#| label: fixed-effects-and-clustered-standard-errors-model-fe-firm
 model_fe_firm = pf.feols(
     "investment_lead ~ cash_flows + tobins_q | gvkey",
     vcov = "iid",
@@ -188,6 +197,7 @@ $${#eq-tobin-q-2way}
 where $\alpha_t$ is the time fixed effect. Here you can think of higher investments during an economic expansion with simultaneously high cash flows. You can include a time fixed effects by using "TimeEffects" in the formula of PanelOLS.
 
 ```{python}
+#| label: fixed-effects-and-clustered-standard-errors-model-fe-firmyear
 model_fe_firmyear = pf.feols(
     "investment_lead ~ cash_flows + tobins_q | gvkey + year",
     vcov = "iid",
@@ -203,6 +213,7 @@ How can we further improve the robustness of our regression results? Ideally, we
 Before we discuss the properties of our estimation errors, we want to point out that regression tables are at the heart of every empirical analysis, where you compare multiple models. Fortunately, the `results.compare()` function provides a convenient way to tabulate the regression output (with many parameters to customize and even print the output in LaTeX). We recommend printing $t$-statistics rather than standard errors in regression tables because the latter are typically very hard to interpret across coefficients that vary in size. We also do not print p-values because they are sometimes misinterpreted to signal the importance of observed effects [@Wasserstein2016]. The $t$-statistics provide a consistent way to interpret changes in estimation uncertainty across different model specifications.
 
 ```{python}
+#| label: fixed-effects-and-clustered-standard-errors-etable-fe
 pf.etable([model_ols, model_fe_firm, model_fe_firmyear], coef_fmt = "b (t)")
 ```
 
@@ -215,6 +226,7 @@ In our setting, the residuals may be correlated across years for a given firm (t
 Instead of relying on the i.i.d. assumption, we can use the `cov_type="clustered"` option in the `fit()`-function as above. The code chunk below applies both one-way clustering by firm as well as two-way clustering by firm and year.
 
 ```{python}
+#| label: fixed-effects-and-clustered-standard-errors-cluster-models
 model_cluster_firm = pf.feols(
     "investment_lead ~ cash_flows + tobins_q | gvkey + year",
     vcov = {"CRV1": "gvkey"},
@@ -232,6 +244,7 @@ model_cluster_firmyear = pf.feols(
 The table below shows the comparison of the different assumptions behind the standard errors. In the first column, we can see highly significant coefficients on both cash flows and Tobin's q. By clustering the standard errors on the firm level, the $t$-statistics of both coefficients drop in half, indicating a high correlation of residuals within firms. If we additionally cluster by year, we see a drop, particularly for Tobin's q, again. Even after relaxing the assumptions behind our standard errors, both coefficients are still comfortably significant as the $t$-statistics are well above the usual critical values of 1.96 or 2.576 for two-tailed significance tests.
 
 ```{python}
+#| label: fixed-effects-and-clustered-standard-errors-etable-cluster
 pf.etable([model_fe_firmyear, model_cluster_firm, model_cluster_firmyear], coef_fmt = "b (t)")
 ```
 

--- a/python/index.qmd
+++ b/python/index.qmd
@@ -104,6 +104,7 @@ Python [@python] is an open-source, general-purpose, high-level programming lang
 The so-called *Zen of Python* by Tim Peters summarizes its major syntax guidelines for structured, tidy, and human-readable code. It is easily accessible in every Python environment through:\index{Zen of Python}
 
 ```{python}
+#| label: index-zen-of-python
 import this
 ```
 

--- a/python/modern-portfolio-theory.qmd
+++ b/python/modern-portfolio-theory.qmd
@@ -6,6 +6,7 @@ metadata:
 ---
 
 ```{python}
+#| label: modern-portfolio-theory-setup
 #| echo: false
 exec(open("python/render-settings.py").read())
 ```
@@ -23,6 +24,7 @@ At the heart of MPT is mean-variance analysis, which evaluates portfolios based 
 We use the following packages throughout this chapter: 
 
 ```{python}
+#| label: modern-portfolio-theory-packages
 import polars as pl
 import numpy as np
 import tidyfinance as tf
@@ -33,6 +35,7 @@ from adjustText import adjust_text
 ```
 
 ```{python}
+#| label: modern-portfolio-theory-render-plotnine
 #| echo: false
 exec(open("python/render-plotnine-custom.py").read())
 ```
@@ -50,6 +53,7 @@ To keep things conceptually simple, we focus on the latter part for now and assu
 Thus, leveraging the approach introduced in [Working with Stock Returns](working-with-stock-returns.qmd), we download the constituents of the Dow Jones Industrial Average as an example portfolio as well as their daily adjusted close prices. 
 
 ```{python}
+#| label: modern-portfolio-theory-download-data
 symbols = pl.from_pandas(tf.download_data(
     domain="constituents", index="Dow Jones Industrial Average"
 ))
@@ -65,6 +69,7 @@ prices_daily = pl.from_pandas(tf.download_data(
 To have a stable stock universe and to keep the analysis simple, we ensure that all stocks were traded over the whole sample period:
 
 ```{python}
+#| label: modern-portfolio-theory-filter-prices
 prices_daily = (prices_daily
     .with_columns(
         counts=pl.col("adjusted_close").drop_nulls().len().over("symbol")
@@ -76,6 +81,7 @@ prices_daily = (prices_daily
 We compute the sample average returns as $\frac{1}{T} \sum_{t=1}^{T} r_{i,t},$ where $r_{i,t}$ is the return of asset $i$ in period $t$, and $T$ is the total number of periods. As noted above, we treat the vector of sample averages as the true expected returns of the assets. For simplicity and easier interpretation, we focus on monthly returns going forward.
 
 ```{python}
+#| label: modern-portfolio-theory-monthly-returns
 returns_monthly = (prices_daily
     .sort("date")
     .with_columns(date=pl.col("date").dt.truncate("1mo"))
@@ -91,6 +97,7 @@ Individual asset risk in MPT is typically quantified using variance (i.e., $\sig
 We compute the sample standard deviation for each asset by using the `std()` function.
 
 ```{python}
+#| label: modern-portfolio-theory-asset-moments
 assets = (returns_monthly
     .group_by("symbol")
     .agg(
@@ -131,6 +138,7 @@ The interpretation of the covariance is straightforward: While a positive covari
 We can use `numpy`'s `cov()` function that takes a matrix of returns as inputs. We thus need to transform the returns from a data frame into a $(T \times N)$ matrix with one column for each of the $N$ symbols and one row for each of the $T$ trading days. We achieve this by using `pivot()` with the new column names from the `symbol`-column and setting the values to `ret`. We sort the columns by symbol so that the order matches `assets`, drop the rows with missing returns, and hand the resulting matrix to `numpy` at the boundary.
 
 ```{python}
+#| label: modern-portfolio-theory-covariance-matrix
 symbol_order = assets["symbol"].to_list()
 
 returns_wide = (returns_monthly
@@ -193,6 +201,7 @@ $$\omega_\text{mvp} = \frac{\Sigma^{-1}\iota}{\iota^{\prime}\Sigma^{-1}\iota},$$
 where $\iota$ is a vector of 1's and $\Sigma^{-1}$ is the inverse of the variance-covariance matrix $\Sigma$. See [Proofs](proofs.qmd) in the Appendix for details on the derivation. In the following code chunk, we calculate the weights of the minimum-variance portfolio:
 
 ```{python}
+#| label: modern-portfolio-theory-mvp-weights
 iota = np.ones(sigma.shape[0])
 sigma_inv = np.linalg.inv(sigma)
 omega_mvp = (sigma_inv @ iota) / (iota @ sigma_inv @ iota)
@@ -229,6 +238,7 @@ omega_figure.show()
 Before we move on to other portfolios, we collect the return and volatility of the minimum-variance portfolio in a data frame:
 
 ```{python}
+#| label: modern-portfolio-theory-mvp-summary
 mu = assets["mu"].to_numpy()
 mu_mvp = omega_mvp @ mu
 sigma_mvp = np.sqrt(omega_mvp @ sigma @ omega_mvp)
@@ -249,6 +259,7 @@ In many instances, earning the lowest possible variance may not be the desired o
 Suppose, for instance, the investor wants to earn at least the historical average return of the asset that delivered the highest average returns in the past:
 
 ```{python}
+#| label: modern-portfolio-theory-target-return
 mu_bar = assets["mu"].max()
 ```
 
@@ -265,6 +276,7 @@ where $\lambda^* = 2\frac{\bar\mu - D/C}{E-D^2/C}$, $C = \iota'\Sigma^{-1}\iota$
 The code below implements the analytic solution to this optimization problem and collects the resulting portfolio return and risk in a data frame.
 
 ```{python}
+#| label: modern-portfolio-theory-efficient-portfolio
 C = iota @ sigma_inv @ iota
 D = iota @ sigma_inv @ mu
 E = mu @ sigma_inv @ mu
@@ -329,6 +341,7 @@ which corresponds to the efficient portfolio earning $a\mu_1 + (1-a)\mu_2$ in ex
 The code below implements the construction of this efficient frontier, which characterizes the highest expected return achievable at each level of risk.
 
 ```{python}
+#| label: modern-portfolio-theory-efficient-frontier
 a_grid = np.arange(-1, 2.01, 0.01)
 omega_grid = [a * omega_efp + (1 - a) * omega_mvp for a in a_grid]
 

--- a/python/option-pricing-via-machine-learning.qmd
+++ b/python/option-pricing-via-machine-learning.qmd
@@ -5,7 +5,8 @@ metadata:
   description-meta: Use machine learning tools such as random forests and deep neural networks to price call options using the programming language Python.
 ---
 
-```{python} 
+```{python}
+#| label: option-pricing-via-machine-learning-setup
 #| echo: false
 exec(open("python/render-settings.py").read())
 ```
@@ -22,6 +23,7 @@ ML algorithms build a model based on training data in order to make predictions 
 Throughout this chapter, we need the following Python packages.
 
 ```{python}
+#| label: option-pricing-via-machine-learning-packages
 import polars as pl
 import numpy as np
 
@@ -40,6 +42,7 @@ from sklearn.linear_model import Lasso
 
 
 ```{python}
+#| label: option-pricing-via-machine-learning-render-plotnine
 #| echo: false
 exec(open("python/render-plotnine-custom.py").read())
 ```
@@ -96,6 +99,7 @@ where $C(S, T)$ is the price of the option as a function of today's stock price 
 The Black-Scholes equation provides a way to compute the arbitrage-free price of a call option once the parameters $S, K, r_f, T$, and $\sigma$ are specified (arguably, in a realistic context, all parameters are easy to specify except for $\sigma$ which has to be estimated). A simple Python function allows computing the price as we do below. 
 
 ```{python}
+#| label: option-pricing-via-machine-learning-black-scholes-function
 def black_scholes_price(S, K, r, T, sigma):
     """Calculate Black Scholes option price."""
 
@@ -117,6 +121,7 @@ To that end, we start with simulated data. We compute option prices for call opt
 In order to keep the analysis reproducible, we use `np.random.seed()`. A random seed specifies the start point when a computer generates a random number sequence and ensures that our simulated data is the same across different machines. 
 
 ```{python}
+#| label: option-pricing-via-machine-learning-simulate-data
 random_state = 42
 np.random.seed(random_state)
 
@@ -152,6 +157,7 @@ The code above generates more than 1.5 million random parameter constellations (
 Next, we split the data into a training set (which contains 1 percent of all the observed option prices) and a test set that will only be used for the final evaluation. Note that the entire grid of possible combinations contains `{python} f'{option_prices.shape[0]:,}'` different specifications. Thus, the sample to learn the Black-Scholes price contains only 31,489 observations and is therefore relatively small.
 
 ```{python}
+#| label: option-pricing-via-machine-learning-train-test-split
 train_data, test_data = train_test_split(
     option_prices.to_pandas(), test_size=0.01, random_state=random_state
 )
@@ -160,6 +166,7 @@ train_data, test_data = train_test_split(
 We process the training dataset further before we fit the different ML models. We define a `ColumnTransformer()` that defines all processing steps for that purpose. For our specific case, we want to explain the observed price by the five variables that enter the Black-Scholes equation. The *true* price (stored in column `black_scholes`) should obviously not be used to fit the model. The recipe also reflects that we standardize all predictors via `StandardScaler()` to ensure that each variable exhibits a sample average of zero and a sample standard deviation of one.  
 
 ```{python}
+#| label: option-pricing-via-machine-learning-preprocessor
 preprocessor = ColumnTransformer(
     transformers=[
         (
@@ -177,6 +184,7 @@ preprocessor = ColumnTransformer(
 Next, we show how to fit a neural network to the data. The function `MLPRegressor()` from the package `scikit-learn` provides the functionality to initialize a single layer, feed-forward neural network. The specification below defines a single layer feed-forward neural network with ten hidden units. We set the number of training iterations to `max_iter=1000`. 
 
 ```{python}
+#| label: option-pricing-via-machine-learning-nnet-model
 max_iter = 1000
 
 nnet_model = MLPRegressor(
@@ -187,6 +195,7 @@ nnet_model = MLPRegressor(
 We can follow the straightforward workflow as in the chapter before: define a workflow, equip it with the recipe, and specify the associated model. Finally, fit the model with the training data. 
 
 ```{python}
+#| label: option-pricing-via-machine-learning-nnet-fit
 nnet_pipeline = Pipeline(
     [("preprocessor", preprocessor), ("regressor", nnet_model)]
 )
@@ -202,6 +211,7 @@ One word of caution regarding the training of Neural networks: For illustrative 
 Once you are familiar with the `scikit-learn` workflow, it is a piece of cake to fit other models. For instance, the model below initializes a random forest with 50 trees contained in the ensemble, where we require at least 2000 observations in a node. The random forests are trained using the function `RandomForestRegressor()`. 
 
 ```{python}
+#| label: option-pricing-via-machine-learning-rf-model
 rf_model = RandomForestRegressor(
     n_estimators=50, min_samples_leaf=2000, random_state=random_state
 )
@@ -210,6 +220,7 @@ rf_model = RandomForestRegressor(
 Fitting the model follows exactly the same convention as for the neural network before.
 
 ```{python}
+#| label: option-pricing-via-machine-learning-rf-fit
 rf_pipeline = Pipeline(
     [("preprocessor", preprocessor), ("regressor", rf_model)]
 )
@@ -225,6 +236,7 @@ rf_fit = rf_pipeline.fit(
 A deep neural network is a neural network with multiple layers between the input and output layers. By chaining multiple layers together, more complex structures can be represented with fewer parameters than simple shallow (one-layer) networks as the one implemented above. For instance, image or text recognition are typical tasks where deep neural networks are used [for applications of deep neural networks in finance, see, for instance, @Jiang2022; @Jensen2022]. The following code chunk implements a deep neural network with three hidden layers of size ten each and logistic activation functions. 
 
 ```{python}
+#| label: option-pricing-via-machine-learning-deepnnet-fit
 #| warning: false
 deepnnet_model = MLPRegressor(
     hidden_layer_sizes=(10, 10, 10),
@@ -248,7 +260,8 @@ deepnnet_fit = deepnnet_pipeline.fit(
 
 Before we evaluate the results, we implement one more model. In principle, any non-linear function can also be approximated by a linear model containing the input variables' polynomial expansions. To illustrate this, we include polynomials up to the fifth degree of each predictor and then add all possible pairwise interaction terms. We fit a Lasso regression model with a pre-specified penalty term (consult [Factor Selection via Machine Learning](factor-selection-via-machine-learning.qmd) on how to tune the model hyperparameters).
 
-```{python} 
+```{python}
+#| label: option-pricing-via-machine-learning-lasso-fit
 #| warning: false
 lm_pipeline = Pipeline(
     [
@@ -274,6 +287,7 @@ lm_fit = lm_pipeline.fit(
 Finally, we collect all predictions to compare the *out-of-sample* prediction error evaluated on 10,000 new data points. 
 
 ```{python}
+#| label: option-pricing-via-machine-learning-predictions
 test_X = test_data.get(["S", "K", "r", "T", "sigma"])
 test_y = test_data.get("observed_price")
 

--- a/python/parametric-portfolio-policies.qmd
+++ b/python/parametric-portfolio-policies.qmd
@@ -6,6 +6,7 @@ metadata:
 ---
 
 ```{python}
+#| label: parametric-portfolio-policies-setup
 #| echo: false
 exec(open("python/render-settings.py").read())
 ```
@@ -19,6 +20,7 @@ In this chapter, we apply different portfolio performance measures to evaluate a
 The current chapter relies on the following set of Python packages:
 
 ```{python}
+#| label: parametric-portfolio-policies-packages
 import polars as pl
 import pandas as pd
 import numpy as np
@@ -35,6 +37,7 @@ Compared to previous chapters, we introduce the `scipy.optimize` module from the
 To get started, we load the monthly CRSP file, which forms our investment universe. We load the data from our Parquet files introduced in [Accessing and Managing Financial Data](accessing-and-managing-financial-data.qmd) and [WRDS, CRSP, and Compustat](wrds-crsp-and-compustat.qmd).\index{Data!CRSP}
 
 ```{python}
+#| label: parametric-portfolio-policies-load-crsp
 crsp_monthly = (
     pl.read_parquet("data-python/crsp_monthly.parquet")
     .drop_nulls()
@@ -44,6 +47,7 @@ crsp_monthly = (
 To evaluate the performance of portfolios, we further use monthly market returns as a benchmark to compute CAPM alphas.\index{Data!Fama-French factors} 
 
 ```{python}
+#| label: parametric-portfolio-policies-load-factors
 factors_ff_monthly = (
     pl.read_parquet("data-python/factors_ff3_monthly.parquet")
     .select(["date", "mkt_excess"])
@@ -53,6 +57,7 @@ factors_ff_monthly = (
 Next, we retrieve some stock characteristics that have been shown to have an effect on the expected returns or expected variances (or even higher moments) of the return distribution. \index{Momentum} In particular, we record the lagged one-year return momentum (`momentum_lag`), defined as the compounded return between months $t-13$ and $t-2$ for each firm, which we calculate using market capitalization for simplicity. In finance, momentum is the empirically observed tendency for rising asset prices to rise further and falling prices to keep falling [@Jegadeesh1993]. We refer to the exercise for a more elaborate measure of momentum. \index{Size!Size effect} The second characteristic is the firm's market equity (`size_lag`), defined as the log of the price per share times the number of shares outstanding [@Banz1981]. To construct the correct lagged values, we use the approach introduced in [WRDS, CRSP, and Compustat](wrds-crsp-and-compustat.qmd).\index{Data!CRSP}
 
 ```{python}
+#| label: parametric-portfolio-policies-compute-characteristics
 crsp_monthly_lags = (crsp_monthly
     .with_columns(date=pl.col("date").dt.offset_by("13mo"))
     .select(["permno", "date", "mktcap"])
@@ -97,6 +102,7 @@ Intuitively, the portfolio strategy is a form of active portfolio management rel
 We first implement cross-sectional standardization for the entire CRSP universe. We also keep track of (lagged) relative market capitalization `relative_mktcap`, which will represent the value-weighted benchmark portfolio, while `n` denotes the number of traded assets $N_t$, which we use to construct the naive portfolio benchmark.
 
 ```{python}
+#| label: parametric-portfolio-policies-standardize-characteristics
 lag_columns = [i for i in data_portfolios.columns if i.endswith("lag")]
 
 data_portfolios = (data_portfolios
@@ -126,6 +132,7 @@ The allocation strategy is straightforward because the number of parameters to e
 To get a feeling for the performance of such an allocation strategy, we start with an arbitrary initial vector $\theta_0$. The next step is to choose $\theta$ optimally to maximize the objective function. We automatically detect the number of parameters by counting the number of columns with lagged values. Note that the value for $\theta$ of 1.5 is an arbitrary choice.
 
 ```{python}
+#| label: parametric-portfolio-policies-initial-theta
 lag_columns = [i for i in data_portfolios.columns if "lag" in i]
 n_parameters = len(lag_columns)
 theta = np.array([1.5]*n_parameters)
@@ -144,6 +151,7 @@ $${#eq-short-sale-constraint}
 The following function computes the optimal portfolio weights in the way just described.\index{Functional programming}
 
 ```{python}
+#| label: parametric-portfolio-policies-define-compute-weights
 def compute_portfolio_weights(theta,
                               data,
                               value_weighting=True,
@@ -192,6 +200,7 @@ def compute_portfolio_weights(theta,
 In the next step, we compute the portfolio weights for the arbitrary vector $\theta_0$. In the example below, we use the value-weighted portfolio as a benchmark and allow negative portfolio weights.
 
 ```{python}
+#| label: parametric-portfolio-policies-compute-weights
 weights_crsp = compute_portfolio_weights(
     theta,
     data_portfolios,
@@ -211,6 +220,7 @@ $${#eq-power-utility}
 where $\gamma$ is the risk aversion factor.\index{Power utility}
 
 ```{python}
+#| label: parametric-portfolio-policies-define-power-utility
 def power_utility(r, gamma=5):
     """Calculate power utility for given risk aversion."""
     
@@ -224,6 +234,7 @@ We want to note that @Gehrig2020 warn that, in the leading case of constant rela
 No doubt, there are many other ways to evaluate a portfolio. The function below provides a summary of all kinds of interesting measures that can be considered relevant. Do we need all these evaluation measures? It depends: The original paper by @Brandt2009 only cares about the expected utility to choose $\theta$. However, if you want to choose optimal values that achieve the highest performance while putting some constraints on your portfolio weights, it is helpful to have everything in one function.
 
 ```{python}
+#| label: parametric-portfolio-policies-define-evaluate-portfolio
 def evaluate_portfolio(weights_data,
                        full_evaluation=True,
                        capm_evaluation=True,
@@ -311,6 +322,7 @@ def evaluate_portfolio(weights_data,
 Let us take a look at the different portfolio strategies and evaluation measures.
 
 ```{python}
+#| label: parametric-portfolio-policies-evaluate-initial
 evaluate_portfolio(weights_crsp).round(2)
 ```
 
@@ -321,6 +333,7 @@ The value-weighted portfolio delivers an annualized return of more than six perc
 Next, we move to a choice of $\theta$ that actually aims to improve some (or all) of the performance measures. We first define the helper function `compute_objective_function()`, which we then pass to an optimizer.
 
 ```{python}
+#| label: parametric-portfolio-policies-define-objective-function
 def objective_function(theta,
                        data,
                        objective_measure="Expected utility",
@@ -346,6 +359,7 @@ def objective_function(theta,
 You may wonder why we return the negative value of the objective function. This is simply due to the common convention for optimization procedures to search for minima as a default. By minimizing the negative value of the objective function, we get the maximum value as a result. In its most basic form, Python optimization uses the function `minimize()`.\index{Optimization} As main inputs, the function requires an initial guess of the parameters and the objective function to minimize. Now, we are fully equipped to compute the optimal values of $\hat\theta$, which maximize the hypothetical expected utility of the investor.
 
 ```{python}
+#| label: parametric-portfolio-policies-optimize-theta
 optimal_theta = minimize(
     fun=objective_function,
     x0=[1.5]*n_parameters,
@@ -368,6 +382,7 @@ The resulting values of $\hat\theta$ are easy to interpret: intuitively, expecte
 How does the portfolio perform for different model specifications? For this purpose, we compute the performance of a number of different modeling choices based on the entire CRSP sample. The next code chunk performs all the heavy lifting.
 
 ```{python}
+#| label: parametric-portfolio-policies-define-optimal-performance
 def evaluate_optimal_performance(data,
                                  objective_measure="Expected utility",
                                  value_weighting=True,
@@ -407,6 +422,7 @@ def evaluate_optimal_performance(data,
 Finally, we can compare the results. The table below shows summary statistics for all possible combinations: equal- or value-weighted benchmark portfolio, with or without short-selling constraints, and tilted toward maximizing expected utility. 
 
 ```{python}
+#| label: parametric-portfolio-policies-evaluate-specifications
 data = [data_portfolios]
 value_weighting = [True, False]
 allow_short_selling = [True, False]
@@ -426,9 +442,11 @@ performance_table = (pd.concat(results, axis=1)
 performance_table.get(["EW", "VW"])
 ``` 
 ```{python}
+#| label: parametric-portfolio-policies-performance-optimal
 performance_table.get(["EW Optimal", "VW Optimal"])
 ```
 ```{python}
+#| label: parametric-portfolio-policies-performance-no-short
 performance_table.get(["EW Optimal (no s.)", "VW Optimal (no s.)"])
 ```
 

--- a/python/replicating-fama-and-french-factors.qmd
+++ b/python/replicating-fama-and-french-factors.qmd
@@ -6,6 +6,7 @@ metadata:
 ---
 
 ```{python}
+#| label: replicating-fama-and-french-factors-setup
 #| echo: false
 exec(open("python/render-settings.py").read())
 ```
@@ -23,6 +24,7 @@ After the replication of the three-factor model, we move to the five-factors by 
 The current chapter relies on this set of Python packages. 
 
 ```{python}
+#| label: replicating-fama-and-french-factors-packages
 import polars as pl
 import numpy as np
 import statsmodels.formula.api as smf
@@ -35,6 +37,7 @@ from regtabletotext import prettify_result
 We use CRSP and Compustat as data sources, as we need exactly the same variables to compute the size and value factors in the way Fama and French do it. Hence, we only load data from our Parquet files introduced in [Accessing and Managing Financial Data](accessing-and-managing-financial-data.qmd) and [WRDS, CRSP, and Compustat](wrds-crsp-and-compustat.qmd).^[Note that @Fama1992 claim to exclude financial firms. To a large extent this happens through using industry format "INDL", as we do in [WRDS, CRSP, and Compustat](wrds-crsp-and-compustat.qmd). Neither the original paper, nor Ken French's website, or the WRDS replication contains any indication that financial companies are excluded using additional filters such as industry codes.] \index{Data!CRSP}\index{Data!Compustat}\index{Data!Fama-French factors} The only addition is that we keep only firms with positive book equity, which is a common practice when working with book-to-market ratios [see @Fama1992 for details].\index{Book equity}
 
 ```{python}
+#| label: replicating-fama-and-french-factors-load-data
 crsp_monthly = (
     pl.read_parquet("data-python/crsp_monthly.parquet")
     .select(["permno", "gvkey", "date", "ret_excess", "mktcap",
@@ -67,6 +70,7 @@ Second, Fama and French also have a different protocol for computing the book-to
 To implement all these time lags, we again employ the temporary `sorting_date`-column. Notice that when we combine the information, we want to have a single observation per year and stock since we are only interested in computing the breakpoints held constant for the entire year. We ensure this by a call of `unique()` at the end of the chunk below.
 
 ```{python}
+#| label: replicating-fama-and-french-factors-sorting-variables
 size = (crsp_monthly
     .filter(pl.col("date").dt.month() == 6)
     .with_columns(sorting_date=pl.col("date").dt.offset_by("1mo").cast(pl.Date))
@@ -102,6 +106,7 @@ sorting_variables = (size
 Next, we construct our portfolios with an adjusted `assign_portfolio()` function.\index{Portfolio sorts} Fama and French rely on NYSE-specific breakpoints to independently form two portfolios in the size dimension at the median and three portfolios in the dimension of book-to-market at the 30- and 70-percentiles. The sorts for book-to-market require an adjustment to the function in [Value and Bivariate Sorts](value-and-bivariate-sorts.qmd) because it would not produce the right breakpoints. Instead of `n_portfolios`, we now specify `percentiles`, which takes the sequence of breakpoints as an object specified in the function's call. Specifically, we give `percentiles = [0.3, 0.7]` to the function. Additionally, we perform a join with our return data to ensure that we only use traded stocks when computing the breakpoints as a first step.\index{Breakpoints}
 
 ```{python}
+#| label: replicating-fama-and-french-factors-assign-portfolio
 def assign_portfolio(data, sorting_variable, percentiles):
     """Assign portfolios to a bin according to a sorting variable."""
 
@@ -146,6 +151,7 @@ Alternatively, you can implement the same portfolio sorts using the `assign_port
 Next, we merge the portfolios to the return data for the rest of the year. To implement this step, we create a new column `sorting_date` in our return data by setting the date to sort on to July of $t-1$ if the month is June (of year $t$) or earlier or to July of year $t$ if the month is July or later.
 
 ```{python}
+#| label: replicating-fama-and-french-factors-merge-portfolios-ff3
 portfolios = (crsp_monthly
     .with_columns(
         sorting_date=pl.when(pl.col("date").dt.month() <= 6)
@@ -161,6 +167,7 @@ portfolios = (crsp_monthly
 Equipped with the return data and the assigned portfolios, we can now compute the value-weighted average return for each of the six portfolios. Then, we form the Fama-French factors. For the size factor (i.e., SMB), we go long in the three small portfolios and short the three large portfolios by taking an average across either group. For the value factor (i.e., HML), we go long in the two high book-to-market portfolios and short the two low book-to-market portfolios, again weighting them equally (using the `mean()` function).\index{Factor!Size}\index{Factor!Value}\index{Long-short}
 
 ```{python}
+#| label: replicating-fama-and-french-factors-compute-ff3
 factors_replicated = (portfolios
     .group_by(["portfolio_size", "portfolio_bm", "date"])
     .agg(ret=(pl.col("ret_excess") * pl.col("mktcap_lag")).sum()
@@ -189,6 +196,7 @@ In the previous section, we replicated the size and value premiums following the
 To test the success of the SMB factor, we hence run the following regression:
 
 ```{python}
+#| label: replicating-fama-and-french-factors-evaluate-smb-ff3
 model_smb = (smf.ols(
         formula="smb ~ smb_replicated",
         data=factors_replicated.to_pandas()
@@ -201,6 +209,7 @@ prettify_result(model_smb)
 The results for the SMB factor are quite convincing as all three criteria outlined above are met and the coefficient is `{python} np.round(model_smb.params["smb_replicated"], 2)` and R-squared are at `{python} int(np.round(model_smb.rsquared_adj, 2) * 100)` percent. 
 
 ```{python}
+#| label: replicating-fama-and-french-factors-evaluate-hml-ff3
 model_hml = (smf.ols(
         formula="hml ~ hml_replicated",
         data=factors_replicated.to_pandas()
@@ -219,6 +228,7 @@ The evidence allows us to conclude that we did a relatively good job in replicat
 Now, let us move to the replication of the five-factor model. We extend the `other_sorting_variables` table from above with the additional characteristics operating profitability `op` and investment `inv`. Note that the `drop_nulls()` statement yields different sample sizes, as some firms with `be` values might not have `op` or `inv` values. 
 
 ```{python}
+#| label: replicating-fama-and-french-factors-sorting-variables-ff5
 other_sorting_variables = (compustat_annual
     .with_columns(
         sorting_date=pl.date(pl.col("datadate").dt.year() + 1, 7, 1)
@@ -238,6 +248,7 @@ sorting_variables = (size
 In each month, we independently sort all stocks into the two size portfolios. The value, profitability, and investment portfolios, on the other hand, are the results of dependent sorts based on the size portfolios. We then merge the portfolios to the return data for the rest of the year just as above. 
 
 ```{python}
+#| label: replicating-fama-and-french-factors-portfolio-sorts-ff5
 portfolios = (sorting_variables
     .group_by("sorting_date")
     .map_groups(lambda x: x
@@ -271,6 +282,7 @@ portfolios = (crsp_monthly
 Now, we want to construct each of the factors, but this time, the size factor actually comes last because it is the result of averaging across all other factor portfolios. This dependency is the reason why we keep the table with value-weighted portfolio returns as a separate object that we reuse later. We construct the value factor, HML, as above by going long the two portfolios with high book-to-market ratios and shorting the two portfolios with low book-to-market.
 
 ```{python}
+#| label: replicating-fama-and-french-factors-value-factor
 portfolios_value = (portfolios
     .group_by(["portfolio_size", "portfolio_bm", "date"])
     .agg(ret=(pl.col("ret_excess") * pl.col("mktcap_lag")).sum()
@@ -288,6 +300,7 @@ factors_value = (portfolios_value
 For the profitability factor, RMW (robust-minus-weak), we take a long position in the two high profitability portfolios and a short position in the two low profitability portfolios.\index{Factor!Profitability}
 
 ```{python}
+#| label: replicating-fama-and-french-factors-profitability-factor
 portfolios_profitability = (portfolios
     .group_by(["portfolio_size", "portfolio_op", "date"])
     .agg(ret=(pl.col("ret_excess") * pl.col("mktcap_lag")).sum()
@@ -305,6 +318,7 @@ factors_profitability = (portfolios_profitability
 For the investment factor, CMA (conservative-minus-aggressive), we go long the two low investment portfolios and short the two high investment portfolios.\index{Factor!Investment}
 
 ```{python}
+#| label: replicating-fama-and-french-factors-investment-factor
 portfolios_investment = (portfolios
     .group_by(["portfolio_size", "portfolio_inv", "date"])
     .agg(ret=(pl.col("ret_excess") * pl.col("mktcap_lag")).sum()
@@ -322,6 +336,7 @@ factors_investment = (portfolios_investment
 Finally, the size factor, SMB, is constructed by going long the nine small portfolios and short the nine large portfolios. 
 
 ```{python}
+#| label: replicating-fama-and-french-factors-size-factor
 factors_size = (
     pl.concat(
         [portfolios_value.select(["portfolio_size", "date", "ret"]),
@@ -338,6 +353,7 @@ factors_size = (
 We then join all factors together into one dataframe and construct again a suitable table to run tests for evaluating our replication.
 
 ```{python}
+#| label: replicating-fama-and-french-factors-combine-ff5
 factors_replicated = (factors_size
     .join(factors_value, how="full", on="date", coalesce=True)
     .join(factors_profitability, how="full", on="date", coalesce=True)
@@ -353,6 +369,7 @@ factors_replicated = (factors_replicated
 Let us start the replication evaluation again with the size factor:
 
 ```{python}
+#| label: replicating-fama-and-french-factors-evaluate-smb-ff5
 model_smb = (smf.ols(
         formula="smb ~ smb_replicated",
         data=factors_replicated.to_pandas()
@@ -365,6 +382,7 @@ prettify_result(model_smb)
 The results for the SMB factor are quite convincing, as all three criteria outlined above are met and the coefficient is `{python} np.round(model_smb.params["smb_replicated"], 2)` and the R-squared is at `{python} int(np.round(model_smb.rsquared_adj, 2) * 100)` percent. 
 
 ```{python}
+#| label: replicating-fama-and-french-factors-evaluate-hml-ff5
 model_hml = (smf.ols(
         formula="hml ~ hml_replicated",
         data=factors_replicated.to_pandas()
@@ -377,6 +395,7 @@ prettify_result(model_hml)
 The replication of the HML factor is also a success, although at a slightly higher coefficient of `{python} np.round(model_hml.params["hml_replicated"], 2)` and an R-squared around `{python} int(np.round(model_hml.rsquared_adj, 2) * 100)` percent. 
 
 ```{python}
+#| label: replicating-fama-and-french-factors-evaluate-rmw
 model_rmw = (smf.ols(
         formula="rmw ~ rmw_replicated",
         data=factors_replicated.to_pandas()
@@ -389,6 +408,7 @@ prettify_result(model_rmw)
 We are also able to replicate the RMW factor quite well with a coefficient of `{python} np.round(model_rmw.params["rmw_replicated"], 2)` and an R-squared around `{python} int(np.round(model_rmw.rsquared_adj, 2) * 100)` percent.
 
 ```{python}
+#| label: replicating-fama-and-french-factors-evaluate-cma
 model_cma = (smf.ols(
         formula="cma ~ cma_replicated",
         data=factors_replicated.to_pandas()

--- a/python/setting-up-your-environment.qmd
+++ b/python/setting-up-your-environment.qmd
@@ -86,6 +86,7 @@ You can use `.env`-files to store environment variables. Upon startup, Python pr
 First, you need to install the `python-dotenv` library if you haven't already:
 
 ```{python}
+#| label: setting-up-your-environment-install-dotenv
 #| eval: false
 uv pip install python-dotenv
 ```
@@ -100,6 +101,7 @@ WRDS_PASSWORD=password
 To access these environment variables in your Python code, load the environment variables at the start of your Python script using `python-dotenv`:
 
 ```{python}
+#| label: setting-up-your-environment-load-env-variables
 #| eval: false
 from dotenv import load_dotenv
 import os

--- a/python/size-sorts-and-p-hacking.qmd
+++ b/python/size-sorts-and-p-hacking.qmd
@@ -6,6 +6,7 @@ metadata:
 ---
 
 ```{python}
+#| label: size-sorts-and-p-hacking-setup
 #| echo: false
 exec(open("python/render-settings.py").read())
 ```
@@ -22,6 +23,7 @@ There is arguably a thin line between p-hacking and conducting robustness tests.
 The chapter relies on the following set of Python packages:
 
 ```{python}
+#| label: size-sorts-and-p-hacking-packages
 import polars as pl
 import numpy as np
 
@@ -32,6 +34,7 @@ from joblib import Parallel, delayed, cpu_count
 ```
 
 ```{python}
+#| label: size-sorts-and-p-hacking-render-plotnine
 #| echo: false
 exec(open("python/render-plotnine-custom.py").read())
 ```
@@ -43,6 +46,7 @@ Compared to previous chapters, we introduce `itertools`, which is a component of
 First, we retrieve the relevant data from our Parquet files introduced in [Accessing and Managing Financial Data](accessing-and-managing-financial-data.qmd) and [WRDS, CRSP, and Compustat](wrds-crsp-and-compustat.qmd). Firm size is defined as market equity in most asset pricing applications that we retrieve from CRSP. We further use the Fama-French factor returns for performance evaluation.\index{Data!CRSP}\index{Data!Fama-French factors}
 
 ```{python}
+#| label: size-sorts-and-p-hacking-read-data
 crsp_monthly = pl.read_parquet("data-python/crsp_monthly.parquet")
 
 factors_ff3_monthly = pl.read_parquet("data-python/factors_ff3_monthly.parquet")
@@ -136,6 +140,7 @@ Finally, we consider the distribution of firm size across listing exchanges and 
 The resulting table shows that firms listed on NYSE in December 2023 are significantly larger on average than firms listed on the other exchanges. Moreover, NASDAQ lists the largest number of firms. This discrepancy between firm sizes across listing exchanges motivated researchers to form breakpoints exclusively on the NYSE sample and apply those breakpoints to all stocks. In the following, we use this distinction to update our portfolio sort procedure.
 
 ```{python}
+#| label: size-sorts-and-p-hacking-summary-statistics
 def summary_statistics(variable, percentiles):
     """Build the list of summary-statistic expressions for a variable."""
 
@@ -186,6 +191,7 @@ In [Univariate Portfolio Sorts](univariate-portfolio-sorts.qmd), we construct po
 To replicate the NYSE-centered sorting procedure, we introduce `exchanges` as an argument in our `assign_portfolio()` function from [Univariate Portfolio Sorts](univariate-portfolio-sorts.qmd). The exchange-specific argument then enters in the filter `pl.col("exchange").is_in(exchanges)`. For example, if `exchanges=["NYSE"]` is specified, only stocks listed on NYSE are used to compute the breakpoints. Alternatively, you could specify `exchanges=["NYSE", "NASDAQ", "AMEX"]`, which keeps all stocks listed on either of these exchanges.
 
 ```{python}
+#| label: size-sorts-and-p-hacking-assign-portfolio
 def assign_portfolio(data, exchanges, sorting_variable, n_portfolios):
     """Assign portfolio for a given sorting variable."""
 
@@ -221,6 +227,7 @@ Apart from computing breakpoints on different samples, researchers often use dif
 We implement the two weighting schemes in the function `compute_portfolio_returns()` that takes a logical argument to weight the returns by firm value. Additionally, the long-short portfolio is long in the smallest firms and short in the largest firms, consistent with research showing that small firms outperform their larger counterparts. Apart from these two changes, the function is similar to the procedure in [Univariate Portfolio Sorts](univariate-portfolio-sorts.qmd).\index{Long-short}
 
 ```{python}
+#| label: size-sorts-and-p-hacking-compute-portfolio-returns
 def calculate_returns(value_weighted):
     """Build the (value-weighted) return expression."""
 
@@ -268,6 +275,7 @@ def compute_portfolio_returns(n_portfolios=10,
 To see how the function `compute_portfolio_returns()` works, we consider a simple median breakpoint example with value-weighted returns. We are interested in the effect of restricting listing exchanges on the estimation of the size premium. In the first function call, we compute returns based on breakpoints from all listing exchanges. Then, we computed returns based on breakpoints from NYSE-listed stocks.
 
 ```{python}
+#| label: size-sorts-and-p-hacking-exchange-comparison
 ret_all = compute_portfolio_returns(
     n_portfolios=2,
     exchanges=["NYSE", "NASDAQ", "AMEX"],
@@ -305,6 +313,7 @@ Nevertheless, the multitude of options creates a problem since there is no singl
 Below, we conduct a series of robustness tests, which could also be interpreted as a p-hacking exercise. To do so, we examine the size premium in different specifications presented in the table `p_hacking_setup`. The function `itertools.product()` produces all possible permutations of its arguments. Note that we use the argument `data` to exclude financial firms and truncate the time series. 
 
 ```{python}
+#| label: size-sorts-and-p-hacking-setup-grid
 n_portfolios = [2, 5, 10]
 exchanges = [["NYSE"], ["NYSE", "NASDAQ", "AMEX"]]
 value_weighted = [True, False]
@@ -322,6 +331,7 @@ p_hacking_setup = list(
 To speed the computation up, we parallelize the (many) different sorting procedures, as in [Beta Estimation](beta-estimation.qmd) using the `joblib` package. Finally, we report the resulting size premiums in descending order. There are indeed substantial size premiums possible in our data, in particular when we use equal-weighted portfolios.\index{Parallelization}
 
 ```{python}
+#| label: size-sorts-and-p-hacking-parallel-premia
 #| warning: false
 n_cores = cpu_count()-1
 size_premia = Parallel(n_jobs=n_cores)(

--- a/python/trace-and-fisd.qmd
+++ b/python/trace-and-fisd.qmd
@@ -6,6 +6,7 @@ metadata:
 ---
 
 ```{python}
+#| label: trace-and-fisd-setup
 #| echo: false
 exec(open("python/render-settings.py").read())
 ```
@@ -23,6 +24,7 @@ This chapter also draws on the resources provided by the project [Open Source Bo
 The current chapter relies on the following set of Python packages. 
 
 ```{python}
+#| label: trace-and-fisd-packages
 import polars as pl
 import numpy as np
 import tidyfinance as tf
@@ -38,6 +40,7 @@ from mizani.formatters import comma_format
 ```
 
 ```{python}
+#| label: trace-and-fisd-render-plotnine
 #| echo: false
 exec(open("python/render-plotnine-custom.py").read())
 ```
@@ -49,6 +52,7 @@ Compared to previous chapters, we load `httpimport` [@httpimport] to source code
 Both bond databases we need are available on [WRDS](https://wrds-www.wharton.upenn.edu/) to which we establish the PostgreSQL connection described in [WRDS, CRSP, and Compustat](wrds-crsp-and-compustat.qmd).\index{WRDS}
 
 ```{python}
+#| label: trace-and-fisd-wrds-connection
 #| eval: false
 import os
 from dotenv import load_dotenv
@@ -93,6 +97,7 @@ The following chunk connects to the data and selects the bond sample to remove c
 1. Exclude unit deal bonds (`(unit_deal = 'N' OR unit_deal IS NULL)`).
 
 ```{python}
+#| label: trace-and-fisd-fisd-query
 #| eval: false
 fisd_query = (
   "SELECT complete_cusip, maturity, offering_amt, offering_date, "
@@ -141,6 +146,7 @@ fisd = pl.read_database(
 We also pull issuer information from `fisd_mergedissuer` regarding the industry and country of the firm that issued a particular bond. Then, we filter to include only US-domiciled firms' bonds. We match the data by `issuer_id`.
 
 ```{python}
+#| label: trace-and-fisd-fisd-issuer
 #| eval: false
 fisd_issuer_query = (
     "SELECT issuer_id, sic_code, country_domicile "
@@ -164,6 +170,7 @@ fisd = (fisd
 To download the FISD data with the above filters and processing steps, you can use the `tidyfinance` package. Note that you might have to set the login credentials for WRDS first using `tf.set_wrds_credentials()`.
 
 ```{python}
+#| label: trace-and-fisd-download-fisd
 #| eval: false
 #| output: false
 fisd = pl.from_pandas(tf.download_data(domain="wrds", dataset="fisd"))
@@ -172,6 +179,7 @@ fisd = pl.from_pandas(tf.download_data(domain="wrds", dataset="fisd"))
 Finally, we save the bond characteristics to our local folder. This selection of bonds also constitutes the sample for which we will collect trade reports from TRACE below.
 
 ```{python}
+#| label: trace-and-fisd-write-fisd
 #| eval: false
 #| output: false
 fisd.write_parquet("data-python/fisd.parquet")
@@ -180,6 +188,7 @@ fisd.write_parquet("data-python/fisd.parquet")
 The FISD database also contains other data. The issue-based file contains information on covenants, i.e., restrictions included in bond indentures to limit specific actions by firms [e.g., @handler2021]. The FISD redemption database also contains information on callable bonds. Moreover, FISD also provides information on bond ratings. We do not need either here.
 
 ```{python}
+#| label: trace-and-fisd-read-fisd
 #| echo: false
 #| eval: true
 fisd = pl.read_parquet("data-python/fisd.parquet")
@@ -194,6 +203,7 @@ Why do we repeatedly talk about cleaning TRACE? Trade messages are submitted wit
 We store code for cleaning enhanced TRACE with Python on the following GitHub [Gist.](https://gist.githubusercontent.com/patrick-weiss/86ddef6de978fbdfb22609a7840b5d8b) \index{GitHub!Gist} [Clean Enhanced TRACE with Python](clean-enhanced-trace-with-python.qmd) also contains the code for reference. We only need to source the code from the Gist, which we can do with the code below using `httpimport`. In the chunk, we explicitly load the necessary function interpreting the Gist as a module (i.e., you could also use it as a module and precede the function calls with the module's name). Alternatively, you can also go to the Gist, download it, and manually execute it. The `clean_enhanced_trace()` function takes a vector of CUSIPs, a connection to WRDS explained in [WRDS, CRSP, and Compustat](wrds-crsp-and-compustat.qmd), and a start and end date, respectively. 
 
 ```{python}
+#| label: trace-and-fisd-source-cleaning
 #| eval: false
 #| warning: false
 import requests
@@ -211,6 +221,7 @@ exec(response.text)
 The TRACE database is considerably large. Therefore, we only download subsets of data at once. Specifying too many CUSIPs over a long time horizon will result in very long download times and a potential failure due to the size of the request to WRDS. The size limit depends on many parameters, and we cannot give you a guideline here. For the applications in this book, we need data around the Paris Agreement in December 2015 and download the data in sets of 1,000 bonds, which we define below.\index{Paris (Climate) Agreement}
 
 ```{python}
+#| label: trace-and-fisd-define-batches
 #| eval: false
 cusips = fisd["complete_cusip"].unique().to_list()
 batch_size = 1000
@@ -220,6 +231,7 @@ batches = np.ceil(len(cusips)/batch_size).astype(int)
 Finally, we run a loop in the same style as in [WRDS, CRSP, and Compustat](wrds-crsp-and-compustat.qmd) where we download daily returns from CRSP. For each of the CUSIP sets defined above, we call the cleaning function and save the resulting output. We add new data to the existing dataset for batch two and all following batches.  Because our later applications load the entire table at once, we partition the data by batch rather than by security identifier. Using a smaller number of larger files improves efficiency when loading the full dataset into memory.
 
 ```{python}
+#| label: trace-and-fisd-download-loop
 #| eval: false
 #| output: false
 for j in range(1, batches + 1):
@@ -255,6 +267,7 @@ for j in range(1, batches + 1):
 If you want to download the prepared enhanced TRACE data for selected bonds via the `tidyfinance` package, you can call, e.g.:
 
 ```{python}
+#| label: trace-and-fisd-download-tidyfinance
 #| eval: false
 #| output: false
 tf.download_data(
@@ -273,6 +286,7 @@ While many news outlets readily provide information on stocks and the underlying
 We start by looking into the number of bonds outstanding over time and compare it to the number of bonds traded in our sample. First, we compute the number of bonds outstanding for each quarter around the Paris Agreement from 2014 to 2016. 
 
 ```{python}
+#| label: trace-and-fisd-bonds-outstanding
 dates = pl.DataFrame(
     {"date": pl.date_range(
         date(2014, 3, 1), date(2016, 11, 30), interval="3mo", eager=True
@@ -294,6 +308,7 @@ bonds_outstanding = (dates
 Next, we look at the bonds traded each quarter in the same period. Notice that we load the complete TRACE data from our dataset, as we only have a single part of it in the environment from the download loop above.
 
 ```{python}
+#| label: trace-and-fisd-bonds-traded
 trace_enhanced = pl.from_arrow(
     ds.dataset("data-python/trace_enhanced", format="parquet").to_table()
 )
@@ -344,6 +359,7 @@ bonds_figure.draw()
 We see that the number of bonds outstanding increases steadily between 2014 and 2016. During our sample period of trade data, we see that the fraction of bonds trading each quarter is roughly 60 percent. The relatively small number of traded bonds means that many bonds do not trade through an entire quarter. This lack of trading activity illustrates the generally low level of liquidity in the corporate bond market, where it can be hard to trade specific bonds. Does this lack of liquidity mean that corporate bond markets are irrelevant in terms of their size? With over 7,500 traded bonds each quarter, it is hard to say that the market is small. However, let us also investigate the characteristics of issued corporate bonds. In particular, we consider maturity (in years), coupon, and offering amount (in million USD).\index{Liquidity}
 
 ```{python}
+#| label: trace-and-fisd-bond-characteristics
 average_characteristics = (fisd
     .with_columns(
         maturity=(pl.col("maturity") - pl.col("offering_date")).dt.total_days()/365,
@@ -373,6 +389,7 @@ We see that the sample is dominated by zero-coupon bonds: the median coupon is z
 Finally, let us compute some summary statistics for the trades in this market. To this end, we show a summary based on aggregate information daily. In particular, we consider the trade size (in million USD) and the number of trades.
 
 ```{python}
+#| label: trace-and-fisd-trade-summary
 average_trade_size = (trace_enhanced
     .group_by("trd_exctn_dt")
     .agg(

--- a/python/univariate-portfolio-sorts.qmd
+++ b/python/univariate-portfolio-sorts.qmd
@@ -6,6 +6,7 @@ metadata:
 ---
 
 ```{python}
+#| label: univariate-portfolio-sorts-setup
 #| echo: false
 exec(open("python/render-settings.py").read())
 ```
@@ -21,6 +22,7 @@ A univariate portfolio sort considers only one sorting variable $x_{i,t-1}$.\ind
 The current chapter relies on the following set of Python packages.
 
 ```{python}
+#| label: univariate-portfolio-sorts-packages
 import polars as pl
 import statsmodels.api as sm
 
@@ -30,6 +32,7 @@ from regtabletotext import prettify_result
 ```
 
 ```{python}
+#| label: univariate-portfolio-sorts-render-plotnine
 #| echo: false
 exec(open("python/render-plotnine-custom.py").read())
 ```
@@ -39,6 +42,7 @@ exec(open("python/render-plotnine-custom.py").read())
 We start with loading the required data from our Parquet files introduced in [Accessing and Managing Financial Data](accessing-and-managing-financial-data.qmd) and [WRDS, CRSP, and Compustat](wrds-crsp-and-compustat.qmd). In particular, we use the monthly CRSP sample as our asset universe.\index{Data!CRSP} Once we form our portfolios, we use the Fama-French market factor returns to compute the risk-adjusted performance (i.e., alpha).\index{Data!Fama-French factors} `beta` is the dataframe with market betas computed in the previous chapter.\index{Beta}
 
 ```{python}
+#| label: univariate-portfolio-sorts-load-data
 crsp_monthly = (
     pl.read_parquet("data-python/crsp_monthly.parquet")
     .select(["permno", "date", "ret_excess", "mktcap_lag"])
@@ -61,6 +65,7 @@ beta = (
 Next, we merge our sorting variable with the return data. We use the one-month *lagged* betas as a sorting variable to ensure that the sorts rely only on information available when we create the portfolios. To lag stock beta by one month, we add one month to the current date and join the resulting information with our return data. This procedure ensures that month $t$ information is available in month $t+1$. You may be tempted to simply use a call such as `crsp_monthly.with_columns(beta_lag=pl.col("beta").shift(1).over("permno"))` instead. This procedure, however, does not work correctly if there are implicit missing values in the time series.
 
 ```{python}
+#| label: univariate-portfolio-sorts-lag-beta
 beta_lag = (beta
     .with_columns(date=pl.col("date").dt.offset_by("1mo"))
     .select(["permno", "date", "beta"])
@@ -76,6 +81,7 @@ data_for_sorts = (crsp_monthly
 The first step to conduct portfolio sorts is to calculate periodic breakpoints that you can use to group the stocks into portfolios.\index{Breakpoints} For simplicity, we start with the median lagged market beta as the single breakpoint. We assign portfolios within each date using `qcut()` with the median as the only breakpoint. We then compute the value-weighted returns for each of the two resulting portfolios, which means that the lagged market capitalization determines the weight: we divide the sum of capitalization-weighted excess returns by the sum of weights.
 
 ```{python}
+#| label: univariate-portfolio-sorts-median-portfolios
 beta_portfolios = (data_for_sorts
     .with_columns(
         portfolio=pl.col("beta_lag")
@@ -95,6 +101,7 @@ beta_portfolios = (data_for_sorts
 We can construct a long-short strategy based on the two portfolios: buy the high-beta portfolio and, at the same time, short the low-beta portfolio. Thereby, the overall position in the market is net-zero, i.e., you do not need to invest money to realize this strategy in the absence of frictions.\index{Long-short}
 
 ```{python}
+#| label: univariate-portfolio-sorts-longshort-median
 beta_longshort = (beta_portfolios
     .pivot(values="ret", index="date", on="portfolio")
     .sort("date")
@@ -105,6 +112,7 @@ beta_longshort = (beta_portfolios
 We compute the average return and the corresponding standard error to test whether the long-short portfolio yields on average positive or negative excess returns. In the asset pricing literature, one typically adjusts for autocorrelation by using @Newey1987 $t$-statistics to test the null hypothesis that average portfolio excess returns are equal to zero.\index{Standard errors!Newey-West} One necessary input for Newey-West standard errors is a chosen bandwidth based on the number of lags employed for the estimation. Researchers often default to choosing a pre-specified lag length of six months (which is not a data-driven approach). We do so in the `fit()` function by indicating the `cov_type` as `HAC` and providing the maximum lag length through an additional keywords dictionary.
 
 ```{python}
+#| label: univariate-portfolio-sorts-longshort-test-median
 model_fit = (sm.OLS.from_formula(
     formula="long_short ~ 1",
     data=beta_longshort.to_pandas()
@@ -123,6 +131,7 @@ Now, we take portfolio sorts to the next level. We want to be able to sort stock
 In some applications, the variable used for the sorting might be clustered (e.g., at a lower bound of 0). Then, multiple breakpoints may be identical, leading to empty portfolios. Similarly, some portfolios might have a very small number of stocks at the beginning of the sample. Cases where the number of portfolio constituents differs substantially due to the distribution of the characteristics require careful consideration and, depending on the application, might require customized sorting approaches.
 
 ```{python}
+#| label: univariate-portfolio-sorts-assign-function
 def assign_portfolio(sorting_variable, n_portfolios):
     """Assign portfolios to a bin between breakpoints."""
 
@@ -140,6 +149,7 @@ def assign_portfolio(sorting_variable, n_portfolios):
 We can use the above function to sort stocks into ten portfolios each month using lagged betas and compute value-weighted returns for each portfolio. Note that we cast the portfolio column to an ordered categorical (`pl.Enum`) because it provides more convenience for the figure construction below.
 
 ```{python}
+#| label: univariate-portfolio-sorts-decile-portfolios
 portfolio_labels = pl.Enum([str(i) for i in range(1, 11)])
 
 beta_portfolios = (data_for_sorts
@@ -161,6 +171,7 @@ beta_portfolios = (data_for_sorts
 In the next step, we compute summary statistics for each beta portfolio. Namely, we compute CAPM-adjusted alphas, the beta of each beta portfolio, and average returns.\index{Performance evaluation}\index{Alpha}\index{CAPM}
 
 ```{python}
+#| label: univariate-portfolio-sorts-portfolio-summary
 beta_portfolios_summary = []
 for portfolio, portfolio_data in beta_portfolios.group_by("portfolio"):
     model_fit = (sm.OLS.from_formula(
@@ -252,6 +263,7 @@ sml_figure.show()
 To provide more evidence against the CAPM predictions, we again form a long-short strategy that buys the high-beta portfolio and shorts the low-beta portfolio.
 
 ```{python}
+#| label: univariate-portfolio-sorts-longshort-deciles
 beta_longshort = (beta_portfolios
   .with_columns(
     portfolio=pl.when(pl.col("portfolio") == pl.col("portfolio").max())
@@ -271,6 +283,7 @@ beta_longshort = (beta_portfolios
 Again, the resulting long-short strategy does not exhibit statistically significant returns. 
 
 ```{python}
+#| label: univariate-portfolio-sorts-longshort-test
 model_fit = (sm.OLS.from_formula(
     formula="long_short ~ 1",
     data=beta_longshort.to_pandas()
@@ -283,6 +296,7 @@ prettify_result(model_fit)
 However, controlling for the effect of beta, the long-short portfolio yields a statistically significant negative CAPM-adjusted alpha, although the average excess stock returns should be zero according to the CAPM. The results thus provide no evidence in support of the CAPM. The negative value has been documented as the so-called betting-against-beta factor [@Frazzini2014]. Betting-against-beta corresponds to a strategy that shorts high-beta stocks and takes a (levered) long position in low-beta stocks. If borrowing constraints prevent investors from taking positions on the security market line they are instead incentivized to buy high-beta stocks, which leads to a relatively higher price (and therefore lower expected returns than implied by the CAPM) for such high-beta stocks. As a result, the betting-against-beta strategy earns from providing liquidity to capital-constrained investors with lower risk aversion.\index{Risk aversion}\index{Betting-against-beta}
 
 ```{python}
+#| label: univariate-portfolio-sorts-longshort-capm
 model_fit = (sm.OLS.from_formula(
     formula="long_short ~ 1 + mkt_excess",
     data=beta_longshort.to_pandas()

--- a/python/value-and-bivariate-sorts.qmd
+++ b/python/value-and-bivariate-sorts.qmd
@@ -6,6 +6,7 @@ metadata:
 ---
 
 ```{python}
+#| label: value-and-bivariate-sorts-setup
 #| echo: false
 exec(open("python/render-settings.py").read())
 ```
@@ -21,6 +22,7 @@ We form portfolios on firm size and the book-to-market ratio. To calculate book-
 The current chapter relies on this set of Python packages. 
 
 ```{python}
+#| label: value-and-bivariate-sorts-packages
 import polars as pl
 import numpy as np
 
@@ -29,6 +31,7 @@ from mizani.formatters import percent_format
 ```
 
 ```{python}
+#| label: value-and-bivariate-sorts-render-plotnine
 #| echo: false
 exec(open("python/render-plotnine-custom.py").read())
 ```
@@ -40,6 +43,7 @@ Compared to previous chapters, we rely on `numpy` to construct evenly spaced bre
 First, we load the necessary data from our Parquet files introduced in [Accessing and Managing Financial Data](accessing-and-managing-financial-data.qmd) and [WRDS, CRSP, and Compustat](wrds-crsp-and-compustat.qmd). We conduct portfolio sorts based on the CRSP sample but keep only the necessary columns in our memory. We use the same data sources for firm size as in [Size Sorts and P-Hacking](size-sorts-and-p-hacking.qmd).\index{Data!CRSP}\index{Data!Fama-French factors}
 
 ```{python}
+#| label: value-and-bivariate-sorts-load-crsp
 crsp_monthly = (
     pl.read_parquet("data-python/crsp_monthly.parquet")
     .select(["permno", "gvkey", "date", "ret_excess", "mktcap",
@@ -51,6 +55,7 @@ crsp_monthly = (
 Further, we utilize accounting data. The most common source of accounting data is Compustat. We only need book equity data in this application, which we select from our local folder. We keep only firms with positive book equity, which is a common practice when working with book-to-market ratios [see @Fama1992 for details].\index{Book equity} Additionally, we convert the variable `datadate` to its monthly value, as we only consider monthly returns here and do not need to account for the exact date.\index{Data!Compustat}
 
 ```{python}
+#| label: value-and-bivariate-sorts-load-book-equity
 book_equity = (pl.read_parquet("data-python/compustat_annual.parquet")
     .select(["gvkey", "datadate", "be"])
     .filter(pl.col("be") > 0)
@@ -70,6 +75,7 @@ As in the previous chapter, we continue to lag firm size by one month.\index{Mar
 Having both variables, i.e., firm size lagged by one month and book-to-market lagged by six months, we merge these sorting variables to our returns using the `sorting_date`-column created for this purpose. The final step in our data preparation deals with differences in the frequency of our variables. Returns and firm size are recorded monthly. Yet, the accounting information is only released on an annual basis. Hence, we only match book-to-market to one month per year and have eleven empty observations. To solve this frequency issue, we carry the latest book-to-market ratio of each firm to the subsequent months, i.e., we fill the missing observations with the most current report. This is done via the `forward_fill()`-expression after sorting by date and firm (which we identify by `permno` and `gvkey`) and on a firm basis (which we do by adding `.over(["permno", "gvkey"])` as usual). We filter out all observations with accounting data that is older than a year. As the last step, we remove all rows with missing entries because the returns cannot be matched to any annual report.
 
 ```{python}
+#| label: value-and-bivariate-sorts-prepare-data
 size = (crsp_monthly
     .with_columns(sorting_date=pl.col("date").dt.offset_by("1mo"))
     .rename({"mktcap": "size"})
@@ -115,6 +121,7 @@ data_for_sorts = (data_for_sorts
 The last step of preparation for the portfolio sorts is the computation of breakpoints.\index{Breakpoints} We continue to use the same function, allowing for the specification of exchanges to be used for the breakpoints. Additionally, we reintroduce the argument `sorting_variable` into the function for defining different sorting variables.
 
 ```{python}
+#| label: value-and-bivariate-sorts-assign-portfolio
 def assign_portfolio(data, exchanges, sorting_variable, n_portfolios):
     """Assign portfolio for a given sorting variable."""
 
@@ -159,6 +166,7 @@ Bivariate sorts create portfolios within a two-dimensional space spanned by two 
 To implement the independent bivariate portfolio sort, we assign monthly portfolios for each of our sorting variables separately to create the variables `portfolio_bm` and `portfolio_size`, respectively.\index{Portfolio sorts!Independent bivariate} Then, these separate portfolios are combined to the final sort stored in `portfolio_combined`. After assigning the portfolios, we compute the average return within each portfolio for each month. Additionally, we keep the book-to-market portfolio as it makes the computation of the value premium easier. The alternative would be to disaggregate the combined portfolio in a separate step. Notice that we weigh the stocks within each portfolio by their market capitalization, i.e., we decide to value-weight our returns.
 
 ```{python}
+#| label: value-and-bivariate-sorts-independent-portfolios
 value_portfolios = (data_for_sorts
     .group_by("date")
     .map_groups(lambda x: x.with_columns(
@@ -181,6 +189,7 @@ value_portfolios = (data_for_sorts
 Equipped with our monthly portfolio returns, we are ready to compute the value premium. However, we still have to decide how to invest in the five high and the five low book-to-market portfolios. The most common approach is to weigh these portfolios equally, but this is yet another researcher's choice. Then, we compute the return differential between the high and low book-to-market portfolios and show the average value premium.
 
 ```{python}
+#| label: value-and-bivariate-sorts-independent-value-premium
 value_premium = (value_portfolios
     .group_by(["date", "portfolio_bm"])
     .agg(ret=pl.col("ret").mean())
@@ -205,6 +214,7 @@ In the previous exercise, we assigned the portfolios without considering the sec
 To implement the dependent sorts, we first create the size portfolios by calling `assign_portfolio()` with `sorting_variable="size"`. Then, we group our data again by month and by the size portfolio before assigning the book-to-market portfolio. The rest of the implementation is the same as before. Finally, we compute the value premium.
 
 ```{python}
+#| label: value-and-bivariate-sorts-dependent-portfolios
 value_portfolios = (
     data_for_sorts.group_by("date")
     .map_groups(
@@ -265,6 +275,7 @@ So far, we have focused exclusively on the returns of our portfolios. Yet the wa
 We start with the independent assignment. As before, we group by month and assign the size and book-to-market portfolios separately.
 
 ```{python}
+#| label: value-and-bivariate-sorts-assignments-independent
 assignments_independent = (data_for_sorts
     .group_by("date")
     .map_groups(lambda x: x.with_columns(
@@ -283,6 +294,7 @@ assignments_independent = (data_for_sorts
 For the dependent assignment, we again first form the size portfolios and then assign book-to-market portfolios within each size bucket, so that the book-to-market breakpoints are specific to each size group.
 
 ```{python}
+#| label: value-and-bivariate-sorts-assignments-dependent
 assignments_dependent = (data_for_sorts
     .group_by("date")
     .map_groups(lambda x: x.with_columns(
@@ -305,6 +317,7 @@ assignments_dependent = (data_for_sorts
 Next, we stack both assignments and compute the characteristics of interest. For each month and portfolio, we count the number of stocks and sum their lagged market capitalization. We then average these monthly figures across the whole sample to obtain one value per portfolio. Finally, we express market capitalization as a share of the total within each sorting method, which makes the concentration of market value across the grid directly comparable.
 
 ```{python}
+#| label: value-and-bivariate-sorts-portfolio-characteristics
 portfolio_characteristics = (
     pl.concat([assignments_independent, assignments_dependent])
     .group_by(["sorting_method", "date", "portfolio_size", "portfolio_bm"])
@@ -390,6 +403,7 @@ So far, we have focused exclusively on the returns of our portfolios. Yet the wa
 We start with the independent assignment. As before, we group by month and assign the size and book-to-market portfolios separately.
 
 ```{python}
+#| label: value-and-bivariate-sorts-assignments-independent-pandas
 assignments_independent = (data_for_sorts
     .groupby("date")
     .apply(lambda x: x.assign(
@@ -409,6 +423,7 @@ assignments_independent = (data_for_sorts
 For the dependent assignment, we again first form the size portfolios and then assign book-to-market portfolios within each size bucket, so that the book-to-market breakpoints are specific to each size group.
 
 ```{python}
+#| label: value-and-bivariate-sorts-assignments-dependent-pandas
 assignments_dependent = (data_for_sorts
     .groupby("date")
     .apply(lambda x: x.assign(
@@ -433,6 +448,7 @@ assignments_dependent = (data_for_sorts
 Next, we stack both assignments and compute the characteristics of interest. For each month and portfolio, we count the number of stocks and sum their lagged market capitalization. We then average these monthly figures across the whole sample to obtain one value per portfolio. Finally, we express market capitalization as a share of the total within each sorting method, which makes the concentration of market value across the grid directly comparable.
 
 ```{python}
+#| label: value-and-bivariate-sorts-portfolio-characteristics-pandas
 portfolio_characteristics = (
     pd.concat([assignments_independent, assignments_dependent])
     .groupby(

--- a/python/working-with-stock-returns.qmd
+++ b/python/working-with-stock-returns.qmd
@@ -8,6 +8,7 @@ metadata:
 ---
 
 ```{python}
+#| label: working-with-stock-returns-setup
 #| echo: false
 exec(open("python/render-settings.py").read())
 ```
@@ -23,6 +24,7 @@ At the start of each session, we load the required Python packages. Throughout t
 You typically have to install a package once before you can load it into your active Python session. In case you have not done this yet, call, for instance, `pip install polars tidyfinance` in your terminal.\index{tidyfinance}
 
 ```{python}
+#| label: working-with-stock-returns-packages
 import polars as pl
 import tidyfinance as tf
 ```
@@ -38,6 +40,7 @@ In the following code, we request daily data from the beginning of 2000 to the e
 Because `tf.download_data()` returns a `pandas` data frame, we wrap the call in `pl.from_pandas()` to obtain a `polars` data frame that we work with for the rest of the chapter. Since `pandas` represents dates as timestamps, we also cast the `date` column to the `polars` `Date` type — daily prices are calendar-dated, and we use this convention throughout the book.
 
 ```{python}
+#| label: working-with-stock-returns-download-apple
 prices = pl.from_pandas(
     tf.download_data(
         domain="stock_prices",
@@ -54,10 +57,12 @@ prices.head()
 Next, we use the `plotnine` package [@plotnine] to visualize the time series of adjusted prices in @fig-100. This package takes care of visualization tasks based on the principles of the grammar of graphics [@Wilkinson2012].\index{Graph!Time series} Note that generally, we do not recommend using the `*` import style. However, we use it here only for the plotting functions, which are distinct to `plotnine` and have very plotting-related names. So, the risk of misuse through a polluted namespace is marginal.
 
 ```{python}
+#| label: working-with-stock-returns-import-plotnine
 from plotnine import *
 ```
 
 ```{python}
+#| label: working-with-stock-returns-render-plotnine
 #| echo: false
 exec(open("python/render-plotnine-custom.py").read())
 ```
@@ -81,6 +86,7 @@ apple_prices_figure.show()
 Instead of analyzing prices, we compute daily returns defined as $r_t = p_t / p_{t-1} - 1$, where $p_t$ is the adjusted price at the end of day $t$.\index{Returns} In that context, the function `lag()` is helpful by returning the previous value.
 
 ```{python}
+#| label: working-with-stock-returns-compute-returns
 returns = (prices
     .sort("date")
     .with_columns(ret=pl.col("adjusted_close").pct_change())
@@ -94,6 +100,7 @@ The resulting data frame has three columns, the last of which contains the daily
 For the upcoming examples, we remove missing values as these would require separate treatment for many applications. For example, missing values can affect sums and averages by reducing the number of valid data points if not properly accounted for. In general, always ensure you understand why `NaN` values occur and carefully examine if you can simply get rid of these observations.
 
 ```{python}
+#| label: working-with-stock-returns-drop-nulls
 returns = returns.drop_nulls()
 ```
 
@@ -120,6 +127,7 @@ apple_returns_figure.show()
 Here, `bins=100` determines the number of bins used in the illustration and, hence, implicitly sets the width of the bins. Before proceeding, make sure you understand how to use the geom `geom_vline()` to add a dashed line that indicates the historical five percent quantile of the daily returns. Before proceeding with *any* data, a typical task is to compute and analyze the summary statistics for the main variables of interest.
 
 ```{python}
+#| label: working-with-stock-returns-describe
 returns.select("ret").describe()
 ```
 
@@ -128,6 +136,7 @@ We see that the maximum *daily* return was `{python} round(returns["ret"].max()*
 You can also compute these summary statistics for each year individually by grouping with `group_by(pl.col("date").dt.year())`, where the call `dt.year()` extracts the year. More specifically, the few lines of code below compute the summary statistics from above for individual groups of data defined by the values of the column year. Unlike `pandas`, `polars` has no single `describe()` per group, so we list the desired statistics explicitly inside `agg()`. The summary statistics, therefore, allow an eyeball analysis of the time-series dynamics of the daily return distribution.\index{Summary statistics}
 
 ```{python}
+#| label: working-with-stock-returns-yearly-summary
 (returns
     .group_by(pl.col("date").dt.year().alias("year"))
     .agg(
@@ -154,6 +163,7 @@ This is where the `tidyverse` magic starts: Tidy data makes it extremely easy to
 We first download a table with Dow Jones constituents again using `tf.download_data()`, but this time with `domain="constituents"`.
 
 ```{python}
+#| label: working-with-stock-returns-download-constituents
 symbols = pl.from_pandas(
     tf.download_data(
         domain="constituents",
@@ -165,6 +175,7 @@ symbols = pl.from_pandas(
 Conveniently, `tf.download_data()` provides the functionality to get all stock prices from an index for a specific point in time with a single call.\index{Exchange!NASDAQ}
 
 ```{python}
+#| label: working-with-stock-returns-download-index
 prices_daily = pl.from_pandas(
     tf.download_data(
         domain="stock_prices",
@@ -196,6 +207,7 @@ Do you notice the small differences relative to the code we used before? All we 
 The same holds for stock returns. Before computing the returns, we sort by symbol and date and add `.over("symbol")` to the `pct_change()` expression, so that returns are computed within each symbol individually without bleeding across symbol boundaries. The same logic also applies to the computation of summary statistics: `group_by("symbol")` is the key to aggregating the time series into symbol-specific variables of interest.\index{Summary statistics}
 
 ```{python}
+#| label: working-with-stock-returns-multi-symbol-summary
 returns_daily = (prices_daily
     .sort("symbol", "date")
     .with_columns(ret=pl.col("adjusted_close").pct_change().over("symbol"))
@@ -227,6 +239,7 @@ Financial data often exists at different frequencies due to varying reporting sc
 So far, we have worked with daily returns, but we can easily convert our data to other frequencies. Let's create monthly returns from our daily data:
 
 ```{python}
+#| label: working-with-stock-returns-monthly-returns
 returns_monthly = (returns_daily
     .with_columns(date=pl.col("date").dt.truncate("1mo"))
     .group_by(["symbol", "date"])

--- a/python/wrds-crsp-and-compustat.qmd
+++ b/python/wrds-crsp-and-compustat.qmd
@@ -6,6 +6,7 @@ metadata:
 ---
 
 ```{python}
+#| label: wrds-crsp-and-compustat-setup
 #| echo: false
 exec(open("python/render-settings.py").read())
 ```
@@ -21,6 +22,7 @@ If you don't have access to WRDS but still want to run the code in this book, we
 First, we load the Python packages that we use throughout this chapter. Later on, we load more packages in the sections where we need them. The last two packages are used for plotting.
 
 ```{python}
+#| label: wrds-crsp-and-compustat-packages
 import polars as pl
 import numpy as np
 import tidyfinance as tf
@@ -33,6 +35,7 @@ from datetime import datetime
 ```
 
 ```{python}
+#| label: wrds-crsp-and-compustat-render-plotnine
 #| echo: false
 exec(open("python/render-plotnine-custom.py").read()) 
 ```
@@ -40,6 +43,7 @@ exec(open("python/render-plotnine-custom.py").read())
 We use the same date range as in the previous chapter to ensure consistency. However, we have to use the date format that the WRDS database expects.
 
 ```{python}
+#| label: wrds-crsp-and-compustat-date-range
 start_date = "01/01/1960"
 end_date = "12/31/2024"
 ```
@@ -49,6 +53,7 @@ end_date = "12/31/2024"
 WRDS is the most widely used source for asset and firm-specific financial data used in academic settings. WRDS is a data platform that provides data validation, flexible delivery options, and access to many different data sources. The data at WRDS is organized in an SQL database, although they use the [PostgreSQL](https://www.postgresql.org/) engine. This database engine is just as easy to handle with Python as SQL. We use the `sqlalchemy` package to establish a connection to the WRDS database because it already contains a suitable driver.^[An alternative to establish a connection to WRDS is to use the `WRDS-Py` library. We chose to work with `sqlalchemy` [@sqlalchemy] to show how to access PostgreSQL engines  in general.]\index{Database!PostgreSQL} 
 
 ```{python}
+#| label: wrds-crsp-and-compustat-sqlalchemy-import
 #| eval: false
 from sqlalchemy import create_engine
 ```
@@ -58,6 +63,7 @@ To establish a connection to WRDS, you use the function `create_engine()` with a
 Additionally, you have to use two-factor authentication since May 2023 when establishing a remote connection to WRDS. You have two choices to provide the additional identification. First, if you have Duo Push enabled for your WRDS account, you will receive a push notification on your mobile phone when trying to establish a connection with the code below. Upon accepting the notification, you can continue your work. Second, you can log in to a WRDS website that requires two-factor authentication with your username and the same IP address. Once you have successfully identified yourself on the website, your username-IP combination will be remembered for 30 days, and you can comfortably use the remote connection below.\index{Two-factor authentication}\index{WRDS!Two-factor authentication}
 
 ```{python}
+#| label: wrds-crsp-and-compustat-wrds-connection
 #| eval: false
 #| output: false
 import os
@@ -81,6 +87,7 @@ wrds = create_engine(connection_url, pool_pre_ping=True)
 You can also use the `tidyfinance` package to set the login credentials and create a connection.
 
 ```{python}
+#| label: wrds-crsp-and-compustat-tidyfinance-connection
 #| eval: false
 tf.set_wrds_credentials()
 wrds = tf.get_wrds_connection()
@@ -95,6 +102,7 @@ The remote connection to WRDS is very useful. Yet, the database itself contains 
 We use the two remote tables to fetch the data we want to put into our local folder. Just as above, the idea is that we let the WRDS database do all the work and just download the data that we actually need. We apply common filters and data selection criteria to narrow down our data of interest: (i) we use only stock prices from NYSE, Amex, and NASDAQ (`primaryexch %in% c("N", "A", "Q")`) when or after issuance (`conditionaltype %in% c("RW", "NW")`) for actively traded stocks (`tradingstatusflg == "A"`)^[These three criteria jointly replicate the filter `exchcd %in% c(1, 2, 3, 31, 32, 33)` used for the legacy version of CRSP. If you do not want to include stocks at issuance, you can set the `conditionaltype == "RW"`, which is equivalent to the restriction of `exchcd %in% c(1, 2, 3)` with the old CRSP format.], (ii) we keep only data in the time windows of interest, (iii) we keep only US-listed stocks as identified via no special share types (`sharetype = 'NS'`), security type equity (`securitytype = 'EQTY'`), security sub type common stock (`securitysubtype = 'COM'`), issuers that are a corporation (`issuertype %in% c("ACOR", "CORP")`), and (iv) we keep only months within permno-specific start dates (`secinfostartdt`) and end dates (`secinfoenddt`). As of July 2022, there is no need to additionally download delisting information since it is already contained in the most recent version of `msf` (see our blog post about [CRSP 2.0](../blog/crsp-v2-update/index.qmd) for more information). We refer to @SchwarzEtAl2026 for details on the changes in the CRSP tape rolled out in 2025. Additionally, the industry information in `stksecurityinfohist` records the historic industry and should be used instead of the one stored under same variable name in `msf_v2`.\index{Permno}\index{Returns!Delisting}\index{Industry codes}
 
 ```{python}
+#| label: wrds-crsp-and-compustat-crsp-monthly-query
 #| eval: false
 crsp_monthly_query = (
   "SELECT msf.permno, date_trunc('month', msf.mthcaldt)::date AS date, "
@@ -132,6 +140,7 @@ Now, we have all the relevant monthly return data in memory and proceed with pre
 The first additional variable we create is market capitalization (`mktcap`), which is the product of the number of outstanding shares (`shrout`) and the last traded price in a month (`prc`).\index{Market capitalization} Note that in contrast to returns (`ret`), these two variables are not adjusted ex-post for any corporate actions like stock splits. Therefore, if you want to use a stock's price, you need to adjust it with a cumulative adjustment factor.  We also keep the market cap in millions of USD just for convenience, as we do not want to print huge numbers in our figures and tables. In addition, we set zero market capitalization to missing as it makes conceptually little sense (i.e., the firm would be bankrupt).\index{Stock price}\index{Returns}
 
 ```{python}
+#| label: wrds-crsp-and-compustat-compute-mktcap
 #| eval: false
 crsp_monthly = (crsp_monthly
     .with_columns(mktcap=pl.col("shrout")*pl.col("prc")/1000000)
@@ -146,6 +155,7 @@ crsp_monthly = (crsp_monthly
 The next variable we frequently use is the one-month *lagged* market capitalization. Lagged market capitalization is typically used to compute value-weighted portfolio returns, as we demonstrate in a later chapter. The most simple and consistent way to add a column with lagged market cap values is to add one month to each observation and then join the information to our monthly CRSP data.\index{Weighting!Value}
 
 ```{python}
+#| label: wrds-crsp-and-compustat-lag-mktcap
 #| eval: false
 mktcap_lag = (crsp_monthly
     .with_columns(
@@ -163,6 +173,7 @@ crsp_monthly = (crsp_monthly
 Next, we transform primary listing exchange codes to explicit exchange names.\index{Exchange!Exchange codes}
 
 ```{python}
+#| label: wrds-crsp-and-compustat-exchange-names
 #| eval: false
 crsp_monthly = crsp_monthly.with_columns(
     exchange=pl.when(pl.col("primaryexch") == "N").then(pl.lit("NYSE"))
@@ -175,6 +186,7 @@ crsp_monthly = crsp_monthly.with_columns(
 Similarly, we transform industry codes to industry descriptions following @BaliEngleMurray2016.\index{Industry codes} Notice that there are also other categorizations of industries [e.g., @FamaFrench1997] that are commonly used.
 
 ```{python}
+#| label: wrds-crsp-and-compustat-industry-names
 #| eval: false
 crsp_monthly = crsp_monthly.with_columns(
     industry=pl.when(pl.col("siccd").is_between(1, 999)).then(pl.lit("Agriculture"))
@@ -195,6 +207,7 @@ crsp_monthly = crsp_monthly.with_columns(
 Next, we compute excess returns by subtracting the monthly risk-free rate provided by our Fama-French data.\index{Returns!Excess}\index{Risk-free rate} As we base all our analyses on the excess returns, we can drop the risk-free rate from our data frame. Note that we ensure excess returns are bounded by -1 from below as a return less than -100% makes no sense conceptually. Before we can adjust the returns, we load the data frame `factors_ff3_monthly`.
 
 ```{python}
+#| label: wrds-crsp-and-compustat-excess-returns
 #| eval: false
 factors_ff3_monthly = (pl.read_parquet("data-python/factors_ff3_monthly.parquet")
     .select(["date", "risk_free"])
@@ -210,6 +223,7 @@ crsp_monthly = (crsp_monthly
 The `tidyfinance` package provides a shortcut to implement all these processing steps from above:
 
 ```{python}
+#| label: wrds-crsp-and-compustat-tidyfinance-crsp-monthly
 #| eval: false
 crsp_monthly = pl.from_pandas(tf.download_data(
     domain="wrds",
@@ -222,6 +236,7 @@ crsp_monthly = pl.from_pandas(tf.download_data(
 Since excess returns and market capitalization are crucial for all our analyses, we can safely exclude all observations with missing returns or market capitalization. 
 
 ```{python}
+#| label: wrds-crsp-and-compustat-drop-nulls
 #| eval: false
 crsp_monthly = (crsp_monthly
     .drop_nulls(subset=["ret_excess", "mktcap", "mktcap_lag"])
@@ -231,12 +246,14 @@ crsp_monthly = (crsp_monthly
 Finally, we store the monthly CRSP file in our folder.
 
 ```{python}
+#| label: wrds-crsp-and-compustat-write-crsp-monthly
 #| eval: false
 #| output: false
 crsp_monthly.write_parquet("data-python/crsp_monthly.parquet")
 ```
 
 ```{python}
+#| label: wrds-crsp-and-compustat-read-crsp-monthly
 #| eval: true
 crsp_monthly = pl.read_parquet("data-python/crsp_monthly.parquet")
 ```
@@ -377,6 +394,7 @@ Before we turn to accounting data, we provide a proposal for downloading daily C
 There is a solution to this challenge. As with many *big data* problems, you can split up the big task into several smaller tasks that are easier to handle.\index{Big data} That is, instead of downloading data about all stocks at once, download the data in small batches of stocks consecutively. Such operations can be implemented in `for`-loops,\index{For-loops} where we download, prepare, and store the data for a small number of stocks in each iteration. This operation might nonetheless take around 5 minutes, depending on your internet connection. To keep track of the progress, we create ad-hoc progress updates using `print()`. Notice that we also use the method `to_sql()` here with the option to append the new data to an existing table, when we process the second and all following batches. As for the monthly CRSP data, there is no need to adjust for delisting returns in the daily CRSP data since July 2022.\index{Returns!Delisting}
 
 ```{python}
+#| label: wrds-crsp-and-compustat-crsp-daily-loop
 #| output: false
 #| eval: false
 factors_ff3_daily = pl.read_parquet("data-python/factors_ff3_daily.parquet")
@@ -457,6 +475,7 @@ Eventually, we end up with more than 72 million rows of daily return data. Note 
 To download the daily CRSP data via the `tidyfinance` package, you can call:
 
 ```{python}
+#| label: wrds-crsp-and-compustat-tidyfinance-crsp-daily
 #| eval: false
 crsp_daily = pl.from_pandas(tf.download_data(
     domain="wrds",
@@ -475,6 +494,7 @@ Firm accounting data are an important source of information that we use in portf
 To access Compustat data, we can again tap WRDS, which hosts the `funda` table that contains annual firm-level information on North American companies. We follow the typical filter conventions and pull only data that we actually need: (i) we get only records in industrial data format, which includes companies that are primarily involved in manufacturing, services, and other non-financial business activities,^[Companies that operate in the banking, insurance, or utilities sector typically report in different industry formats that reflect their specific regulatory requirements.], (ii) in the standard format (i.e., consolidated information in standard presentation), (iii) reported in USD,^[Compustat also contains reports in CAD, which can lead to a currency mismatch, e.g., when relating book equity to market equity.] and (iv) only data in the desired time window.\index{Gvkey}
 
 ```{python}
+#| label: wrds-crsp-and-compustat-compustat-query
 #| eval: false
 compustat_query = (
     "SELECT gvkey, datadate, seq, ceq, at, lt, txditc, txdb, itcb,  pstkrv, "
@@ -499,6 +519,7 @@ compustat_annual = (pl.read_database(
 Next, we calculate the book value of preferred stock and equity `be` and the operating profitability `op` inspired by the [variable definitions in Kenneth French's data library.](https://mba.tuck.dartmouth.edu/pages/faculty/ken.french/data_library.html)\index{Book equity}\index{Preferred stock}\index{Operating profitability}
 
 ```{python}
+#| label: wrds-crsp-and-compustat-compute-be-op
 #| eval: false
 compustat_annual = (compustat_annual
     .with_columns(
@@ -524,6 +545,7 @@ compustat_annual = (compustat_annual
 We keep only the last available information for each firm-year group (by using `tail(1)` for each group). Note that `datadate` defines the time the corresponding financial data refers to (e.g., annual report as of December 31, 2022). Therefore, `datadate` is not the date when data was made available to the public. Check out the Exercises for more insights into the peculiarities of `datadate`.
 
 ```{python}
+#| label: wrds-crsp-and-compustat-keep-last-firm-year
 #| eval: false
 compustat_annual = (
     compustat_annual.with_columns(year=pl.col("datadate").dt.year().cast(pl.Float64))
@@ -536,6 +558,7 @@ compustat_annual = (
 We also compute the investment ratio (`inv`) according to Kenneth French's variable definitions as the change in total assets from one fiscal year to another. Note that we again use the approach using joins as introduced with the CRSP data above to construct lagged assets.\index{Investment ratio}
 
 ```{python}
+#| label: wrds-crsp-and-compustat-compute-investment
 #| eval: false
 compustat_annual_lag = (compustat_annual
     .select(["gvkey", "year", "at"])
@@ -555,6 +578,7 @@ compustat_annual = (compustat_annual
 With the last step, we are already done preparing the firm fundamentals. Thus, we can store them in our local folder. 
 
 ```{python}
+#| label: wrds-crsp-and-compustat-write-compustat
 #| output: false
 #| eval: false
 compustat_annual.write_parquet("data-python/compustat_annual.parquet")
@@ -563,6 +587,7 @@ compustat_annual.write_parquet("data-python/compustat_annual.parquet")
 The `tidyfinance` package provides a shortcut for these processing steps as well:
 
 ```{python}
+#| label: wrds-crsp-and-compustat-tidyfinance-compustat
 #| eval: false
 compustat_annual = pl.from_pandas(tf.download_data(
     domain="wrds",
@@ -573,6 +598,7 @@ compustat_annual = pl.from_pandas(tf.download_data(
 ```
 
 ```{python}
+#| label: wrds-crsp-and-compustat-read-compustat
 #| eval: true
 compustat_annual = pl.read_parquet("data-python/compustat_annual.parquet")
 ```
@@ -582,6 +608,7 @@ compustat_annual = pl.read_parquet("data-python/compustat_annual.parquet")
 Unfortunately, CRSP and Compustat use different keys to identify stocks and firms. CRSP uses `permno` for stocks, while Compustat uses `gvkey` to identify firms. Fortunately, a curated matching table on WRDS allows us to merge CRSP and Compustat, so we create a connection to the *CRSP-Compustat Merged* table (provided by CRSP).\index{Data!CRSP-Compustat Merged}\index{Permno}\index{Gvkey}\index{Data!Linking table} The linking table contains links between CRSP and Compustat identifiers from various approaches. However, we need to make sure that we keep only relevant and correct links, again following the description outlined in @BaliEngleMurray2016. Note also that currently active links have no end date, so we just enter the current date via the SQL verb `CURRENT_DATE`.
 
 ```{python}
+#| label: wrds-crsp-and-compustat-ccm-linking-query
 #| eval: false
 ccm_linking_table_query = (
     "SELECT lpermno AS permno, gvkey, linkdt, "
@@ -601,6 +628,7 @@ ccm_linking_table = pl.read_database(
 To fetch these links via `tidyfinance`, you can call:
 
 ```{python}
+#| label: wrds-crsp-and-compustat-tidyfinance-ccm-links
 #| eval: false
 ccm_links = pl.from_pandas(tf.download_data(domain="wrds", dataset="ccm_links"))
 ```
@@ -608,6 +636,7 @@ ccm_links = pl.from_pandas(tf.download_data(domain="wrds", dataset="ccm_links"))
 We use these links to create a new table with a mapping between stock identifier, firm identifier, and month. We then add these links to the Compustat `gvkey` to our monthly stock data.
 
 ```{python}
+#| label: wrds-crsp-and-compustat-merge-ccm-links
 #| eval: false
 ccm_links = (crsp_monthly
     .join(ccm_linking_table, how="inner", on="permno")
@@ -627,6 +656,7 @@ crsp_monthly = (crsp_monthly
 As the last step, we update the previously prepared monthly CRSP file with the linking information in our local folder.
 
 ```{python}
+#| label: wrds-crsp-and-compustat-write-crsp-merged
 #| eval: false
 #| output: false
 crsp_monthly.write_parquet("data-python/crsp_monthly.parquet")

--- a/python/wrds-dummy-data.qmd
+++ b/python/wrds-dummy-data.qmd
@@ -13,6 +13,7 @@ We deliberately use the pseudo label because the data is not meaningful in the s
 To generate the pseudo data, we use the following packages:
 
 ```{python}
+#| label: wrds-dummy-data-packages
 import polars as pl
 import numpy as np
 import string
@@ -21,6 +22,7 @@ import string
 We store the data in the folder `data-python`. Be careful, if you already downloaded the data from WRDS, then the code in this chapter will overwrite your data!
 
 ```{python}
+#| label: wrds-dummy-data-create-folder
 import os
 
 if not os.path.exists("data-python"):
@@ -30,6 +32,7 @@ if not os.path.exists("data-python"):
 Since we draw random numbers for most of the columns, we also define a seed to ensure that the generated numbers are replicable. We also initialize vectors of dates of different frequencies over ten years that we then use to create yearly, monthly, and daily data, respectively. 
 
 ```{python}
+#| label: wrds-dummy-data-seed-and-dates
 np.random.seed(1234)
 
 start_date = pl.date(2003, 1, 1)
@@ -49,6 +52,7 @@ pseudo_days = pl.date_range(
 Let us start with the core data used throughout the book: stock and firm characteristics. We first generate a table with a cross-section of stock identifiers with unique `permno` and `gvkey` values, as well as associated `exchcd`, `exchange`, `industry`, and `siccd` values. The generated data is based on the characteristics of stocks in the `crsp_monthly` table of the original data, ensuring that the generated stocks roughly reflect the distribution of industries and exchanges in the original data, but the identifiers and corresponding exchanges or industries do not reflect actual firms. Similarly, the `permno`-`gvkey` combinations are purely nonsensical and should not be used together with actual CRSP or Compustat data.
 
 ```{python}
+#| label: wrds-dummy-data-stock-identifiers
 number_of_stocks = 100
 
 industries = pl.DataFrame(
@@ -141,6 +145,7 @@ Next, we construct the `stock_panel_monthly` panel. Similar to the yearly panel,
 Lastly, we create the `stock_panel_daily` panel. We combine `stock_identifiers` with a table containing the `date` variable from `pseudo_days`. After merging, we retain only the `permno` and `date` columns for our daily panel.
 
 ```{python}
+#| label: wrds-dummy-data-stock-panels
 stock_panel_yearly = pl.DataFrame(
     {
         "gvkey": np.tile(stock_identifiers["gvkey"], len(pseudo_years)),
@@ -173,6 +178,7 @@ stock_panel_daily = pl.DataFrame(
 We then proceed to create pseudo beta values for our `stock_panel_monthly` table. We generate monthly beta values `beta_monthly` using the `rnorm()` function with a mean and standard deviation of 1. For daily beta values `beta_daily`, we take the pseudo monthly beta and add a small random noise to it. This noise is generated again using the `rnorm()` function, but this time we divide the random values by 100 to ensure they are small deviations from the monthly beta.
 
 ```{python}
+#| label: wrds-dummy-data-beta
 beta_pseudo = (stock_panel_monthly
     .with_columns(
         beta_monthly=np.random.normal(
@@ -195,6 +201,7 @@ beta_pseudo.write_parquet("data-python/beta.parquet")
 To create pseudo annual firm characteristics, we take all columns from the `compustat_annual` table and create random numbers between 0 and 1. For simplicity, we set the `datadate` for each firm-year observation to the last day of the year, although it is empirically not the case. \index{Data!Compustat}
 
 ```{python}
+#| label: wrds-dummy-data-compustat-annual
 relevant_columns = [
     "seq",
     "ceq",
@@ -237,6 +244,7 @@ compustat_pseudo.write_parquet("data-python/compustat_annual.parquet")
 The `crsp_monthly` table only lacks a few more columns compared to `stock_panel_monthly`: the returns `ret` drawn from a normal distribution, the excess returns `ret_excess` with small deviations from the returns, the shares outstanding `shrout` and the last price per month `prc` both drawn from uniform distributions, and the market capitalization `mktcap` as the product of `shrout` and `prc`. \index{Data!CRSP}
 
 ```{python}
+#| label: wrds-dummy-data-crsp-monthly
 crsp_monthly_pseudo = (
     stock_panel_monthly
     .with_columns(
@@ -263,6 +271,7 @@ crsp_monthly_pseudo.write_parquet("data-python/crsp_monthly.parquet")
 The `crsp_daily` table only contains a `date` column and the daily excess returns `ret_excess` as additional columns to `stock_panel_daily`.  
 
 ```{python}
+#| label: wrds-dummy-data-crsp-daily
 crsp_daily_pseudo = (stock_panel_daily
     .with_columns(
         ret_excess=np.fmax(np.random.normal(size=len(stock_panel_daily)), -1)
@@ -281,6 +290,7 @@ Lastly, we move to the bond data that we use in our books.
 To create pseudo data with the structure of Mergent FISD, we calculate the empirical probabilities of actual bonds for several variables: `maturity`, `offering_amt`, `interest_frequency`, `coupon`, and `sic_code`. We use these probabilities to sample a small cross-section of bonds with completely made up `complete_cusip`, `issue_id`, and `issuer_id`.\index{Data!FISD}
 
 ```{python}
+#| label: wrds-dummy-data-fisd
 # | eval: false
 number_of_bonds = 100
 
@@ -358,6 +368,7 @@ fisd_pseudo.write_parquet("data-python/fisd.parquet")
 Finally, we create a pseudo bond transaction data for the fictional CUSIPs of the pseudo `fisd` data. We take the date range that we also analyze in the book and ensure that we have at least five transactions per day to fulfill a filtering step in the book. \index{Data!TRACE}
 
 ```{python}
+#| label: wrds-dummy-data-trace-enhanced
 number_of_bonds = 100
 start_date = pl.date(2014, 1, 1)
 end_date = pl.date(2016, 11, 30)

--- a/r/accessing-and-managing-financial-data.qmd
+++ b/r/accessing-and-managing-financial-data.qmd
@@ -18,6 +18,7 @@ This chapter shows how to import different open source data sets. Specifically, 
 First, we load the global R packages that we use throughout this chapter. Later on, we load more packages in the sections where we need them.
 
 ```{r}
+#| label: accessing-and-managing-financial-data-packages
 #| message: false
 library(tidyverse)
 library(tidyfinance)
@@ -27,6 +28,7 @@ library(scales)
 Moreover, we initially define the date range for which we fetch and store the financial data, making future data updates tractable. In case you need another time frame, you can adjust the dates below. Our data starts with 1960 since most asset pricing studies use data from 1962 on.
 
 ```{r}
+#| label: accessing-and-managing-financial-data-date-range
 start_date <- ymd("1960-01-01")
 end_date <- ymd("2024-12-31")
 ```
@@ -49,6 +51,7 @@ Doing this once is fine; doing it repeatedly across projects is exactly the kind
 A minimal download script mirrors the manual steps one by one. To fetch a Fama-French dataset, we first construct the URL of the corresponding ZIP archive on Kenneth French's server. Each dataset is identified by the file name of its archive; the *Fama/French 3 Factors* set, for instance, lives in `F-F_Research_Data_Factors_CSV.zip`.
 
 ```{r}
+#| label: accessing-and-managing-financial-data-ff-url
 base_url <- "https://mba.tuck.dartmouth.edu/pages/faculty/ken.french/ftp/"
 file_name <- "F-F_Research_Data_Factors_CSV.zip"
 url <- paste0(base_url, file_name)
@@ -57,6 +60,7 @@ url <- paste0(base_url, file_name)
 Next, we replace the browser download with an HTTP request using the `httr2` [@httr2] package and store the archive in a temporary file. We attach a browser-like user agent because Kenneth French's server rejects requests that do not provide one.\index{httr2}
 
 ```{r}
+#| label: accessing-and-managing-financial-data-download-ff-zip
 #| message: false
 library(httr2)
 
@@ -72,6 +76,7 @@ request(url) |>
 The archive contains a single CSV file, which we extract into a temporary directory and read line by line.
 
 ```{r}
+#| label: accessing-and-managing-financial-data-extract-ff-zip
 tmp_dir <- tempfile()
 dir.create(tmp_dir)
 csv_file <- unzip(tmp_zip, exdir = tmp_dir)[1]
@@ -81,6 +86,7 @@ raw_lines <- readLines(csv_file, warn = FALSE)
 The raw file starts with several lines of descriptive text, followed by one or more data tables (e.g., monthly returns and a block of annual summary rows). To emulate *scrolling down until the numbers start*, we flag every line that begins with a date key---an optional run of spaces followed by a digit---and keep the first contiguous block of such lines. The line directly above that block holds the column names.
 
 ```{r}
+#| label: accessing-and-managing-financial-data-locate-ff-block
 is_data <- grepl("^\\s*[0-9]", raw_lines)
 runs <- rle(is_data)
 first_run <- which(runs$values)[1]
@@ -93,6 +99,7 @@ block <- raw_lines[c(first_data - 1, first_data:last_data)]
 We hand this block to `read.csv()` and label the first (unnamed) column `date`.
 
 ```{r}
+#| label: accessing-and-managing-financial-data-parse-ff3-raw
 factors_ff3_monthly_raw <- read.csv(text = block, check.names = FALSE)
 names(factors_ff3_monthly_raw)[1] <- "date"
 factors_ff3_monthly_raw <- as_tibble(factors_ff3_monthly_raw)
@@ -108,6 +115,7 @@ Finally, we still have to clean the data. The set *Fama/French 3 Factors* contai
 -   Filter the data to the desired date range.
 
 ```{r}
+#| label: accessing-and-managing-financial-data-clean-ff3-monthly
 factors_ff3_monthly <- factors_ff3_monthly_raw |>
   mutate(
     date = floor_date(ymd(str_c(date, "01")), "month"),
@@ -129,6 +137,7 @@ All of these steps are doable, but none of them are really about finance---they 
 The `tidyfinance` package performs the entire workflow above under the hood: you request a Fama-French dataset by name and receive a clean, consistently formatted tibble from Kenneth French's data library. This avoids repetitive boilerplate, reduces errors, and lets you focus on modeling rather than data plumbing. For precise descriptions of the variables, we suggest consulting Prof. Kenneth French's finance data library directly. We can use the `download_data()` function to download the same monthly *Fama/French 3 Factors* as above.
 
 ```{r}
+#| label: accessing-and-managing-financial-data-download-ff3-monthly
 #| output: false
 factors_ff3_monthly <- download_data(
   domain = "famafrench",
@@ -141,6 +150,7 @@ factors_ff3_monthly <- download_data(
 We also download the set *5 Factors (2x3)*, which additionally includes the return time series of the profitability `rmw` and investment `cma` factors. We demonstrate how the monthly factors are constructed in the chapter [Replicating Fama and French Factors](replicating-fama-and-french-factors.qmd).
 
 ```{r}
+#| label: accessing-and-managing-financial-data-download-ff5-monthly
 #| output: false
 factors_ff5_monthly <- download_data(
   domain = "famafrench",
@@ -153,6 +163,7 @@ factors_ff5_monthly <- download_data(
 It is straightforward to download the corresponding *daily* Fama-French factors with the same function.
 
 ```{r}
+#| label: accessing-and-managing-financial-data-download-ff3-daily
 #| output: false
 factors_ff3_daily <- download_data(
   domain = "famafrench",
@@ -165,6 +176,7 @@ factors_ff3_daily <- download_data(
 In a subsequent chapter, we also use the monthly returns of 10 industry portfolios, so let us fetch that data, too.\index{Data!Industry portfolios}
 
 ```{r}
+#| label: accessing-and-managing-financial-data-download-industries
 #| output: false
 industries_ff_monthly <- download_data(
   domain = "famafrench",
@@ -179,6 +191,7 @@ It is worth taking a look at all available portfolio return time series from Ken
 The `tidyfinance` package implements the processing steps as above and returns the same cleaned data frame. The list of supported Fama-French datasets can be called as follows:
 
 ```{r}
+#| label: accessing-and-managing-financial-data-list-ff-datasets
 #| output: false
 list_supported_datasets(domain = "Fama-French")
 ```
@@ -190,6 +203,7 @@ In recent years, the academic discourse experienced the rise of alternative fact
 We also need to adjust this data. First, we discard information we will not use in the remainder of the book. Then, we rename the columns with the "R\_"-prescript using regular expressions and write all column names in lowercase. You should always try sticking to a consistent style for naming objects, which we try to illustrate here - the emphasis is on *try*. You can check out style guides available online, e.g., [Hadley Wickham's `tidyverse` style guide.](https://style.tidyverse.org/index.html)\index{Style guide}
 
 ```{r}
+#| label: accessing-and-managing-financial-data-download-q-factors
 #| message: false
 factors_q_monthly_link <-
   "https://global-q.org/uploads/1/2/2/6/122679606/q5_factors_monthly_2024.csv"
@@ -207,6 +221,7 @@ factors_q_monthly <- read_csv(factors_q_monthly_link) |>
 Again, you can use the `tidyfinance` package for a shortcut:
 
 ```{r}
+#| label: accessing-and-managing-financial-data-download-q-factors-shortcut
 #| output: false
 download_data(
   domain = "factors_q",
@@ -221,6 +236,7 @@ download_data(
 Our next data source is a set of macroeconomic variables often used as predictors for the equity premium. @Goyal2008 comprehensively reexamine the performance of variables suggested by the academic literature to be good predictors of the equity premium. The authors host the data updated to 2022 on [Amit Goyal's website.](https://sites.google.com/view/agoyal145) The data is an XLSX-file stored on a public Google drive location and we directly export a CSV file.\index{Data!Macro predictors}
 
 ```{r}
+#| label: accessing-and-managing-financial-data-download-macro-raw
 #| message: false
 sheet_id <- "1bM7vCWd3WOt95Sf9qjLPZjoiafgF_8EG"
 sheet_name <- "Monthly"
@@ -252,6 +268,7 @@ Next, we transform the columns into the variables that we later use:
 For variable definitions and the required data transformations, you can consult the material on [Amit Goyal's website](https://sites.google.com/view/agoyal145).
 
 ```{r}
+#| label: accessing-and-managing-financial-data-clean-macro-predictors
 macro_predictors <- macro_predictors_raw |>
   mutate(date = ym(yyyymm)) |>
   mutate(across(where(is.character), as.numeric)) |>
@@ -291,6 +308,7 @@ macro_predictors <- macro_predictors_raw |>
 To get the equivalent data through `tidyfinance`, you can call:
 
 ```{r}
+#| label: accessing-and-managing-financial-data-download-macro-shortcut
 #| output: false
 download_data(
   domain = "macro_predictors",
@@ -305,6 +323,7 @@ download_data(
 The Federal Reserve bank of St. Louis provides the Federal Reserve Economic Data (FRED), an extensive database for macroeconomic data. In total, there are 817,000 US and international time series from 108 different sources. The data can be downloaded directly from FRED by constructing the appropriate URL. For instance, let us consider the consumer price index (CPI) data that can be found under the [CPIAUCNS](https://fred.stlouisfed.org/series/CPIAUCNS):\index{Data!FRED}\index{Data!CPI}
 
 ```{r}
+#| label: accessing-and-managing-financial-data-fred-url
 series <- "CPIAUCNS"
 cpi_url <- paste0(
   "https://fred.stlouisfed.org/graph/fredgraph.csv?id=",
@@ -315,6 +334,7 @@ cpi_url <- paste0(
 We can then use the `httr2` [@httr2] package to request the CSV, extract the data from the response body, and convert the columns to a tidy format:
 
 ```{r}
+#| label: accessing-and-managing-financial-data-download-cpi
 #| message: false
 library(httr2)
 
@@ -343,6 +363,7 @@ The last line sets the current (latest) price level as the reference price level
 The `tidyfinance` package can, of course, also fetch the same index data and many more data series:
 
 ```{r}
+#| label: accessing-and-managing-financial-data-download-cpi-shortcut
 #| message: false
 download_data(
   domain = "fred",
@@ -361,12 +382,14 @@ Now that we have downloaded some (freely available) data from the web into the m
 There are many ways to set up and organize your data, depending on the use case. Storing data as Parquet files creates a universal data format that seamlessly works across different programming languages and platforms. Unlike CSV files that often lose data types when shared between R, Python, Julia, or other languages, Parquet files maintain perfect data integrity regardless of which tool reads them. A dataset saved as Parquet in R can be opened directly in Python's pandas, or Julia's DataFrames.jl.^[In previous editions of this book, we suggested using SQLite databases. However, Parquet files are more versatile and easier to handle across different programming languages. Should you still prefer using SQLite, you can find the relevant code snippets in a separate blog post.]
 
 ```{r}
+#| label: accessing-and-managing-financial-data-arrow-package
 library(arrow)
 ```
 
 Parquet files are easily created - the code below is really all there is. You do not need any external software. We will store everything in the data subfolder, to retrieve data for all subsequent chapters. The initial part of the code ensures that the directory is created if it does not already exist.
 
 ```{r}
+#| label: accessing-and-managing-financial-data-create-data-dir
 if (!dir.exists("data-r")) {
   dir.create("data-r")
 }
@@ -375,12 +398,14 @@ if (!dir.exists("data-r")) {
 Next, we create a file with the monthly Fama-French factor data. We do so with the function `write_parquet`.
 
 ```{r}
+#| label: accessing-and-managing-financial-data-write-ff3-monthly
 write_parquet(factors_ff3_monthly, "data-r/factors_ff3_monthly.parquet")
 ```
 
 You can retrieve the data directly in your memory by calling `read_parquet()`. It is also possible to evaluate `dplyr` calls lazily, i.e., the data is not in our R session's memory, and the database does most of the work. 
 
 ```{r}
+#| label: accessing-and-managing-financial-data-read-ff3-monthly
 read_parquet("data-r/factors_ff3_monthly.parquet") |>
   select(date, risk_free) |>
   head(10)
@@ -389,6 +414,7 @@ read_parquet("data-r/factors_ff3_monthly.parquet") |>
 Before we move on to the next data source, let us also store the other five tables in our new data folder.
 
 ```{r}
+#| label: accessing-and-managing-financial-data-write-remaining-tables
 lst(
   factors_ff5_monthly,
   factors_ff3_daily,

--- a/r/beta-estimation.qmd
+++ b/r/beta-estimation.qmd
@@ -16,6 +16,7 @@ In this chapter, we introduce an important concept in financial economics: the e
 We use the following R packages throughout this chapter:
 
 ```{r}
+#| label: beta-estimation-packages
 #| message: false
 library(tidyverse)
 library(arrow)
@@ -30,6 +31,7 @@ Compared to previous chapters, we introduce `slider` [@slider] for sliding windo
 The estimation procedure is based on a rolling-window estimation, where we may use either monthly or daily returns and different window lengths. First, let us start with loading the monthly CRSP data from our Parquet files introduced in [Accessing and Managing Financial Data](accessing-and-managing-financial-data.qmd) and [WRDS, CRSP, and Compustat](wrds-crsp-and-compustat.qmd).\index{Data!CRSP}\index{Data!Fama-French factors}
 
 ```{r}
+#| label: beta-estimation-load-crsp-monthly
 crsp_monthly <- read_parquet("data-r/crsp_monthly.parquet") |>
   select(permno, date, industry, ret_excess)
 
@@ -49,6 +51,7 @@ $$
 we regress stock excess returns `ret_excess` on excess returns of the market portfolio `mkt_excess`. R provides a simple solution to estimate (linear) models with the function `lm()`. `lm()` requires a formula as input that is specified in a compact symbolic form. An expression of the form `y ~ model` is interpreted as a specification that the response `y` is modeled by a linear predictor specified symbolically by `model`. Such a model consists of a series of terms separated by `+` operators. In addition to standard linear models, `lm()` provides a lot of flexibility. You should check out the documentation for more information. To start, we restrict the data only to the time series of observations in CRSP that correspond to Apple’s stock (i.e., to `permno` 14593 for Apple) and compute $\hat\alpha_i$ as well as $\hat\beta_i$.
 
 ```{r}
+#| label: beta-estimation-capm-apple
 model_fit <- lm(
   "ret_excess ~ mkt_excess",
   data = crsp_monthly |>
@@ -65,6 +68,7 @@ coefficients
 After we estimated the regression coefficients on an example, we scale the estimation of  $\beta_i$ to a whole different level and perform rolling-window estimations for the entire CRSP sample.\index{Rolling-window estimation} The following function implements the CAPM regression for a data frame (or a part thereof) containing at least `min_obs` observations to avoid huge fluctuations if the time series is too short. The function conveniently returns the regression results as a data frame, which ensures that our approach is scalable. If the `min_obs`-condition is violated, that is, the time series is too short, the function returns an empty data frame for consistency. 
 
 ```{r}
+#| label: beta-estimation-define-estimate-capm
 estimate_capm <- function(data, min_obs = 1) {
   if (nrow(data) < min_obs) {
     return(tibble())
@@ -93,6 +97,7 @@ estimate_capm <- function(data, min_obs = 1) {
 Next, we define a function that performs the rolling estimation. The `slide_period` function is able to handle months in its window input in a straightforward manner. The following function takes input data and slides across the `date` vector, considering only a total of `look_back` months. The function essentially performs three steps: (i) arrange all rows, (ii) compute betas by sliding across months, and (iii) return a tibble with months and corresponding parameter estimates. As we demonstrate further below, we can also apply the same function to daily returns data. 
 
 ```{r}
+#| label: beta-estimation-define-roll-capm
 roll_capm_estimation <- function(data, look_back = 60, min_obs = 48) {
   data <- data |>
     arrange(date)
@@ -114,6 +119,7 @@ roll_capm_estimation <- function(data, look_back = 60, min_obs = 48) {
 Before we attack the whole CRSP sample, let us focus on a couple of examples for well-known firms.
 
 ```{r}
+#| label: beta-estimation-example-firms
 examples <- tibble(
   permno = c(14593, 10107, 93436, 17778),
   company = c("Apple", "Microsoft", "Tesla", "Berkshire Hathaway")
@@ -123,6 +129,7 @@ examples <- tibble(
 The main idea is to apply the function to each stock individually and then combine the results into a single data frame. First, we nest the data by `permno`. Nested data means we now have a list of `permno` with corresponding grouped time series data. We get one row of output for each unique combination of non-nested variables which is only `permno` in this case.\index{Data!Nested}
 
 ```{r}
+#| label: beta-estimation-nest-examples
 capm_examples_nested <- crsp_monthly |>
   filter(permno %in% examples$permno) |>
   nest(data = c(date, ret_excess, mkt_excess, industry))
@@ -132,6 +139,7 @@ capm_examples_nested
 Next, we want to apply the `roll_capm_estimation()` function to each stock. This situation is an ideal use case for `map()`, which takes a list or vector as input and returns an object of the same length as the input. In our case, `map()` returns a single data frame with a time series of beta estimates for each stock. Therefore, we use `unnest()` to transform the list of outputs to a tidy data frame. 
 
 ```{r}
+#| label: beta-estimation-estimate-examples
 capm_examples <- capm_examples_nested |>
   mutate(capm = map(data, roll_capm_estimation)) |>
   unnest(capm) |>
@@ -172,6 +180,7 @@ Even though we could now just apply the function using the approach from above o
 If you have a Windows or Mac machine, it makes most sense to define `multisession`, which means that separate R processes are running in the background on the same machine to perform the individual jobs. If you check out the documentation of `plan()`, you can also see other ways to resolve the parallelization in different environments. Note that we use `availableCores()` to determine the number of cores available for parallelization, but keep one core free for other tasks. Some machines might freeze if all cores are busy with R jobs. \index{Parallelization}
 
 ```{r}
+#| label: beta-estimation-setup-parallel
 n_cores = availableCores() - 1
 plan(multisession, workers = n_cores)
 ```
@@ -179,6 +188,7 @@ plan(multisession, workers = n_cores)
 Using eight cores, the estimation for our sample of around 25k stocks takes around 20 minutes. Of course, you can speed up things considerably by having more cores available to share the workload or by having more powerful cores. Notice the difference in the code below? All you need to do is to replace `map()` with `future_map()`, which uses the `furrr` package in the background to handle the parallelization.
 
 ```{r}
+#| label: beta-estimation-estimate-monthly-all
 capm_monthly <- crsp_monthly |>
   nest(data = c(date, ret_excess, mkt_excess, industry)) |>
   mutate(capm = future_map(data, roll_capm_estimation)) |>
@@ -194,6 +204,7 @@ Before we provide some descriptive statistics of our beta estimates, we implemen
 First, we load the daily Fama-French market excess returns.
 
 ```{r}
+#| label: beta-estimation-load-ff3-daily
 factors_ff3_daily <- read_parquet("data-r/factors_ff3_daily.parquet") |>
   select(date, mkt_excess)
 ```
@@ -201,6 +212,7 @@ factors_ff3_daily <- read_parquet("data-r/factors_ff3_daily.parquet") |>
 We then create a connection to the daily CRSP data, but we don't load the whole table into our memory. We only extract all distinct `permno` because we loop the beta estimation over batches of stocks with size 500. To estimate the CAPM over a consistent lookback window while accommodating different return frequencies, we adjust the minimum required number of observations accordingly. Specifically, we require at least 1,000 daily returns over a five‑year period for a valid estimation. This threshold is consistent with the monthly requirement of 48 observations out of 60 months, given that there are roughly 252 trading days in a year.
 
 ```{r}
+#| label: beta-estimation-setup-daily-batches
 crsp_daily_db <- open_dataset("data-r/crsp_daily")
 
 permnos <- crsp_daily_db |>
@@ -215,6 +227,7 @@ min_obs <- 1000
 We then proceed to perform the same steps as with the monthly CRSP data, just in batches: Load in daily returns, nest the data by stock, and parallelize the beta estimation across stocks. 
 
 ```{r}
+#| label: beta-estimation-estimate-daily-all
 #| output: false
 capm_daily <- list()
 
@@ -261,6 +274,7 @@ capm_daily <- bind_rows(capm_daily)
 What is a typical value for stock betas? First, let us extract the relevant estimates from our CAPM results based on monthly returns.
 
 ```{r}
+#| label: beta-estimation-extract-beta-monthly
 beta_monthly <- capm_monthly |>
   filter(coefficient == "mkt_excess") |>
   select(permno, date, beta = estimate) |>
@@ -319,6 +333,7 @@ beta_monthly |>
 To compare the difference between daily and monthly data, we combine beta estimates to a single table. 
 
 ```{r}
+#| label: beta-estimation-combine-beta-estimates
 beta_daily <- capm_daily |>
   filter(coefficient == "mkt_excess") |>
   select(permno, date, beta = estimate) |>
@@ -357,6 +372,7 @@ The estimates in @fig-604 look as expected. As you can see, it really depends on
 Finally, we write the estimates to our local folder such that we can use them in later chapters. 
 
 ```{r}
+#| label: beta-estimation-write-beta
 write_parquet(beta, "data-r/beta.parquet")
 ```
 
@@ -395,6 +411,7 @@ beta_coverage |>
 We also encourage everyone to always look at the distributional summary statistics of variables. You can easily spot outliers or weird distributions when looking at such tables.\index{Summary statistics}
 
 ```{r}
+#| label: beta-estimation-summary-statistics
 beta |>
   group_by(return_type) |>
   summarize(
@@ -414,6 +431,7 @@ The summary statistics indicate that estimates based on daily returns are, on av
 Finally, since we have two different estimators for the same theoretical object, we expect the estimators should be at least positively correlated (although not perfectly as the estimators are based on different frequencies).
 
 ```{r}
+#| label: beta-estimation-correlation
 beta |>
   pivot_wider(names_from = return_type, values_from = beta) |>
   select(monthly, daily) |>

--- a/r/capital-asset-pricing-model.qmd
+++ b/r/capital-asset-pricing-model.qmd
@@ -14,6 +14,7 @@ The Capital Asset Pricing Model (CAPM) is one of the most influential theories i
 We use the following packages throughout this chapter:
 
 ```{r}
+#| label: capital-asset-pricing-model-packages
 #| message: false
 #| warning: false
 library(tidyverse)
@@ -27,6 +28,7 @@ library(ggrepel)
 Building on our analysis from the previous chapter on [Modern Portfolio Theory](modern-portfolio-theory.qmd), we again examine the Dow Jones Industrial Average constituents as an exemplary asset universe. We download and prepare our monthly return data:
 
 ```{r}
+#| label: capital-asset-pricing-model-download-returns
 #| output: false
 symbols <- download_data(
   domain = "constituents",
@@ -102,6 +104,7 @@ is central to the CAPM and is typically called the efficient tangency portfolio.
 For illustrative purposes, we compute the efficient tangency portfolio for our hypothetical asset universe. As a realistic proxy for the risk-free rate, we use the average13-week T-bill rate (traded with the symbol ^IRX). Since the prices are quoted in annualized percentage yields, we have to divide them by 100 and convert them to monthly rates. 
 
 ```{r}
+#| label: capital-asset-pricing-model-risk-free
 risk_free_monthly <- download_data(
   domain = "stock_prices", symbols = "^IRX",
   start_date = "2019-10-01", end_date = "2024-09-30"
@@ -118,6 +121,7 @@ rf <- mean(risk_free_monthly$risk_free)
 Next, we define the core parameters governing the distribution of asset returns, $\Sigma$ and $\tilde\mu$.
 
 ```{r}
+#| label: capital-asset-pricing-model-moments
 assets <- returns_monthly |> 
   group_by(symbol) |> 
   summarise(
@@ -143,6 +147,7 @@ $$\frac{\omega^{\prime}_\text{tan}\mu-r_f}{\omega_\text{tan}^{\prime}\Sigma\omeg
 Typically, the excess return of an asset scaled by its volatility, $\frac{\tilde\mu_i}{\sigma_i}$, is called the Sharpe ratio of the asset. Thus, the slope of the efficient frontier corresponds to the Sharpe ratio of the tangency portfolio returns. By construction, the tangency portfolio is the maximum Sharpe ratio portfolio.^[We prove in the Appendix [Proofs](proofs.qmd) that the efficient tangency portfolio $\omega_\text{tan}$ can also be derived as a solution to the optimization problem $\max_{\omega} \frac{\omega^{\prime}\tilde\mu}{\sqrt{\omega^{\prime}\Sigma\omega}} \text{ s.t. } \omega^{\prime}\iota=1.$]
 
 ```{r}
+#| label: capital-asset-pricing-model-tangency-portfolio
 w_tan <- solve(sigma) %*% (mu - rf)
 w_tan <- w_tan / sum(w_tan)
 
@@ -202,6 +207,7 @@ We derived the CAPM equation as a consequence of efficient wealth allocation. Su
 We can illustrate the relationship between systematic risk and expected returns in the so-called security market line.
 
 ```{r}
+#| label: capital-asset-pricing-model-security-market-line
 betas <- (sigma %*% w_tan) / as.numeric(t(w_tan) %*% sigma %*% w_tan)
 assets <- assets |> 
   mutate(beta = betas)
@@ -249,6 +255,7 @@ where $r_{i,t}$ and $r_{m,t}$ are the realized returns of the asset and market p
 Let's turn to estimating CAPM parameters using real market data. Instead of using our previously constructed tangency portfolio, we employ the Fama-French market excess returns, which provide a widely accepted proxy for the market portfolio. These returns are already adjusted to represent excess returns over the risk-free rate, simplifying our analysis.
 
 ```{r}
+#| label: capital-asset-pricing-model-download-factors
 factors <- download_data(
   domain = "factors_ff", dataset = "Fama/French 5 Factors (2x3)",
   start_date = "2000-01-01", end_date = "2024-09-30"
@@ -259,6 +266,7 @@ factors <- download_data(
 For our regression analysis, we first prepare the data by calculating excess returns for each stock. We join our monthly returns with the Fama-French factors and subtract the risk-free rate to obtain excess returns. The `estimate_capm()` function then implements the regression equation we previously discussed. We leverage nested dataframes to efficiently run these regressions for all assets simultaneously. The `map()` function applies our regression to each nested dataset and extracts the coefficients, giving us a clean data frame of assets and their corresponding betas.
 
 ```{r}
+#| label: capital-asset-pricing-model-estimate-capm
 returns_excess_monthly <- returns_monthly |> 
   left_join(factors, join_by(date)) |> 
   mutate(ret_excess = ret - risk_free) |> 

--- a/r/clean-enhanced-trace-with-r.qmd
+++ b/r/clean-enhanced-trace-with-r.qmd
@@ -16,6 +16,7 @@ This appendix contains code to clean enhanced TRACE with R. It is also available
 The function takes a vector of CUSIPs (in `cusips`), a connection to WRDS (`connection`) explained in Chapter 3, and a start and end date (`start_date` and `end_date`, respectively). Specifying too many CUSIPs will result in very slow downloads and a potential failure due to the size of the request to WRDS. The dates should be within the coverage of TRACE itself, i.e., starting after 2002, and the dates should be supplied using the class date. The output of the function contains all valid trade messages for the selected CUSIPs over the specified period.\index{CUSIP}\index{Dick-Nielsen cleaning} 
 
 ```{r}
+#| label: clean-enhanced-trace-with-r-define-function
 #| eval: false
 clean_enhanced_trace <- function(cusips,
                                  connection,

--- a/r/constrained-optimization-and-backtesting.qmd
+++ b/r/constrained-optimization-and-backtesting.qmd
@@ -17,6 +17,7 @@ We start with standard mean-variance efficient portfolios and introduce constrai
 Throughout this chapter, we use the following R packages:
 
 ```{r}
+#| label: constrained-optimization-and-backtesting-packages
 #| message: false
 library(tidyverse)
 library(arrow)
@@ -31,6 +32,7 @@ Compared to previous chapters, we introduce the `nloptr` package [@nloptr] to pe
 We start by loading the required data from our Parquet files introduced in [Accessing and Managing Financial Data](accessing-and-managing-financial-data.qmd). For simplicity, we restrict our investment universe to the monthly Fama-French industry portfolio returns in the following application. \index{Data!Industry portfolios}
 
 ```{r}
+#| label: constrained-optimization-and-backtesting-load-data
 industry_returns <- read_parquet("data-r/industries_ff_monthly.parquet") |>
   select(-date) |>
   drop_na()
@@ -44,6 +46,7 @@ $$\omega_\text{mvp} = \arg\min \omega'\Sigma \omega \text{ s.t. } \omega'\iota =
 where $\Sigma$ is the $(N \times N)$ covariance matrix of the returns. The optimal weights $\omega_\text{mvp}$ can be found analytically and are $\omega_\text{mvp} = \frac{\Sigma^{-1}\iota}{\iota'\Sigma^{-1}\iota}$. In terms of code, the math is equivalent to the following chunk. \index{Minimum variance portfolio}
 
 ```{r}
+#| label: constrained-optimization-and-backtesting-mvp-analytical
 n_industries <- ncol(industry_returns)
 
 Sigma <- cov(industry_returns)
@@ -101,6 +104,7 @@ The function below implements the efficient portfolio weight in its general form
 For $\beta=0$, the computation resembles the standard mean-variance efficient framework. `gamma` denotes the coefficient of risk aversion $\gamma$, `beta` is the transaction cost parameter $\beta$ and `w_prev` are the weights before rebalancing $\omega_{t^+}$. 
 
 ```{r}
+#| label: constrained-optimization-and-backtesting-efficient-weight-function
 compute_efficient_weight <- function(Sigma,
                                      mu,
                                      gamma = 2,
@@ -132,6 +136,7 @@ The portfolio weights above indicate the efficient portfolio for an investor wit
 What is the effect of transaction costs or different levels of risk aversion on the optimal portfolio choice? The following few lines of code analyze the distance between the minimum variance portfolio and the portfolio implemented by the investor for different values of the transaction cost parameter $\beta$ and risk aversion $\gamma$.
 
 ```{r}
+#| label: constrained-optimization-and-backtesting-transaction-costs
 gammas <- c(2, 4, 8, 20)
 betas <- 20 * qexp((1:99) / 100)
                    
@@ -192,6 +197,7 @@ We rely on the powerful `nloptr` package, which provides a common interface to a
 We illustrate the use of the `nloptr()` function by replicating the analytical solutions for the minimum variance and efficient portfolio weights from above. Note that the equality constraint for both solutions is given by the requirement that the weights must sum up to one. In addition, we supply a vector of equal weights as an initial value for the algorithm in all applications. We verify that the output is equal to the above solution. Note that `near()` is a safe way to compare two vectors for pairwise equality. The alternative `==` is sensitive to small differences that may occur due to the representation of floating points on a computer, while `near()` has a built-in tolerance. 
 
 ```{r}
+#| label: constrained-optimization-and-backtesting-nloptr-replication
 w_initial <- rep(1 / n_industries, n_industries)
 
 objective_mvp <- function(w) {
@@ -252,6 +258,7 @@ The result above shows that indeed the numerical procedure recovered the optimal
 Next, we approach problems where no analytical solutions exist. First, we additionally impose short-sale constraints, which implies $N$ inequality constraints of the form $\omega_i >=0$. We can implement the short-sale constraints by imposing a vector of lower bounds `lb = rep(0, n_industries)`.
 
 ```{r}
+#| label: constrained-optimization-and-backtesting-no-short-sale
 w_no_short_sale <- nloptr(
   x0 = w_initial, 
   eval_f = objective_efficient, 
@@ -272,6 +279,7 @@ You can verify that `sum(w_no_short_sale$solution)` returns 1. In other words, `
 The constraint enforces that a maximum of 50 percent of the allocated wealth can be allocated to short positions, thus implying an initial margin requirement of 50 percent. Imposing such a margin requirement reduces portfolio risks because extreme portfolio weights are not attainable anymore. The implementation of Regulation-T rules is numerically interesting because the margin constraints imply a non-linear constraint on the portfolio weights. \index{Regulation T}
 
 ```{r}
+#| label: constrained-optimization-and-backtesting-regulation-t
 reg_t <- 1.5
 
 inequality_constraint <- function(w) {
@@ -344,6 +352,7 @@ Estimation uncertainty may thus lead to inefficient allocations. By imposing res
 Before we move on, we want to propose a final allocation strategy, which reflects a somewhat more realistic structure of transaction costs instead of the quadratic specification used above. The function below computes efficient portfolio weights while adjusting for transaction costs of the form $\beta\sum_{i=1}^N |(\omega_{i, t+1} - \omega_{i, t^+})|$. No closed-form solution exists, and we rely on non-linear optimization procedures.
 
 ```{r}
+#| label: constrained-optimization-and-backtesting-l1-tc-function
 compute_efficient_weight_L1_TC <- function(mu,
                                            Sigma,
                                            gamma,
@@ -381,6 +390,7 @@ While interesting from a methodological point of view, we cannot evaluate the pe
 The few lines below define the general setup. We consider 120 periods from the past to update the parameter estimates before recomputing portfolio weights. Then, we update portfolio weights which is costly and affects the performance. The portfolio weights determine the portfolio return. A period later, the current portfolio weights have changed and form the foundation for transaction costs incurred in the next period. We consider three different competing strategies: the mean-variance efficient portfolio, the mean-variance efficient portfolio with ex-ante adjustment for transaction costs, and the naive portfolio, which allocates wealth equally across the different assets.\index{Transaction cost}
 
 ```{r}
+#| label: constrained-optimization-and-backtesting-backtest-setup
 window_length <- 120
 periods <- nrow(industry_returns) - window_length
 
@@ -408,6 +418,7 @@ w_prev_1 <- w_prev_2 <- w_prev_3 <- rep(
 We also define two helper functions: one to adjust the weights due to returns and one for performance evaluation, where we compute realized returns net of transaction costs. 
 
 ```{r}
+#| label: constrained-optimization-and-backtesting-helper-functions
 adjust_weights <- function(w, next_return) {
   w_prev <- 1 + w * next_return
   as.numeric(w_prev / sum(as.vector(w_prev)))
@@ -425,6 +436,7 @@ The following code chunk performs a rolling-window estimation, which we implemen
 Note that we use the sample variance-covariance matrix and ignore the estimation of $\hat\mu$ entirely, but you might use more advanced estimators in practice. 
 
 ```{r}
+#| label: constrained-optimization-and-backtesting-rolling-window
 for (p in 1:periods) {
   returns_window <- industry_returns[p:(p + window_length - 1), ]
   next_return <- industry_returns[p + window_length, ] |> as.matrix()
@@ -480,6 +492,7 @@ for (p in 1:periods) {
 Finally, we get to the evaluation of the portfolio strategies *net-of-transaction costs*. Note that we compute annualized returns and standard deviations.\index{Sharpe Ratio}
 
 ```{r}
+#| label: constrained-optimization-and-backtesting-performance-table
 performance <- lapply(
   performance_values,
   as_tibble

--- a/r/cover-and-logo-design.qmd
+++ b/r/cover-and-logo-design.qmd
@@ -13,6 +13,7 @@ The few lines of code below replicate the entire figure.
 We use the Wes Andersen color palette (also throughout the entire book), provided by the package `wesanderson` [@wesanderson]
 
 ```{r}
+#| label: cover-and-logo-design-cover
 #| message: false
 library(tidyverse)
 library(RSQLite)
@@ -99,6 +100,7 @@ ggsave(
 To generate our logo, we focus on year 2021 - the end of the sample period at the time we published tidy-finance.org for the first time. 
 
 ```{r}
+#| label: cover-and-logo-design-logo
 #| message: false
 logo <- data_plot |>
   ungroup() |> 
@@ -144,6 +146,7 @@ ggsave(
 Here is the code to generate the vector graphics for our buttons.
 
 ```{r}
+#| label: cover-and-logo-design-buttons
 button_r <- data_plot |>
   ungroup() |> 
   filter(year == "2000-01-01") |> 

--- a/r/difference-in-differences.qmd
+++ b/r/difference-in-differences.qmd
@@ -20,6 +20,7 @@ The approach we use here replicates the results of @Seltzer2022 partly. Specific
 The current chapter relies on this set of R packages. 
 
 ```{r}
+#| label: difference-in-differences-packages
 #| message: false
 library(tidyverse)
 library(arrow)
@@ -32,6 +33,7 @@ library(broom)
 We use TRACE and Mergent FISD as data sources from our Parquet files introduced in [Accessing and Managing Financial Data](accessing-and-managing-financial-data.qmd) and [TRACE and FISD](trace-and-fisd.qmd). \index{Data!TRACE}\index{Data!FISD}
 
 ```{r}
+#| label: difference-in-differences-read-data
 fisd <- read_parquet("data-r/fisd.parquet") |>
   select(complete_cusip, maturity, offering_amt, sic_code) |>
   drop_na()
@@ -45,6 +47,7 @@ trace_enhanced <- open_dataset("data-r/trace_enhanced") |>
 We start our analysis by preparing the sample of bonds. We only consider bonds with a time to maturity of more than one year to the signing of the PA, so that we have sufficient data to analyze the yield behavior after the treatment date. This restriction also excludes all bonds issued after the agreement. We also consider only the first two digits of the SIC industry code to identify the polluting industries [in line with @Seltzer2022].\index{Time to maturity}
 
 ```{r}
+#| label: difference-in-differences-prepare-bonds
 treatment_date <- ymd("2015-12-12")
 
 polluting_industries <- c(
@@ -85,6 +88,7 @@ bonds <- fisd |>
 Next, we aggregate the individual transactions as reported in TRACE to a monthly panel of bond yields. We consider bond yields for a bond's last trading day in a month. Therefore, we first aggregate bond data to daily frequency and apply common restrictions from the literature [see, e.g., @Bessembinder2008]. We weigh each transaction by volume to reflect a trade's relative importance and avoid emphasizing small trades. Moreover, we only consider transactions with reported prices `rptd_pr` larger than 25 (to exclude bonds that are close to default) and only bond-day observations with more than five trades on a corresponding day (to exclude prices based on too few, potentially non-representative transactions).\index{Yield aggregation} \index{Returns!Bonds}
 
 ```{r}
+#| label: difference-in-differences-aggregate-trace
 trace_aggregated <- trace_enhanced |>
   filter(rptd_pr > 25) |>
   group_by(cusip_id, trd_exctn_dt) |>
@@ -105,6 +109,7 @@ trace_aggregated <- trace_enhanced |>
 By combining the bond-specific information from Mergent FISD for our bond sample with the aggregated TRACE data, we arrive at the main sample for our analysis.
 
 ```{r}
+#| label: difference-in-differences-build-panel
 bonds_panel <- bonds |>
   inner_join(trace_aggregated, join_by(cusip_id), multiple = "all") |>
   drop_na()
@@ -113,6 +118,7 @@ bonds_panel <- bonds |>
 Before we can run the first regression, we need to define the `treated` indicator, which is the product of the `post_period` (i.e., all months after the signing of the PA) and the `polluter` indicator defined above.\index{Regression!Fixed effects} 
 
 ```{r}
+#| label: difference-in-differences-treated-indicator
 bonds_panel <- bonds_panel |>
   mutate(post_period = date >= floor_date(treatment_date, "months")) |>
   mutate(treated = polluter & post_period)
@@ -121,6 +127,7 @@ bonds_panel <- bonds_panel |>
 As usual, we tabulate summary statistics of the variables that enter the regression to check the validity of our variable definitions.\index{Summary statistics}
 
 ```{r}
+#| label: difference-in-differences-summary-stats
 bonds_panel |>
   pivot_longer(
     cols = c(avg_yield, time_to_maturity, log_offering_amt),
@@ -147,6 +154,7 @@ The PA is a legally binding international treaty on climate change. It was adopt
 The second model follows the typical DiD regression approach by including individual (`cusip_id`) and time (`date`) fixed effects. In this model, we do not include any other variables from the simple model because the fixed effects subsume them, and we observe the coefficient of our main variable of interest: `treated`. 
 
 ```{r}
+#| label: difference-in-differences-did-regressions
 model_without_fe <- feols(
   avg_yield ~ treated +
     post_period +

--- a/r/discounted-cash-flow-analysis.qmd
+++ b/r/discounted-cash-flow-analysis.qmd
@@ -30,6 +30,7 @@ We make a few simplifying assumptions due to the diverse nature of businesses, w
 In this chapter, we rely on the following packages to build a simple DCF analysis:
 
 ```{r}
+#| label: discounted-cash-flow-analysis-packages
 #| message: false
 #| warning: false
 library(tidyverse)
@@ -47,6 +48,7 @@ The `fmpapi` package is developed by Christoph Scheuch and is not sponsored by o
 Before we can perform a DCF analysis, we need historical financial data to inform our forecasts. We use the Financial Modeling Prep (FMP) API to download financial statements. The `fmpapi` package provides a convenient interface for accessing this data in a tidy format.\index{Data!FMP API}
 
 ```{r}
+#| label: discounted-cash-flow-analysis-download-statements
 #| cache: true
 symbol <- "MSFT"
 
@@ -78,6 +80,7 @@ Each component of this formula serves a specific purpose in capturing the compan
 We can implement this calculation by combining and transforming our financial statement data. Note that we also arrange by year, which is important for some of the following code chunks.
 
 ```{r}
+#| label: discounted-cash-flow-analysis-compute-historical-fcf
 dcf_data <- income_statements |>
   mutate(
     fiscal_year = as.integer(fiscal_year),
@@ -194,6 +197,7 @@ The final step in our FCF forecast is projecting revenue growth. While there are
 We use GDP growth forecasts from the [IMF World Economic Outlook (WEO)](https://www.imf.org/en/Publications/WEO/weo-database/2024/October/weo-report?c=111,&s=NGDP_RPCH,&sy=2020&ey=2029&ssm=0&scsm=1&scc=0&ssd=1&ssc=0&sic=1&sort=country&ds=.&br=1) database as our baseline. The WEO provides comprehensive economic projections, though it is important to note that these forecasts are periodically revised as new data becomes available.\index{Data!IMF WEO} We manually collect these forecasts and store them in a tibble.
 
 ```{r}
+#| label: discounted-cash-flow-analysis-gdp-growth-forecasts
 gdp_growth <- tibble(
   year = 2021:2030,
   gdp_growth = c(
@@ -217,6 +221,7 @@ dcf_data <- dcf_data |>
 Our approach models revenue growth as a linear function of GDP growth. This relation captures the intuition that company revenues often move in tandem with broader economic activity, though usually with different sensitivity.\index{Growth modeling} Let us estimate the model with historical data.
 
 ```{r}
+#| label: discounted-cash-flow-analysis-revenue-growth-model
 revenue_growth_model <- dcf_data |>
   lm(revenue_growth ~ gdp_growth, data = _) |>
   coefficients()
@@ -261,6 +266,7 @@ While more sophisticated approaches exist (e.g., proprietary analyst forecasts o
 With all components in place - revenue growth projections and forecast ratios - we can now calculate our FCF forecasts. We must first convert our growth rates into revenue projections and then apply our forecast ratios to compute each FCF component.\index{Free Cash Flow!Computation}
 
 ```{r}
+#| label: discounted-cash-flow-analysis-project-fcf-components
 dcf_data$revenue_growth[1] <- 0
 dcf_data$revenue <- dcf_data$revenue[1] * cumprod(1 + dcf_data$revenue_growth)
 
@@ -312,6 +318,7 @@ The perpetual growth rate $g$ should reflect the long-term economic growth poten
 Let us implement the Perpetuity Growth Model:
 
 ```{r}
+#| label: discounted-cash-flow-analysis-terminal-value
 compute_terminal_value <- function(last_fcf, growth_rate, discount_rate) {
   last_fcf * (1 + growth_rate) / (discount_rate - growth_rate)
 }
@@ -344,6 +351,7 @@ While you can often find estimates of WACC from financial databases or analysts'
 If you would rather not estimate WACC manually, resources are available to help you find industry-specific discount rates. One of the most widely used sources is Aswath Damodaran’s [database](https://pages.stern.nyu.edu/~adamodar/New_Home_Page/datacurrent.html). He maintains an extensive database that provides a wealth of financial data, including estimated discount rates, cash flows, growth rates, multiples, and more. For example, if you are analyzing a company in the Computer Services sector, as we do here, you can look up the industry's average WACC and use it as a benchmark for your analysis. The following code chunk downloads the WACC data and extracts the value for this industry:
 
 ```{r}
+#| label: discounted-cash-flow-analysis-download-wacc
 #| cache: true
 library(readxl)
 
@@ -375,6 +383,7 @@ $$
 where $T$ is the length of our forecast period. Let us implement this calculation in a simple function that takes the WACC and growth rate as input. Then, we present an example at the values discussed above.
 
 ```{r}
+#| label: discounted-cash-flow-analysis-compute-enterprise-value
 compute_dcf <- function(wacc, growth_rate) {
   free_cash_flow <- dcf_data$fcf
   last_fcf <- tail(free_cash_flow, 1)

--- a/r/factor-selection-via-machine-learning.qmd
+++ b/r/factor-selection-via-machine-learning.qmd
@@ -68,6 +68,7 @@ To get started, we load the required R packages and data. The main focus is on t
 @Kuhn2022 provide a thorough introduction into all `tidymodels` components. `glmnet` [@glmnet] was developed and released in sync with @Tibshirani1996 and provides an R implementation of Elastic Net estimation. The package `timetk` [@timetk] provides useful tools for time series data wrangling. 
 
 ```{r}
+#| label: factor-selection-via-machine-learning-packages
 #| message: false
 library(arrow)
 library(tidyverse)
@@ -91,6 +92,7 @@ Finally, we need a set of *test assets*. The aim is to understand which of the p
 In line with many existing papers, we use monthly portfolio returns from 10 different industries according to the definition from [Kenneth French's homepage](https://mba.tuck.dartmouth.edu/pages/faculty/ken.french/Data_Library/det_10_ind_port.html) as test assets.\index{Data!Fama-French factors}\index{Data!q-factors}\index{Data!Macroeconomic predictors}\index{Data!Industry portfolios}
 
 ```{r}
+#| label: factor-selection-via-machine-learning-load-data
 factors_ff3_monthly <- read_parquet("data-r/factors_ff3_monthly.parquet") |>
   rename_with(~ str_c("factor_ff_", .), -date)
 
@@ -110,6 +112,7 @@ industries_ff_monthly <- read_parquet("data-r/industries_ff_monthly.parquet") |>
 We combine all the monthly observations into one dataframe.
 
 ```{r, eval = TRUE}
+#| label: factor-selection-via-machine-learning-combine-data
 data <- industries_ff_monthly |>
   left_join(factors_ff3_monthly, join_by(date)) |>
   left_join(factors_q_monthly, join_by(date)) |>
@@ -157,6 +160,7 @@ The split takes the last 20% of the data as a test set, which is not used for an
 We use this test set to evaluate the predictive accuracy in an out-of-sample scenario.
 
 ```{r}
+#| label: factor-selection-via-machine-learning-train-test-split
 split <- initial_time_split(
   data |>
     filter(industry == "manuf") |>
@@ -180,6 +184,7 @@ $$r_{t} = \alpha_0 + \left(\tilde f_t \otimes \tilde z_t\right)B + \varepsilon_t
 - We demean and scale each regressor such that the standard deviation is one
 
 ```{r}
+#| label: factor-selection-via-machine-learning-recipe
 rec <- recipe(ret_excess ~ ., data = training(split)) |>
   step_rm(date) |>
   step_interact(terms = ~ contains("factor"):contains("macro")) |>
@@ -193,11 +198,13 @@ All that matters at this early stage are the column names and types.
 We can apply the recipe to any data with a suitable structure. The code below combines two different functions: `prep()` estimates the required parameters from a training set that can be applied to other datasets later. `bake()` applies the processed computations to new data.
 
 ```{r}
+#| label: factor-selection-via-machine-learning-prep-recipe
 data_prep <- prep(rec, training(split))
 ```
 The object `data_prep` contains information related to the different preprocessing steps applied to the training data: E.g., it is necessary to compute sample means and standard deviations to center and scale the variables. 
 
 ```{r}
+#| label: factor-selection-via-machine-learning-bake-recipe
 data_bake <- bake(data_prep,
   new_data = testing(split)
 )
@@ -216,6 +223,7 @@ $$\begin{aligned}\hat\beta_\lambda^\text{Lasso} = \arg\min_\beta \left(Y - X\bet
 For now, we start with the linear regression model with a given value for the penalty factor $\lambda$. In the setup below, `mixture` denotes the value of $\rho$, hence setting `mixture = 1` implies the Lasso.
 
 ```{r}
+#| label: factor-selection-via-machine-learning-lasso-model-spec
 lm_model <- linear_reg(
   penalty = 0.0001,
   mixture = 1
@@ -226,6 +234,7 @@ lm_model <- linear_reg(
 That's it - we are done! The object `lm_model` contains the definition of our model with all required information. Note that `set_engine("glmnet")` indicates the API character of the `tidymodels` workflow: Under the hood, the package `glmnet` is doing the heavy lifting, while `linear_reg()` provides a unified framework to collect the inputs. The `workflow`  ends with combining everything necessary for the serious data science workflow, namely, a recipe and a model.
 
 ```{r}
+#| label: factor-selection-via-machine-learning-build-workflow
 lm_fit <- workflow() |>
   add_recipe(rec) |>
   add_model(lm_model)
@@ -239,6 +248,7 @@ The training data is pre-processed according to our recipe steps, and the Lasso 
 First, we focus on the predicted values $\hat{y}_t = x_t\hat\beta^\text{Lasso}.$ @fig-1402 illustrates the projections for the *entire* time series of the manufacturing industry portfolio returns. The grey area indicates the out-of-sample period, which we did not use to fit the model.
 
 ```{r}
+#| label: factor-selection-via-machine-learning-predicted-values
 predicted_values <- lm_fit |>
   fit(data = training(split)) |>
   augment(data |> filter(industry == "manuf")) |>
@@ -300,6 +310,7 @@ predicted_values |>
 What do the estimated coefficients look like? To analyze these values and to illustrate the difference between the `tidymodels` workflow and the underlying `glmnet` package, it is worth computing the coefficients $\hat\beta^\text{Lasso}$ directly. The code below estimates the coefficients for the Lasso and Ridge regression for the processed training data sample. Note that `glmnet` actually takes a vector `y` and the matrix of regressors $X$ as input. Moreover, `glmnet` requires choosing the penalty parameter $\alpha$, which corresponds to $\rho$ in the notation above. When using the `tidymodels` model API, such details do not need consideration.
 
 ```{r}
+#| label: factor-selection-via-machine-learning-glmnet-fits
 x <- data_bake |>
   select(-ret_excess) |>
   as.matrix()
@@ -371,6 +382,7 @@ How should you pick $K$? Large values of $K$ are preferable because the training
 `tidymodels` provides all required tools to conduct $K$-fold cross-validation. We just have to update our model specification and let `tidymodels` know which parameters to tune. In our case, we specify the penalty factor $\lambda$ as well as the mixing factor $\rho$ as *free* parameters. Note that it is simple to change an existing `workflow` with `update_model()`. 
 
 ```{r}
+#| label: factor-selection-via-machine-learning-tune-model-spec
 lm_model <- linear_reg(
   penalty = tune(),
   mixture = tune()
@@ -384,6 +396,7 @@ lm_fit <- lm_fit |>
 For our sample, we consider a time-series cross-validation sample. This means that we tune our models with 20 samples of length five years with a validation period of four years. For a grid of possible hyperparameters, we then fit the model for each fold and evaluate $\hat{\text{MSPE}}$ in the corresponding validation set. Finally, we select the model specification with the lowest MSPE in the validation set. First, we define the cross-validation folds based on our training data only.
 
 ```{r}
+#| label: factor-selection-via-machine-learning-cv-folds
 data_folds <- time_series_cv(
   data        = training(split),
   date_var    = date,
@@ -398,6 +411,7 @@ data_folds
 Then, we evaluate the performance for a grid of different penalty values. `tidymodels` provides functionalities to construct a suitable grid of hyperparameters with `grid_regular`. The code chunk below creates a $10 \times 3$ hyperparameters grid. Then, the function `tune_grid()` evaluates all the models for each fold.
 
 ```{r}
+#| label: factor-selection-via-machine-learning-tune-grid
 lm_tune <- lm_fit |>
   tune_grid(
     resample = data_folds,
@@ -434,6 +448,7 @@ Then, we use the set of `finalize_*()`-functions that take a list or tibble of t
 First, we define the Lasso model with one tuning parameter.
 
 ```{r}
+#| label: factor-selection-via-machine-learning-lasso-tune-model
 lasso_model <- linear_reg(
   penalty = tune(),
   mixture = 1
@@ -447,6 +462,7 @@ lm_fit <- lm_fit |>
 The following task can be easily parallelized to reduce computing time substantially. We use the parallelization capabilities of `furrr`. Note that we can also just recycle all the steps from above and collect them in a function.
 
 ```{r}
+#| label: factor-selection-via-machine-learning-select-variables
 #| message: false
 #| warning: false
 select_variables <- function(input) {

--- a/r/fama-macbeth-regressions.qmd
+++ b/r/fama-macbeth-regressions.qmd
@@ -31,6 +31,7 @@ Before we move to the implementation, we want to highlight that the characterist
 The current chapter relies on this set of R packages. 
 
 ```{r}
+#| label: fama-macbeth-regressions-packages
 #| message: false
 library(tidyverse)
 library(arrow)
@@ -43,6 +44,7 @@ library(broom)
 We illustrate @Fama1973 with the monthly CRSP sample and use three characteristics to explain the cross-section of returns: market capitalization, the book-to-market ratio, and the CAPM beta (i.e., the covariance of the excess stock returns with the market excess returns). We collect the data from our Parquet files introduced in [Accessing and Managing Financial Data](accessing-and-managing-financial-data.qmd) and [WRDS, CRSP, and Compustat](wrds-crsp-and-compustat.qmd). As in the previous chapters, we keep only firms with positive book equity, which is a common practice when working with book-to-market ratios [see @Fama1992 for details].\index{Data!CRSP}\index{Data!Compustat}\index{Beta}\index{Book equity}
 
 ```{r}
+#| label: fama-macbeth-regressions-read-data
 crsp_monthly <- read_parquet("data-r/crsp_monthly.parquet") |>
   select(permno, gvkey, date, ret_excess, mktcap) |>
   collect()
@@ -60,6 +62,7 @@ We use the Compustat and CRSP data to compute the book-to-market ratio and the (
 Furthermore, we also use the CAPM betas based on monthly returns we computed in the previous chapters.\index{Beta}\index{CAPM}
 
 ```{r}
+#| label: fama-macbeth-regressions-build-characteristics
 characteristics <- compustat_annual |>
   mutate(date = floor_date(ymd(datadate), "month")) |>
   left_join(crsp_monthly, join_by(gvkey, date)) |>
@@ -93,6 +96,7 @@ data_fama_macbeth <- crsp_monthly |>
 Next, we run the cross-sectional regressions with the characteristics as explanatory variables for each month. We regress the returns of the test assets at a particular time point on the characteristics of each asset. By doing so, we get an estimate of the risk premiums $\hat\lambda^{f}_t$ for each point in time. \index{Regression!Cross-section}
 
 ```{r}
+#| label: fama-macbeth-regressions-cross-sectional
 risk_premiums <- data_fama_macbeth |>
   nest(data = c(ret_excess_lead, beta, log_mktcap, bm, permno)) |>
   mutate(
@@ -109,6 +113,7 @@ risk_premiums <- data_fama_macbeth |>
 Now that we have the risk premiums' estimates for each period, we can average across the time-series dimension to get the expected risk premium for each characteristic. Similarly, we manually create the $t$-test statistics for each regressor, which we can then compare to usual critical values of 1.96 or 2.576 for two-tailed significance tests. 
 
 ```{r}
+#| label: fama-macbeth-regressions-price-of-risk
 price_of_risk <- risk_premiums |>
   group_by(factor = term) |>
   summarize(
@@ -120,6 +125,7 @@ price_of_risk <- risk_premiums |>
 It is common to adjust for autocorrelation when reporting standard errors of risk premiums. As in [Univariate Portfolio Sorts](univariate-portfolio-sorts.qmd), the typical procedure for this is computing @Newey1987 standard errors. We again recommend the data-driven approach of @Newey1994 using the `NeweyWest()` function, but note that you can enforce the typical 6 lag settings via `NeweyWest(., lag = 6, prewhite = FALSE)`.\index{Standard errors!Newey-West}
 
 ```{r}
+#| label: fama-macbeth-regressions-newey-west
 regressions_for_newey_west <- risk_premiums |>
   select(date, factor = term, estimate) |>
   nest(data = c(date, estimate)) |>
@@ -147,6 +153,7 @@ Finally, let us interpret the results. Stocks with higher book-to-market ratios 
 You can also replicate the results using the `tidyfinance` package via the `estimate_fama_macbeth()` function:
 
 ```{r}
+#| label: fama-macbeth-regressions-tidyfinance
 #| eval: false
 library(tidyfinance)
 

--- a/r/financial-statement-analysis.qmd
+++ b/r/financial-statement-analysis.qmd
@@ -32,6 +32,7 @@ The `fmpapi` package is developed by Christoph Scheuch and not sponsored by or a
 Next to `fmpapi`, we use the following packages throughout this chapter:
 
 ```{r}
+#| label: financial-statement-analysis-packages
 #| message: false
 #| warning: false
 library(tidyverse)
@@ -85,6 +86,7 @@ While there are more details, the basic structure is exactly the same as in the 
 Let us examine Microsoft's balance sheet statements using the `fmp_get()` function. This function requires three main arguments: The type of financial data to retrieve (`resource`), the stock ticker symbol (`symbol`), and additional parameters like periodicity and number of periods (`params`).
 
 ```{r}
+#| label: financial-statement-analysis-balance-sheet-msft
 fmp_get(
   resource = "balance-sheet-statement",
   symbol = "MSFT",
@@ -117,6 +119,7 @@ Consider Microsoft's 2023 income statement in @fig-406, which exemplifies how a 
 We can also access this data programmatically using the FMP API:
 
 ```{r}
+#| label: financial-statement-analysis-income-statement-msft
 fmp_get(
   resource = "income-statement",
   symbol = "MSFT",
@@ -145,6 +148,7 @@ The statement reconciles accrual-based accounting (used in the income statement)
 Of course, we can access this data through the FMP API:
 
 ```{r}
+#| label: financial-statement-analysis-cash-flow-statement-msft
 fmp_get(
   resource = "cash-flow-statement",
   symbol = "MSFT",
@@ -159,6 +163,7 @@ In subsequent sections, we will use cash flow data to calculate important cash f
 We now turn to downloading and processing statements for multiple companies. The next code chunk demonstrates how to retrieve financial data for selected stocks that are supported in the free tier of FMP.
 
 ```{r}
+#| label: financial-statement-analysis-download-statements
 sample <- c(
   "AAPL",
   "MSFT",
@@ -233,6 +238,7 @@ This ratio focuses solely on the most liquid assets - cash and cash equivalents.
 Next, we calculate these ratios for all stocks, focusing on four major technology companies:
 
 ```{r}
+#| label: financial-statement-analysis-liquidity-ratios
 selected_symbols <- c("MSFT", "AAPL", "AMZN", "NVDA")
 
 balance_sheet_statements <- balance_sheet_statements |>
@@ -289,6 +295,7 @@ $$\text{Interest Coverage} = \frac{\text{EBIT}}{\text{Interest Expense}}$$
 Let's calculate these ratios for our sample of companies:
 
 ```{r}
+#| label: financial-statement-analysis-leverage-ratios
 balance_sheet_statements <- balance_sheet_statements |>
   mutate(
     debt_to_equity = total_debt / total_equity,
@@ -403,6 +410,7 @@ A higher ratio indicates more efficient credit and collection processes, though 
 Here is how we can calculate these efficiency metrics across our sample of companies:
 
 ```{r}
+#| label: financial-statement-analysis-efficiency-ratios
 combined_statements <- balance_sheet_statements |>
   select(
     symbol,
@@ -471,6 +479,7 @@ This metric is particularly important for investors as it directly measures the 
 The next code chunk calculates these profitability metrics for our sample of companies, allowing us to analyze how different firms convert their revenue into various levels of profit and return on investment.
 
 ```{r}
+#| label: financial-statement-analysis-profitability-ratios
 combined_statements <- combined_statements |>
   mutate(
     gross_margin = gross_profit / revenue,
@@ -594,6 +603,7 @@ The Fama-French five-factor model aims to explain stock returns by incorporating
 We can calculate these factors using the FMP API as follows. Since the free tier only supports historical data for the last couple of months, we use the earliest available data that is returned by default:
 
 ```{r}
+#| label: financial-statement-analysis-fama-french-factors
 market_cap <- sample |>
   map_df(
     \(x) {

--- a/r/fixed-effects-and-clustered-standard-errors.qmd
+++ b/r/fixed-effects-and-clustered-standard-errors.qmd
@@ -20,6 +20,7 @@ Typically, this investment regression uses quarterly balance sheet data provided
 The current chapter relies on the following set of R packages. 
 
 ```{r}
+#| label: fixed-effects-and-clustered-standard-errors-packages
 #| message: false
 library(tidyverse)
 library(arrow)
@@ -33,6 +34,7 @@ Compared to previous chapters, we introduce `fixest` [@fixest] for the fixed eff
 We use CRSP and annual Compustat as data sources from our Parquet files introduced in [Accessing and Managing Financial Data](accessing-and-managing-financial-data.qmd) and [WRDS, CRSP, and Compustat](wrds-crsp-and-compustat.qmd). In particular, Compustat provides balance sheet and income statement data on a firm level, while CRSP provides market valuations. \index{Data!CRSP}\index{Data!Compustat}
 
 ```{r}
+#| label: fixed-effects-and-clustered-standard-errors-read-data
 crsp_monthly <- read_parquet("data-r/crsp_monthly.parquet") |>
   select(gvkey, date, mktcap)
 
@@ -43,6 +45,7 @@ compustat_annual <- read_parquet("data-r/compustat_annual.parquet") |>
 The classical investment regressions model the capital investment of a firm as a function of operating cash flows and Tobin's q, a measure of a firm's investment opportunities.\index{Cash flows}\index{Regression!Investment} We start by constructing investment and cash flows which are usually normalized by lagged total assets of a firm. In the following code chunk, we construct a *panel* of firm-year observations, so we have both cross-sectional information on firms as well as time-series information for each firm.\index{Regression!Panel}
 
 ```{r}
+#| label: fixed-effects-and-clustered-standard-errors-construct-panel
 data_investment <- compustat_annual |>
   mutate(date = floor_date(datadate, "month")) |>
   left_join(
@@ -69,6 +72,7 @@ data_investment <- data_investment |>
 Tobin's q is the ratio of the market value of capital to its replacement costs.\index{Tobin's q} It is one of the most common regressors in corporate finance applications [e.g., @Fazzari1988; @Erickson2012]. We follow the implementation of @Gulen2015 and compute Tobin's q as the market value of equity (`mktcap`) plus the book value of assets (`at`) minus book value of equity (`be`) plus deferred taxes (`txdb`), all divided by book value of assets (`at`). Finally, we only keep observations where all variables of interest are non-missing, and the reported book value of assets is strictly positive.
 
 ```{r}
+#| label: fixed-effects-and-clustered-standard-errors-compute-tobins-q
 data_investment <- data_investment |>
   left_join(crsp_monthly, join_by(gvkey, date)) |>
   mutate(tobins_q = (mktcap + at - be + txdb) / at) |>
@@ -79,6 +83,7 @@ data_investment <- data_investment |>
 As the variable construction typically leads to extreme values that are most likely related to data issues (e.g., reporting errors), many papers include winsorization of the variables of interest. Winsorization involves replacing values of extreme outliers with quantiles on the respective end. The following function implements the winsorization for any percentage cut that should be applied on either end of the distributions.\index{Winsorization} In the specific example, we winsorize the main variables (`investment`, `cash_flows`, and `tobins_q`) at the one percent level. 
 
 ```{r}
+#| label: fixed-effects-and-clustered-standard-errors-winsorize
 winsorize <- function(x, cut) {
   x <- replace(
     x,
@@ -103,6 +108,7 @@ data_investment <- data_investment |>
 Before proceeding to any estimations, we highly recommend tabulating summary statistics of the variables that enter the regression. These simple tables allow you to check the plausibility of your numerical variables, as well as spot any obvious errors or outliers. Additionally, for panel data, plotting the time series of the variable's mean and the number of observations is a useful exercise to spot potential problems.\index{Summary statistics}
 
 ```{r}
+#| label: fixed-effects-and-clustered-standard-errors-summary-stats
 data_investment |>
   pivot_longer(
     cols = c(investment_lead, cash_flows, tobins_q),
@@ -129,6 +135,7 @@ $$ \text{Investment}_{i,t+1} = \alpha + \beta_1\text{Cash Flows}_{i,t}+\beta_2\t
 where $\varepsilon_t$ is i.i.d. normally distributed across time and firms. We use the `feols()`-function to estimate the simple model so that the output has the same structure as the other regressions below, but you could also use `lm()`. 
 
 ```{r}
+#| label: fixed-effects-and-clustered-standard-errors-model-ols
 model_ols <- feols(
   fml = investment_lead ~ cash_flows + tobins_q,
   vcov = "iid",
@@ -149,6 +156,7 @@ where $\alpha_i$ is the firm fixed effect and captures the firm-specific mean in
 
 To include the firm fixed effect, we use `gvkey` (Compustat's firm identifier) as follows:
 ```{r}
+#| label: fixed-effects-and-clustered-standard-errors-model-fe-firm
 model_fe_firm <- feols(
   investment_lead ~ cash_flows + tobins_q | gvkey,
   vcov = "iid",
@@ -164,6 +172,7 @@ $$ \text{Investment}_{i,t+1} = \alpha_i + \alpha_t + \beta_1\text{Cash Flows}_{i
 where $\alpha_t$ is the time fixed effect. Here you can think of higher investments during an economic expansion with simultaneously high cash flows.
 
 ```{r}
+#| label: fixed-effects-and-clustered-standard-errors-model-fe-firmyear
 model_fe_firmyear <- feols(
   investment_lead ~ cash_flows + tobins_q | gvkey + year,
   vcov = "iid",
@@ -179,6 +188,7 @@ How can we further improve the robustness of our regression results? Ideally, we
 Before we discuss the properties of our estimation errors, we want to point out that regression tables are at the heart of every empirical analysis, where you compare multiple models. Fortunately, the `etable()` function provides a convenient way to tabulate the regression output (with many parameters to customize and even print the output in LaTeX). We recommend printing $t$-statistics rather than standard errors in regression tables because the latter are typically very hard to interpret across coefficients that vary in size. We also do not print p-values because they are sometimes misinterpreted to signal the importance of observed effects [@Wasserstein2016]. The $t$-statistics provide a consistent way to interpret changes in estimation uncertainty across different model specifications.  
 
 ```{r}
+#| label: fixed-effects-and-clustered-standard-errors-etable-fe
 etable(
   model_ols,
   model_fe_firm,
@@ -198,6 +208,7 @@ In our setting, the residuals may be correlated across years for a given firm (t
 Instead of relying on the iid assumption, we can use the cluster option in the `feols`-function as above. The code chunk below applies both one-way clustering by firm as well as two-way clustering by firm and year.
 
 ```{r}
+#| label: fixed-effects-and-clustered-standard-errors-model-cluster
 model_cluster_firm <- feols(
   investment_lead ~ cash_flows + tobins_q | gvkey + year,
   cluster = "gvkey",
@@ -215,6 +226,7 @@ model_cluster_firmyear <- feols(
 The table below shows the comparison of the different assumptions behind the standard errors. In the first column, we can see highly significant coefficients on both cash flows and Tobin's q. By clustering the standard errors on the firm level, the $t$-statistics of both coefficients drop in half, indicating a high correlation of residuals within firms. If we additionally cluster by year, we see a drop, particularly for Tobin's q, again. Even after relaxing the assumptions behind our standard errors, both coefficients are still comfortably significant as the $t$-statistics are well above the usual critical values of 1.96 or 2.576 for two-tailed significance tests.
 
 ```{r}
+#| label: fixed-effects-and-clustered-standard-errors-etable-cluster
 etable(
   model_fe_firmyear,
   model_cluster_firm,

--- a/r/modern-portfolio-theory.qmd
+++ b/r/modern-portfolio-theory.qmd
@@ -18,6 +18,7 @@ At the heart of MPT is mean-variance analysis, which evaluates portfolios based 
 We use the following packages throughout this chapter: 
 
 ```{r}
+#| label: modern-portfolio-theory-packages
 #| message: false
 #| warning: false
 library(tidyverse)
@@ -39,6 +40,7 @@ To keep things conceptually simple, we focus on the latter part for now and assu
 Thus, leveraging the approach introduced in [Working with Stock Returns](working-with-stock-returns.qmd), we download the constituents of the Dow Jones Industrial Average as an example portfolio as well as their daily adjusted close prices. 
 
 ```{r}
+#| label: modern-portfolio-theory-download-data
 #| output: false
 symbols <- download_data(
   domain = "constituents",
@@ -56,6 +58,7 @@ prices_daily <- download_data(
 To have a stable stock universe and to keep the analysis simple, we ensure that all stocks were traded over the whole sample period:
 
 ```{r}
+#| label: modern-portfolio-theory-filter-stable-universe
 prices_daily <- prices_daily |>
   group_by(symbol) |>
   mutate(n = n()) |>
@@ -67,6 +70,7 @@ prices_daily <- prices_daily |>
 We compute the sample average returns as $\frac{1}{T} \sum_{t=1}^{T} r_{i,t},$ where $r_{i,t}$ is the return of asset $i$ in period $t$, and $T$ is the total number of periods. As noted above, we treat the vector of sample averages as the true expected returns of the assets. For simplicity and easier interpretation, we focus on monthly returns going forward.
 
 ```{r}
+#| label: modern-portfolio-theory-compute-monthly-returns
 returns_monthly <- prices_daily |>
   mutate(date = floor_date(date, "month")) |>
   group_by(symbol, date) |>
@@ -81,6 +85,7 @@ Individual asset risk in MPT is typically quantified using variance (i.e., $\sig
 We compute the sample standard deviation for each asset by using the `sd()` function.
 
 ```{r}
+#| label: modern-portfolio-theory-compute-mu-sigma
 assets <- returns_monthly |> 
   group_by(symbol) |> 
   summarize(
@@ -114,6 +119,7 @@ The interpretation of the covariance is straightforward: While a positive covari
 We can use the `cov()` function that takes a matrix of returns as inputs. We thus need to transform the returns from a data frame into a $(T \times N)$ matrix with one column for each of the $N$ symbols and one row for each of the $T$ trading days. We achieve this by using `pivot_wider()` with the new column names from the `symbol`-column and setting the values to `ret`.
 
 ```{r}
+#| label: modern-portfolio-theory-covariance-matrix
 returns_wide <- returns_monthly |> 
   pivot_wider(names_from = symbol, values_from = ret) 
 
@@ -157,6 +163,7 @@ $$\omega_\text{mvp} = \frac{\Sigma^{-1}\iota}{\iota^{\prime}\Sigma^{-1}\iota},$$
 where $\iota$ is a vector of 1's and $\Sigma^{-1}$ is the inverse of the variance-covariance matrix $\Sigma$. See [Proofs](proofs.qmd) in the Appendix for details on the derivation. In the following code chunk, we calculate the weights of the minimum-variance portfolio:
 
 ```{r}
+#| label: modern-portfolio-theory-minimum-variance-weights
 iota <- rep(1, dim(sigma)[1])
 sigma_inv <- solve(sigma)
 omega_mvp <- as.vector(sigma_inv %*% iota) / 
@@ -184,6 +191,7 @@ assets |>
 Before we move on to other portfolios, we collect the return and volatility of the minimum-variance portfolio in a data frame:
 
 ```{r}
+#| label: modern-portfolio-theory-minimum-variance-summary
 mu <- assets$mu
 
 summary_mvp <- tibble(
@@ -201,6 +209,7 @@ In many instances, earning the lowest possible variance may not be the desired o
 Suppose, for instance, the investor wants to earn at least the historical average return of the asset that delivered the highest average returns in the past:
 
 ```{r}
+#| label: modern-portfolio-theory-target-return
 mu_bar <- max(assets$mu)
 ```
 
@@ -217,6 +226,7 @@ where $\lambda^* = 2\frac{\bar\mu - D/C}{E-D^2/C}$, $C = \iota'\Sigma^{-1}\iota$
 The code below implements the analytic solution to this optimization problem and collects the resulting portfolio return and risk in a data frame.
 
 ```{r}
+#| label: modern-portfolio-theory-efficient-portfolio
 C <- as.numeric(t(iota) %*% sigma_inv %*% iota)
 D <- as.numeric(t(iota) %*% sigma_inv %*% mu)
 E <- as.numeric(t(mu) %*% sigma_inv %*% mu)
@@ -277,6 +287,7 @@ which corresponds to the efficient portfolio earning $a\mu_1 + (1-a)\mu_2$ in ex
 The code below implements the construction of this efficient frontier, which characterizes the highest expected return achievable at each level of risk.
 
 ```{r}
+#| label: modern-portfolio-theory-efficient-frontier
 efficient_frontier <- tibble(
   a = seq(from = -1, to = 2, by = 0.01),
 ) |> 

--- a/r/option-pricing-via-machine-learning.qmd
+++ b/r/option-pricing-via-machine-learning.qmd
@@ -22,6 +22,7 @@ While ML can be specified along a vast array of different branches, this chapter
 Throughout this chapter, we need the following R packages.
 
 ```{r}
+#| label: option-pricing-via-machine-learning-packages
 #| message: false
 library(tidyverse)
 library(tidymodels)
@@ -76,6 +77,7 @@ where $C(S, T)$ is the price of the option as a function of today's stock price 
 The Black-Scholes equation provides a way to compute the arbitrage-free price of a call option once the parameters $S, K, r_f, T$, and $\sigma$ are specified (arguably, in a realistic context, all parameters are easy to specify except for $\sigma$ which has to be estimated). A simple R function allows computing the price as we do below. 
 
 ```{r}
+#| label: option-pricing-via-machine-learning-black-scholes-function
 black_scholes_price <- function(S, K = 70, r = 0, T = 1, sigma = 0.2) {
   
   d1 <- (log(S / K) + (r + sigma^2 / 2) * T) / (sigma * sqrt(T))
@@ -97,6 +99,7 @@ To that end, we start with simulated data. We compute option prices for call opt
 In order to keep the analysis reproducible, we use `set.seed()`. A random seed specifies the start point when a computer generates a random number sequence and ensures that our simulated data is the same across different machines. 
 
 ```{r}
+#| label: option-pricing-via-machine-learning-simulate-option-prices
 set.seed(420)
 
 option_prices <- expand_grid(
@@ -120,12 +123,14 @@ The code above generates more than 1.5 million random parameter constellations. 
 Next, we split the data into a training set (which contains 1\% of all the observed option prices) and a test set that will only be used for the final evaluation. Note that the entire grid of possible combinations contains `r option_prices |> nrow()` different specifications. Thus, the sample to learn the Black-Scholes price contains only 31,489 observations and is therefore relatively small.
 
 ```{r}
+#| label: option-pricing-via-machine-learning-train-test-split
 split <- initial_split(option_prices, prop = 1 / 100)
 ```
 
 We process the training dataset further before we fit the different ML models. We define a `recipe()` that defines all processing steps for that purpose. For our specific case, we want to explain the observed price by the five variables that enter the Black-Scholes equation. The *true* prices (stored in column `black_scholes`) should obviously not be used to fit the model. The recipe also reflects that we standardize all predictors to ensure that each variable exhibits a sample average of zero and a sample standard deviation of one.  
 
 ```{r}
+#| label: option-pricing-via-machine-learning-recipe
 rec <- recipe(observed_price ~ .,
   data = option_prices
 ) |>
@@ -138,6 +143,7 @@ rec <- recipe(observed_price ~ .,
 Next, we show how to fit a neural network to the data. Note that this requires that `torch` is installed on your local machine. The function `mlp()` from the package `parsnip` provides the functionality to initialize a single layer, feed-forward neural network. The specification below defines a single layer feed-forward neural network with 10 hidden units. We set the number of training iterations to `epochs = 500`. The option `set_mode("regression")` specifies a linear activation function for the output layer. 
 
 ```{r}
+#| label: option-pricing-via-machine-learning-nnet-model
 nnet_model <- mlp(
   epochs = 500,
   hidden_units = 10,
@@ -151,6 +157,7 @@ nnet_model <- mlp(
 The `verbose = FALSE` argument prevents logging the results to the console. We can follow the straightforward `tidymodel` workflow as in [Factor Selection via Machine Learning](factor-selection-via-machine-learning.qmd): define a workflow, equip it with the recipe, and specify the associated model. Finally, fit the model with the training data. 
 
 ```{r}
+#| label: option-pricing-via-machine-learning-nnet-fit
 nn_fit <- workflow() |>
   add_recipe(rec) |>
   add_model(nnet_model) |>
@@ -162,6 +169,7 @@ For instance, the model below initializes a random forest with 50 trees containe
 The random forests are trained using the package `ranger`, which is required to be installed in order to run the code below. 
 
 ```{r}
+#| label: option-pricing-via-machine-learning-rf-model
 rf_model <- rand_forest(
   trees = 50,
   min_n = 2000
@@ -173,6 +181,7 @@ rf_model <- rand_forest(
 Fitting the model follows exactly the same convention as for the neural network before.
 
 ```{r}
+#| label: option-pricing-via-machine-learning-rf-fit
 rf_fit <- workflow() |>
   add_recipe(rec) |>
   add_model(rf_model) |>
@@ -186,6 +195,7 @@ A deep neural network is a neural network with multiple layers between the input
 Note that while the `tidymodels` workflow is extremely convenient, these more sophisticated multi-layer (so-called *deep*) neural networks are not supported by `tidymodels` yet (as of September 2022). Instead, an implementation of a deep neural network in R requires additional computational tools. For that reason, the code snippet below illustrates how to initialize a sequential model with three hidden layers with 10 units per layer. \index{torch} The `brulee` package provides a convenient interface to `torch` and is flexible enough to handle different activation functions. 
 
 ```{r}
+#| label: option-pricing-via-machine-learning-deep-nnet-model
 deep_nnet_model <- mlp(
   epochs = 500,
   hidden_units = c(10, 10, 10),
@@ -199,6 +209,7 @@ deep_nnet_model <- mlp(
 To train the neural network, we provide the inputs (`x`) and the variable to predict (`y`) and then fit the parameters. Note the slightly tedious use of the method `extract_mold(nn_fit)`. Instead of simply using the *raw* data, we fit the neural network with the same processed data that is used for the single-layer feed-forward network. What is the difference to simply calling `x = training(data) |> select(-observed_price, -black_scholes)`? Recall that the recipe standardizes the variables such that all columns have unit standard deviation and zero mean. Further, it adds consistency if we ensure that all models are trained using the same recipe such that a change in the recipe is reflected in the performance of any model. A final note on a potentially irritating observation: `fit()` alters the model - this is one of the few instances, where a function in R alters the *input* such that after the function call the object `model` is not same anymore!
 
 ```{r}
+#| label: option-pricing-via-machine-learning-deep-nnet-fit
 deep_nn_fit <- workflow() |>
   add_recipe(rec) |>
   add_model(deep_nnet_model) |>
@@ -209,7 +220,8 @@ deep_nn_fit <- workflow() |>
 
 Before we evaluate the results, we implement one more model. In principle, any non-linear function can also be approximated by a linear model containing the input variables' polynomial expansions. To illustrate this, we first define a new recipe, `rec_linear`, which processes the training data even further. We include polynomials up to the fifth degree of each predictor and then add all possible pairwise interaction terms. The final recipe step, `step_lincomb()`, removes potentially redundant variables (for instance, the interaction between $r^2$ and $r^3$ is the same as the term $r^5$). We fit a Lasso regression model with a pre-specified penalty term (consult [Factor Selection via Machine Learning](factor-selection-via-machine-learning.qmd) on how to tune the model hyperparameters).
 
-```{r} 
+```{r}
+#| label: option-pricing-via-machine-learning-linear-lasso-fit
 rec_linear <- rec |>
   step_poly(all_predictors(),
     degree = 5,
@@ -232,6 +244,7 @@ lm_fit <- workflow() |>
 Finally, we collect all predictions to compare the *out-of-sample* prediction error evaluated on 10,000 new data points. Note that for the evaluation, we use the call to `extract_mold()` to ensure that we use the same pre-processing steps for the testing data across each model. We also use the somewhat advanced functionality in `forge()`, which provides an easy, consistent, and robust pre-processor at prediction time. 
 
 ```{r}
+#| label: option-pricing-via-machine-learning-predictive-performance
 out_of_sample_data <- testing(split) |>
   slice_sample(n = 10000)
 

--- a/r/parametric-portfolio-policies.qmd
+++ b/r/parametric-portfolio-policies.qmd
@@ -18,6 +18,7 @@ We choose weights as a function of the characteristics, which maximize the expec
 The current chapter relies on the following set of R packages:
 
 ```{r}
+#| label: parametric-portfolio-policies-packages
 #| message: false
 library(tidyverse)
 library(arrow)
@@ -28,12 +29,14 @@ library(arrow)
 To get started, we load the monthly CRSP file, which forms our investment universe. We load the data from our Parquet files introduced in [Accessing and Managing Financial Data](accessing-and-managing-financial-data.qmd) and [WRDS, CRSP, and Compustat](wrds-crsp-and-compustat.qmd).\index{Data!CRSP}
 
 ```{r}
+#| label: parametric-portfolio-policies-load-crsp
 crsp_monthly <- read_parquet("data-r/crsp_monthly.parquet") |>
   select(permno, date, ret_excess, mktcap, mktcap_lag)
 ```
 
 To evaluate the performance of portfolios, we further use monthly market returns as a benchmark to compute CAPM alphas.\index{Data!Fama-French factors} 
 ```{r}
+#| label: parametric-portfolio-policies-load-factors
 factors_ff3_monthly <- read_parquet("data-r/factors_ff3_monthly.parquet") |>
   select(date, mkt_excess)
 ```
@@ -41,6 +44,7 @@ factors_ff3_monthly <- read_parquet("data-r/factors_ff3_monthly.parquet") |>
 Next, we retrieve some stock characteristics that have been shown to have an effect on the expected returns or expected variances (or even higher moments) of the return distribution. \index{Momentum} In particular, we record the lagged one-year return momentum (`momentum_lag`), defined as the compounded return between months $t-13$ and $t-2$ for each firm, which we calculate using market capitalization for simplicity. In finance, momentum is the empirically observed tendency for rising asset prices to rise further, and falling prices to keep falling [@Jegadeesh1993]. We refer to the exercise for a more elaborate measure of momentum. \index{Size!Size effect} The second characteristic is the firm's market equity (`size_lag`), defined as the log of the price per share times the number of shares outstanding [@Banz1981]. To construct the correct lagged values, we use the approach introduced in [WRDS, CRSP, and Compustat](wrds-crsp-and-compustat.qmd).\index{Data!CRSP}
 
 ```{r}
+#| label: parametric-portfolio-policies-compute-characteristics
 crsp_monthly_lags <- crsp_monthly |>
   transmute(permno, date_13 = date %m+% months(13), mktcap)
 
@@ -76,6 +80,7 @@ Intuitively, the portfolio strategy is a form of active portfolio management rel
 We first implement cross-sectional standardization for the entire CRSP universe. We also keep track of (lagged) relative market capitalization `relative_mktcap`, which will represent the value-weighted benchmark portfolio, while `n` denotes the number of traded assets $N_t$, which we use to construct the naive portfolio benchmark.
 
 ```{r}
+#| label: parametric-portfolio-policies-standardize-characteristics
 data_portfolios <- data_portfolios |>
   group_by(date) |>
   mutate(
@@ -98,6 +103,7 @@ The allocation strategy is straightforward because the number of parameters to e
 To get a feeling for the performance of such an allocation strategy, we start with an arbitrary initial vector $\theta_0$. The next step is to choose $\theta$ optimally to maximize the objective function. We automatically detect the number of parameters by counting the number of columns with lagged values.
 
 ```{r}
+#| label: parametric-portfolio-policies-initial-theta
 n_parameters <- sum(str_detect(
   colnames(data_portfolios), "lag"
 ))
@@ -120,6 +126,7 @@ $$\omega_{i,t}^+ = \frac{\max(0, \omega_{i,t})}{\sum_{j=1}^{N_t}\max(0, \omega_{
 
 The following function computes the optimal portfolio weights in the way just described.  
 ```{r}
+#| label: parametric-portfolio-policies-compute-weights-function
 compute_portfolio_weights <- function(theta,
                                       data,
                                       value_weighting = TRUE,
@@ -154,6 +161,7 @@ compute_portfolio_weights <- function(theta,
 In the next step, we compute the portfolio weights for the arbitrary vector $\theta_0$. In the example below, we use the value-weighted portfolio as a benchmark and allow negative portfolio weights.
 
 ```{r}
+#| label: parametric-portfolio-policies-compute-weights-initial
 weights_crsp <- compute_portfolio_weights(
   theta,
   data_portfolios,
@@ -168,6 +176,7 @@ weights_crsp <- compute_portfolio_weights(
 Are the computed weights optimal in any way? Most likely not, as we picked $\theta_0$ arbitrarily. To evaluate the performance of an allocation strategy, one can think of many different approaches. In their original paper, @Brandt2009 focus on a simple evaluation of the hypothetical utility of an agent equipped with a power utility function $u_\gamma(r) = \frac{(1 + r)^{(1-\gamma)}}{1-\gamma}$, where $\gamma$ is the risk aversion factor.\index{Power utility}
 
 ```{r}
+#| label: parametric-portfolio-policies-power-utility
 power_utility <- function(r, gamma = 5) {
   (1 + r)^(1 - gamma) / (1 - gamma)
 }
@@ -178,6 +187,7 @@ We want to note that @Gehrig2020 warn that, in the leading case of constant rela
 No doubt, there are many other ways to evaluate a portfolio. The function below provides a summary of all kinds of interesting measures that can be considered relevant. Do we need all these evaluation measures? It depends: the original paper by @Brandt2009 only cares about the expected utility to choose $\theta$. However, if you want to choose optimal values that achieve the highest performance while putting some constraints on your portfolio weights, it is helpful to have everything in one function.
 
 ```{r}
+#| label: parametric-portfolio-policies-evaluate-portfolio-function
 evaluate_portfolio <- function(weights_crsp,
                                capm_evaluation = TRUE,
                                full_evaluation = TRUE,
@@ -253,6 +263,7 @@ evaluate_portfolio <- function(weights_crsp,
 Let us take a look at the different portfolio strategies and evaluation measures.
 
 ```{r}
+#| label: parametric-portfolio-policies-evaluate-initial
 evaluate_portfolio(weights_crsp) |>
   print(n = Inf)
 ```
@@ -264,6 +275,7 @@ The value-weighted portfolio delivers an annualized return of more than 6 percen
 Next, we move to a choice of $\theta$ that actually aims to improve some (or all) of the performance measures. We first define a helper function `compute_objective_function()`, which we then pass to an optimizer.
 
 ```{r}
+#| label: parametric-portfolio-policies-objective-function
 compute_objective_function <- function(theta,
                                        data,
                                        objective_measure = "Expected utility",
@@ -292,6 +304,7 @@ You may wonder why we return the negative value of the objective function. This 
 In its most basic form, R optimization relies on the function `optim()`. As main inputs, the function requires an initial guess of the parameters and the objective function to minimize. Now, we are fully equipped to compute the optimal values of $\hat\theta$, which maximize the hypothetical expected utility of the investor. 
 
 ```{r}
+#| label: parametric-portfolio-policies-optimize-theta
 optimal_theta <- optim(
   par = theta,
   fn = compute_objective_function,
@@ -312,6 +325,7 @@ The resulting values of $\hat\theta$ are easy to interpret: intuitively, expecte
 How does the portfolio perform for different model specifications? For this purpose, we compute the performance of a number of different modeling choices based on the entire CRSP sample. The next code chunk performs all the heavy lifting.
 
 ```{r}
+#| label: parametric-portfolio-policies-evaluate-specifications
 evaluate_optimal_performance <- function(data, 
                                          objective_measure,
                                          value_weighting, 
@@ -359,6 +373,7 @@ specifications <- expand_grid(
 Finally, we can compare the results. The table below shows summary statistics for all possible combinations: equal- or value-weighted benchmark portfolio, with or without short-selling constraints, and tilted toward maximizing expected utility. 
 
 ```{r}
+#| label: parametric-portfolio-policies-performance-table
 performance_table <- specifications |>
   select(
     value_weighting,

--- a/r/replicating-fama-and-french-factors.qmd
+++ b/r/replicating-fama-and-french-factors.qmd
@@ -21,6 +21,7 @@ After the replication of the three-factor model, we move to the five factors by 
 The current chapter relies on this set of R packages. 
 
 ```{r}
+#| label: replicating-fama-and-french-factors-packages
 #| message: false
 library(tidyverse)
 library(arrow)
@@ -31,6 +32,7 @@ library(arrow)
 We use CRSP and Compustat as data sources, as we need the same variables to compute the factors in the way Fama and French do it. Hence, we only load data from our Parquet files introduced in [Accessing and Managing Financial Data](accessing-and-managing-financial-data.qmd) and [WRDS, CRSP, and Compustat](wrds-crsp-and-compustat.qmd).^[Note that @Fama1992 claim to exclude financial firms. To a large extent this happens through using industry format "INDL", as we do in [WRDS, CRSP, and Compustat](wrds-crsp-and-compustat.qmd). Neither the original paper, nor Ken French's website, or the WRDS replication contains any indication that financial companies are excluded using additional filters such as industry codes.] \index{Data!CRSP}\index{Data!Compustat} The only addition is that we keep only firms with positive book equity, which is a common practice when working with book-to-market ratios [see @Fama1992 for details].\index{Book equity}
 
 ```{r}
+#| label: replicating-fama-and-french-factors-load-data
 crsp_monthly <- read_parquet("data-r/crsp_monthly.parquet") |>
   select(
     permno,
@@ -60,6 +62,7 @@ Second, Fama and French also have a different protocol for computing the book-to
 To implement all these time lags, we again employ the temporary `sorting_date`-column. Notice that when we combine the information, we want to have a single observation per year and stock since we are only interested in computing the breakpoints held constant for the entire year. We ensure this by a call of `distinct()` at the end of the chunk below.
 
 ```{r}
+#| label: replicating-fama-and-french-factors-sorting-variables-ff3
 size <- crsp_monthly |>
   filter(month(date) == 6) |>
   mutate(sorting_date = date %m+% months(1)) |>
@@ -91,6 +94,7 @@ sorting_variables <- size |>
 Next, we construct our portfolios with an adjusted `assign_portfolio()` function.\index{Portfolio sorts} Fama and French rely on NYSE-specific breakpoints to independently form two portfolios in the size dimension at the median and three portfolios in the dimension of book-to-market at the 30- and 70-percentiles. The sorts for book-to-market require an adjustment to the function in [Value and Bivariate Sorts](value-and-bivariate-sorts.qmd) because it would not produce the right breakpoints. Instead of `n_portfolios`, we now specify `percentiles`, which takes the sequence of breakpoints as an object specified in the function's call. Specifically, we give `percentiles = c(0.3, 0.7)` to the function. Additionally, we perform an `inner_join()` with our return data to ensure that we only use traded stocks when computing the breakpoints as a first step.\index{Breakpoints}
 
 ```{r}
+#| label: replicating-fama-and-french-factors-assign-portfolio
 assign_portfolio <- function(
   data,
   sorting_variable,
@@ -142,6 +146,7 @@ Alternatively, you can implement the same portfolio sorts using the `assign_port
 Next, we merge the portfolios to the return data for the rest of the year. To implement this step, we create a new column `sorting_date` in our return data by setting the date to sort on to July of $t-1$ if the month is June (of year $t$) or earlier or to July of year $t$ if the month is July or later.
 
 ```{r}
+#| label: replicating-fama-and-french-factors-merge-portfolios-ff3
 portfolios <- crsp_monthly |>
   mutate(
     sorting_date = case_when(
@@ -157,6 +162,7 @@ portfolios <- crsp_monthly |>
 Equipped with the return data and the assigned portfolios, we can now compute the value-weighted average return for each of the six portfolios. Then, we form the Fama-French factors. For the size factor (i.e., SMB), we go long in the three small portfolios and short the three large portfolios by taking an average across either group. For the value factor (i.e., HML), we go long in the two high book-to-market portfolios and short the two low book-to-market portfolios, again weighting them equally.\index{Factor!Size}\index{Factor!Value}
 
 ```{r}
+#| label: replicating-fama-and-french-factors-construct-factors-ff3
 factors_replicated <- portfolios |>
   group_by(portfolio_size, portfolio_bm, date) |>
   summarize(
@@ -177,6 +183,7 @@ factors_replicated <- portfolios |>
 In the previous section, we replicated the size and value premiums following the procedure outlined by Fama and French.\index{Size!Size premium}\index{Value premium} The final question is then: how close did we get? We answer this question by looking at the two time-series estimates in a regression analysis using `lm()`. If we did a good job, then we should see a non-significant intercept (rejecting the notion of systematic error), a coefficient close to 1 (indicating a high correlation), and an adjusted R-squared close to 1 (indicating a high proportion of explained variance).
 
 ```{r}
+#| label: replicating-fama-and-french-factors-test-data-ff3
 test <- factors_ff3_monthly |>
   inner_join(factors_replicated, join_by(date)) |>
   mutate(
@@ -187,6 +194,7 @@ test <- factors_ff3_monthly |>
 To test the success of the SMB factor, we hence run the following regression:
 
 ```{r}
+#| label: replicating-fama-and-french-factors-smb-regression-ff3
 model_smb <- lm(smb ~ smb_replicated, data = test)
 summary(model_smb)
 ```
@@ -194,6 +202,7 @@ summary(model_smb)
 The results for the SMB factor are really convincing, as all three criteria outlined above are met and the coefficient is `r round(model_smb$coefficients[2], 2)` and the R-squared is at `r round(summary(model_smb)$adj.r.squared, 2) * 100` percent. 
 
 ```{r}
+#| label: replicating-fama-and-french-factors-hml-regression-ff3
 model_hml <- lm(hml ~ hml_replicated, data = test)
 summary(model_hml)
 ```
@@ -207,6 +216,7 @@ The evidence hence allows us to conclude that we did a relatively good job in re
 Now, let us move to the replication of the five-factor model. We extend the `other_sorting_variables` table from above with the additional characteristics operating profitability `op` and investment `inv`. Note that the `drop_na()` statement yields different sample sizes as some firms with `be` values might not have `op` or `inv` values. 
 
 ```{r}
+#| label: replicating-fama-and-french-factors-sorting-variables-ff5
 other_sorting_variables <- compustat_annual |>
   mutate(sorting_date = ymd(str_c(year(datadate) + 1, "0701"))) |>
   select(gvkey, sorting_date, be, op, inv) |>
@@ -226,6 +236,7 @@ sorting_variables <- size |>
 In each month, we independently sort all stocks into the two size portfolios. The value, profitability, and investment portfolios, on the other hand, are the results of dependent sorts based on the size portfolios. We then merge the portfolios to the return data for the rest of the year just as above. 
 
 ```{r}
+#| label: replicating-fama-and-french-factors-portfolio-sorts-ff5
 portfolios <- sorting_variables |>
   group_by(sorting_date) |>
   mutate(
@@ -270,6 +281,7 @@ portfolios <- crsp_monthly |>
 Now, we want to construct each of the factors, but this time the size factor actually comes last because it is the result of averaging across all other factor portfolios. This dependency is the reason why we keep the table with value-weighted portfolio returns as a separate object that we reuse later. We construct the value factor, HML, as above by going long the two portfolios with high book-to-market ratios and shorting the two portfolios with low book-to-market.
 
 ```{r}
+#| label: replicating-fama-and-french-factors-value-factor-ff5
 portfolios_value <- portfolios |>
   group_by(portfolio_size, portfolio_bm, date) |>
   summarize(
@@ -288,6 +300,7 @@ factors_value <- portfolios_value |>
 For the profitability factor, RMW, we take a long position in the two high profitability portfolios and a short position in the two low profitability portfolios.\index{Factor!Profitability}
 
 ```{r}
+#| label: replicating-fama-and-french-factors-profitability-factor-ff5
 portfolios_profitability <- portfolios |>
   group_by(portfolio_size, portfolio_op, date) |>
   summarize(
@@ -306,6 +319,7 @@ factors_profitability <- portfolios_profitability |>
 For the investment factor, CMA, we go long the two low investment portfolios and short the two high investment portfolios.\index{Factor!Investment}
 
 ```{r}
+#| label: replicating-fama-and-french-factors-investment-factor-ff5
 portfolios_investment <- portfolios |>
   group_by(portfolio_size, portfolio_inv, date) |>
   summarize(
@@ -324,6 +338,7 @@ factors_investment <- portfolios_investment |>
 Finally, the size factor, SMB, is constructed by going long the nine small portfolios and short the nine large portfolios. 
 
 ```{r}
+#| label: replicating-fama-and-french-factors-size-factor-ff5
 factors_size <- bind_rows(
   portfolios_value,
   portfolios_profitability,
@@ -339,6 +354,7 @@ factors_size <- bind_rows(
 We then join all factors together into one dataframe and construct again a suitable table to run tests for evaluating our replication.
 
 ```{r}
+#| label: replicating-fama-and-french-factors-test-data-ff5
 factors_replicated <- factors_size |>
   full_join(factors_value, join_by(date)) |>
   full_join(factors_profitability, join_by(date)) |>
@@ -357,6 +373,7 @@ test <- factors_ff5_monthly |>
 Let us start the replication evaluation again with the size factor:
 
 ```{r}
+#| label: replicating-fama-and-french-factors-smb-regression-ff5
 model_smb <- lm(smb ~ smb_replicated, data = test)
 summary(model_smb)
 ```
@@ -364,6 +381,7 @@ summary(model_smb)
 The results for the SMB factor are quite convincing as all three criteria outlined above are met and the coefficient is `r round(model_smb$coefficients[2], 2)` and the R-squared is at `r round(summary(model_smb)$adj.r.squared, 2) * 100` percent. 
 
 ```{r}
+#| label: replicating-fama-and-french-factors-hml-regression-ff5
 model_hml <- lm(hml ~ hml_replicated, data = test)
 summary(model_hml)
 ```
@@ -371,6 +389,7 @@ summary(model_hml)
 The replication of the HML factor is also a success, although at a slightly higher coefficient of `r round(model_hml$coefficients[2], 2)` and an R-squared around `r round(summary(model_hml)$adj.r.squared, 2) * 100` percent. 
 
 ```{r}
+#| label: replicating-fama-and-french-factors-rmw-regression-ff5
 model_rmw <- lm(rmw ~ rmw_replicated, data = test)
 summary(model_rmw)
 ```
@@ -378,6 +397,7 @@ summary(model_rmw)
 We are also able to replicate the RMW factor quite well with a coefficient of `r round(model_rmw$coefficients[2], 2)` and an R-squared around `r round(summary(model_rmw)$adj.r.squared, 2) * 100` percent.
 
 ```{r}
+#| label: replicating-fama-and-french-factors-cma-regression-ff5
 model_cma <- lm(cma ~ cma_replicated, data = test)
 summary(model_cma)
 ```

--- a/r/setting-up-your-environment.qmd
+++ b/r/setting-up-your-environment.qmd
@@ -36,6 +36,7 @@ RStudio is a program similar to other programs you most likely use, like a brows
 Following your read of the preface to this book, you might now wonder why we did not download the `tidyverse` yet. Therefore, you must understand one more concept, namely packages in R.\index{Packages} You can think of them as extensions that you use for specific purposes, whereas R itself is the core pillar upon which everything rests. Comfortably, you can install packages within R with the following code. 
 
 ```{r, eval = FALSE}
+#| label: setting-up-your-environment-install-tidyverse
 install.packages("tidyverse")
 ```
 
@@ -66,6 +67,7 @@ If you plan to share your own code with collaborators or the public, you may enc
 You can use `.Renviron`-files to store environment variables. Upon startup, R and RStudio look for `.Renviron` files in your home and project directory. `.Renviron`-files can be either at the user or project level. If there is a project-level `.Renviron`, the user-level file will not be sourced. A simple way to create your own `.Renviron`-file is the function `usethis::edit_r_environ()`.
 
 ```{r}
+#| label: setting-up-your-environment-edit-renviron
 #| eval: false
 usethis::edit_r_environ(scope = "project")
 ```
@@ -80,6 +82,7 @@ WRDS_PASSWORD=password
 After you have restarted your RStudio session, you can access these environment variables via `Sys.getenv()` for future sessions using the specific project or user.
 
 ```{r}
+#| label: setting-up-your-environment-access-credentials
 #| eval: false
 Sys.getenv("WRDS_USER")
 Sys.getenv("WRDS_PASSWORD")
@@ -90,6 +93,7 @@ Note that you can also store other login credentials, API keys, or file paths in
 If you use version control, then you should make sure that the `.Renviron`-file is included in your `.gitignore` with the following code line.
 
 ```{r}
+#| label: setting-up-your-environment-edit-gitignore
 #| eval: false
 usethis::edit_git_ignore(scope = "project")
 ```
@@ -102,6 +106,7 @@ The complete source is [available from GitHub](https://github.com/tidy-finance/w
 This version of the book was built with R [@R-base] version `r paste0(version$major,".", version$minor, " (",version$year, "-", version$month, "-", version$day,", ", version$nickname,")")` and the following packages: \index{Colophon}
 
 ```{r}
+#| label: setting-up-your-environment-colophon
 #| echo: false
 #| message: false
 #| warning: false

--- a/r/size-sorts-and-p-hacking.qmd
+++ b/r/size-sorts-and-p-hacking.qmd
@@ -19,6 +19,7 @@ There is arguably a thin line between p-hacking and conducting robustness tests.
 The chapter relies on the following set of packages:
 
 ```{r}
+#| label: size-sorts-and-p-hacking-packages
 #| message: false
 library(tidyverse)
 library(arrow)
@@ -36,6 +37,7 @@ Compared to previous chapters, we introduce the `rlang` package [@rlang] for mor
 First, we retrieve the relevant data from our Parquet files introduced in [Accessing and Managing Financial Data](accessing-and-managing-financial-data.qmd) and [WRDS, CRSP, and Compustat](wrds-crsp-and-compustat.qmd). Firm size is defined as market equity in most asset pricing applications that we retrieve from CRSP. We further use the Fama-French factor returns for performance evaluation.\index{Data!CRSP}\index{Data!Fama-French factors}
 
 ```{r}
+#| label: size-sorts-and-p-hacking-read-data
 crsp_monthly <- read_parquet("data-r/crsp_monthly.parquet")
 
 factors_ff3_monthly <- read_parquet("data-r/factors_ff3_monthly.parquet") |>
@@ -136,6 +138,7 @@ Finally, we consider the distribution of firm size across listing exchanges and 
 The resulting table shows that firms listed on NYSE in December 2023 are significantly larger on average than firms listed on the other exchanges. Moreover, NASDAQ lists the largest number of firms. This discrepancy between firm sizes across listing exchanges motivated researchers to form breakpoints exclusively on the NYSE sample and apply those breakpoints to all stocks. In the following, we use this distinction to update our portfolio sort procedure.
 
 ```{r, message = FALSE}
+#| label: size-sorts-and-p-hacking-create-summary
 create_summary <- function(data, column_name) {
   data |>
     select(value = {{ column_name }}) |>
@@ -170,6 +173,7 @@ In [Univariate Portfolio Sorts](univariate-portfolio-sorts.qmd), we construct po
 To replicate the NYSE-centered sorting procedure, we introduce `exchanges` as an argument in our `assign_portfolio()` function. The exchange-specific argument then enters in the filter `filter(exchange %in% exchanges)`. For example, if `exchanges = 'NYSE'` is specified, only stocks listed on NYSE are used to compute the breakpoints. Alternatively, you could specify `exchanges = c("NYSE", "NASDAQ", "AMEX")`, which keeps all stocks listed on either of these exchanges. Overall, regular expressions are a powerful tool, and we only touch on a specific case here.
 
 ```{r}
+#| label: size-sorts-and-p-hacking-assign-portfolio
 assign_portfolio <- function(
   data,
   n_portfolios,
@@ -207,6 +211,7 @@ Apart from computing breakpoints on different samples, researchers often use dif
 We implement the two weighting schemes in the function `compute_portfolio_returns()` that takes a logical argument to weight the returns by firm value. The statement `if_else(value_weighted, weighted.mean(ret_excess, mktcap_lag), mean(ret_excess))` generates value-weighted returns if `value_weighted = TRUE`. Additionally, the long-short portfolio is long in the smallest firms and short in the largest firms, consistent with research showing that small firms outperform their larger counterparts. Apart from these two changes, the function is similar to the procedure in [Univariate Portfolio Sorts](univariate-portfolio-sorts.qmd).
 
 ```{r}
+#| label: size-sorts-and-p-hacking-compute-portfolio-returns
 compute_portfolio_returns <- function(
   n_portfolios = 10,
   exchanges = c("NYSE", "NASDAQ", "AMEX"),
@@ -244,6 +249,7 @@ compute_portfolio_returns <- function(
 To see how the function `compute_portfolio_returns()` works, we consider a simple median breakpoint example with value-weighted returns. We are interested in the effect of restricting listing exchanges on the estimation of the size premium. In the first function call, we compute returns based on breakpoints from all listing exchanges. Then, we computed returns based on breakpoints from NYSE-listed stocks.
 
 ```{r}
+#| label: size-sorts-and-p-hacking-nyse-vs-all
 ret_all <- compute_portfolio_returns(
   n_portfolios = 2,
   exchanges = c("NYSE", "NASDAQ", "AMEX"),
@@ -283,6 +289,7 @@ Nevertheless, the multitude of options creates a problem since there is no singl
 Below we conduct a series of robustness tests which could also be interpreted as a p-hacking exercise. To do so, we examine the size premium in different specifications presented in the table `p_hacking_setup`. The function `expand_grid()` produces a table of all possible permutations of its arguments. Note that we use the argument `data` to exclude financial firms and truncate the time series. 
 
 ```{r}
+#| label: size-sorts-and-p-hacking-setup-grid
 p_hacking_setup <- expand_grid(
   n_portfolios = c(2, 5, 10),
   exchanges = list("NYSE", c("NYSE", "NASDAQ", "AMEX")),
@@ -299,6 +306,7 @@ p_hacking_setup <- expand_grid(
 To speed the computation up we parallelize the (many) different sorting procedures, as in [Beta Estimation](beta-estimation.qmd). Finally, we report the resulting size premiums in descending order. There are indeed substantial size premiums possible in our data, in particular when we use equal-weighted portfolios. 
 
 ```{r}
+#| label: size-sorts-and-p-hacking-run-results
 n_cores = availableCores() - 1
 plan(multisession, workers = n_cores)
 

--- a/r/trace-and-fisd.qmd
+++ b/r/trace-and-fisd.qmd
@@ -20,6 +20,7 @@ Many researchers study liquidity in the US corporate bond market [see, e.g., @be
 The current chapter relies on this set of R packages. 
 
 ```{r}
+#| label: trace-and-fisd-packages
 #| message: false
 library(tidyverse)
 library(tidyfinance)
@@ -35,6 +36,7 @@ Compared to previous chapters, we load the `devtools` package [@devtools] to sou
 Both bond databases we need are available on [WRDS](https://wrds-www.wharton.upenn.edu/) to which we establish the `RPostgres` connection described in [WRDS, CRSP, and Compustat](wrds-crsp-and-compustat.qmd).\index{WRDS}
 
 ```{r}
+#| label: trace-and-fisd-wrds-connection
 #| eval: !expr params$download_data
 wrds <- dbConnect(
   Postgres(),
@@ -73,6 +75,7 @@ The following chunk connects to the data and selects the bond sample to remove c
 1. Exclude unit deal bonds (`(unit_deal = 'N' OR unit_deal IS NULL)`).
 
 ```{r}
+#| label: trace-and-fisd-filter-fisd-issues
 #| eval: !expr params$download_data
 fisd_mergedissue_db <- tbl(wrds, I("fisd.fisd_mergedissue"))
 
@@ -143,6 +146,7 @@ fisd <- fisd_mergedissue_db |>
 We also pull issuer information from `fisd_mergedissuer` regarding the industry and country of the firm that issued a particular bond. Then, we filter to include only US-domiciled firms' bonds. We match the data by `issuer_id`.
 
 ```{r}
+#| label: trace-and-fisd-merge-issuer-info
 #| eval: !expr params$download_data
 fisd_mergedissuer_db <- tbl(wrds, I("fisd.fisd_mergedissuer"))
 
@@ -159,6 +163,7 @@ fisd <- fisd |>
 To download the FISD data with the above filters and processing steps, you can use the `tidyfinance` package. Note that you might have to set the login credentials for WRDS first using `set_wrds_credentials()`.
 
 ```{r}
+#| label: trace-and-fisd-download-fisd
 #| eval: !expr params$download_data
 #| output: false
 download_data(domain = "wrds", dataset = "fisd")
@@ -167,6 +172,7 @@ download_data(domain = "wrds", dataset = "fisd")
 Finally, we save the bond characteristics to our local folder. This selection of bonds also constitutes the sample for which we will collect trade reports from TRACE below.
 
 ```{r}
+#| label: trace-and-fisd-save-fisd
 #| eval: !expr params$download_data
 write_parquet(fisd, "data-r/fisd.parquet")
 ```
@@ -174,6 +180,7 @@ write_parquet(fisd, "data-r/fisd.parquet")
 The FISD database also contains other data. The issue-based file contains information on covenants, i.e., restrictions included in bond indentures to limit specific actions by firms [e.g., @handler2021]. Moreover, FISD also provides information on bond ratings. We do not need either here.
 
 ```{r}
+#| label: trace-and-fisd-load-fisd
 #| echo: false
 #| eval: !expr "!params$download_data"
 fisd <- read_parquet("data-r/fisd.parquet")
@@ -188,6 +195,7 @@ Why do we repeatedly talk about cleaning TRACE? Trade messages are submitted wit
 The TRACE database is considerably large. Therefore, we only download subsets of data at once. Specifying too many CUSIPs over a long time horizon will result in very long download times and a potential failure due to the size of the request to WRDS. The size limit depends on many parameters, and we cannot give you a guideline here. If we were working with the complete TRACE data for all CUSIPs above, splitting the data into 100 parts takes roughly two hours using our setup. For the applications in this book, we need data around the Paris Agreement in December 2015 and download the data in ten sets, which we define below.\index{Paris (Climate) Agreement}
 
 ```{r}
+#| label: trace-and-fisd-split-cusips
 fisd_cusips <- fisd |>
   pull(complete_cusip)
 
@@ -200,6 +208,7 @@ fisd_parts <- split(
 Finally, we run a loop in the same style as in [WRDS, CRSP, and Compustat](wrds-crsp-and-compustat.qmd) where we download daily returns from CRSP. For each of the CUSIP sets defined above, we call the cleaning function and save the resulting output. We add new data to the existing dataset for batch two and all following batches. Because our later applications load the entire table at once, we partition the data by batch rather than by security identifier. Using a smaller number of larger files improves efficiency when loading the full dataset into memory.
 
 ```{r}
+#| label: trace-and-fisd-download-trace-batches
 #| eval: !expr params$download_data
 #| output: false
 batches <- length(fisd_parts)
@@ -232,6 +241,7 @@ for (j in 1:batches) {
 If you want to download the prepared enhanced TRACE data for selected bonds via the `tidyfinance` package, you can call, e.g.:
 
 ```{r}
+#| label: trace-and-fisd-download-trace-example
 #| eval: !expr params$download_data
 #| output: false
 download_data(
@@ -250,6 +260,7 @@ While many news outlets readily provide information on stocks and the underlying
 We start by looking into the number of bonds outstanding over time and compare it to the number of bonds traded in our sample. First, we compute the number of bonds outstanding for each quarter around the Paris Agreement from 2014 to 2016. 
 
 ```{r}
+#| label: trace-and-fisd-bonds-outstanding
 bonds_outstanding <- expand_grid(
   "date" = seq(ymd("2014-01-01"), ymd("2016-11-30"), by = "quarter"),
   "complete_cusip" = fisd$complete_cusip
@@ -271,6 +282,7 @@ bonds_outstanding <- expand_grid(
 Next, we look at the bonds traded each quarter in the same period. Notice that we do not have to load the complete TRACE table from our dataset into memory to perform the simple aggregation. Arrow's `open_dataset()` creates a lazy query plan that pushes all the filtering and aggregation down to its backend engine, reading only the necessary columns from Parquet and returning just the small summarized result to our session when we call `collect()`.
 
 ```{r}
+#| label: trace-and-fisd-bonds-traded
 trace_enhanced <- open_dataset("data-r/trace_enhanced")  
 
 bonds_traded <- trace_enhanced |>
@@ -308,6 +320,7 @@ We see that the number of bonds outstanding increases steadily between 2014 and 
 Does this lack of liquidity mean that corporate bond markets are irrelevant in terms of their size? With over 7,500 traded bonds each quarter, it is hard to say that the market is small. However, let us also investigate the characteristics of issued corporate bonds. In particular, we consider maturity (in years), coupon, and offering amount (in million USD).\index{Liquidity}
 
 ```{r}
+#| label: trace-and-fisd-bond-characteristics-summary
 fisd |>
   mutate(
     maturity = as.numeric(maturity - offering_date) / 365,
@@ -335,6 +348,7 @@ We see that the sample is dominated by zero-coupon bonds: the median coupon is z
 Finally, let us compute some summary statistics for the trades in this market. To this end, we show a summary based on aggregate information daily. In particular, we consider the trade size (in million USD) and the number of trades.
 
 ```{r}
+#| label: trace-and-fisd-trade-summary
 trace_enhanced |>
   group_by(trd_exctn_dt) |>
   summarize(

--- a/r/univariate-portfolio-sorts.qmd
+++ b/r/univariate-portfolio-sorts.qmd
@@ -22,6 +22,7 @@ To illustrate how portfolio sorts work, we use estimates for market betas from t
 The current chapter relies on the following set of R packages.
 
 ```{r}
+#| label: univariate-portfolio-sorts-packages
 #| message: false
 library(tidyverse)
 library(arrow)
@@ -38,6 +39,7 @@ Compared to previous chapters, we introduce `lmtest` [@lmtest] for inference for
 We start with loading the required data from our local folder introduced in [Accessing and Managing Financial Data](accessing-and-managing-financial-data.qmd) and [WRDS, CRSP, and Compustat](wrds-crsp-and-compustat.qmd). In particular, we use the monthly CRSP sample as our asset universe.\index{Data!CRSP} Once we form our portfolios, we use the Fama-French market factor returns to compute the risk-adjusted performance (i.e., alpha).\index{Data!Fama-French factors} `beta` is the tibble with market betas computed in the previous chapter.\index{Beta}
 
 ```{r}
+#| label: univariate-portfolio-sorts-load-data
 crsp_monthly <- read_parquet("data-r/crsp_monthly.parquet") |>
   select(permno, date, ret_excess, mktcap_lag)
 
@@ -58,6 +60,7 @@ You may be tempted to simply use a call such as `crsp_monthly |> group_by(permno
 This procedure, however, does not work correctly if there are non-explicit missing values in the time series.
 
 ```{r}
+#| label: univariate-portfolio-sorts-lag-beta
 beta_lag <- beta |>
   mutate(date = date %m+% months(1)) |>
   select(permno, date, beta_lag = beta) |>
@@ -72,6 +75,7 @@ For simplicity, we start with the median lagged market beta as the single breakp
 We then compute the value-weighted returns for each of the two resulting portfolios, which means that the lagged market capitalization determines the weight in `weighted.mean()`.  
 
 ```{r}
+#| label: univariate-portfolio-sorts-median-portfolios
 beta_portfolios <- data_for_sorts |>
   group_by(date) |>
   mutate(
@@ -90,6 +94,7 @@ beta_portfolios <- data_for_sorts |>
 We can construct a long-short strategy based on the two portfolios: buy the high-beta portfolio and, at the same time, short the low-beta portfolio. Thereby, the overall position in the market is net-zero, i.e., you do not need to invest money to realize this strategy in the absence of frictions.\index{Long-short}
 
 ```{r}
+#| label: univariate-portfolio-sorts-median-longshort
 beta_longshort <- beta_portfolios |>
   pivot_wider(id_cols = date, names_from = portfolio, values_from = ret) |>
   mutate(long_short = high - low)
@@ -98,6 +103,7 @@ beta_longshort <- beta_portfolios |>
 We compute the average return and the corresponding standard error to test whether the long-short portfolio yields on average positive or negative excess returns. In the asset pricing literature, one typically adjusts for autocorrelation by using @Newey1987 $t$-statistics to test the null hypothesis that average portfolio excess returns are equal to zero.\index{Standard errors!Newey-West} One necessary input for Newey-West standard errors is a chosen bandwidth based on the number of lags employed for the estimation. While it seems that researchers often default on choosing a pre-specified lag length of 6 months, we instead recommend a data-driven approach. This automatic selection is advocated by @Newey1994 and available in the `sandwich` package. To implement this test, we compute the average return via `lm()` and then employ the `coeftest()` function. If you want to implement the typical 6-lag default setting, you can enforce it by passing the arguments `lag = 6, prewhite = FALSE` to the `coeftest()` function in the code below and it passes them on to `NeweyWest()`. 
 
 ```{r}
+#| label: univariate-portfolio-sorts-median-newey-west
 model_fit <- lm(long_short ~ 1, data = beta_longshort)
 coeftest(model_fit, vcov = NeweyWest)
 ```
@@ -111,6 +117,7 @@ Now we take portfolio sorts to the next level. We want to be able to sort stocks
 In some applications, the variable used for the sorting might be clustered (e.g., at a lower bound of 0). Then, multiple breakpoints may be identical, leading to empty portfolios. Similarly, some portfolios might have a very small number of stocks at the beginning of the sample. Cases where the number of portfolio constituents differs substantially due to the distribution of the characteristics require careful consideration and, depending on the application, might require customized sorting approaches.
 
 ```{r}
+#| label: univariate-portfolio-sorts-assign-portfolio-function
 assign_portfolio <- function(
   data,
   sorting_variable,
@@ -142,6 +149,7 @@ assign_portfolio <- function(
 We can use the above function to sort stocks into ten portfolios each month using lagged betas and compute value-weighted returns for each portfolio. Note that we transform the portfolio column to a factor variable because it provides more convenience for the figure construction below.
 
 ```{r}
+#| label: univariate-portfolio-sorts-decile-portfolios
 beta_portfolios <- data_for_sorts |>
   group_by(date) |>
   mutate(
@@ -165,6 +173,7 @@ beta_portfolios <- data_for_sorts |>
 In the next step, we compute summary statistics for each beta portfolio. Namely, we compute CAPM-adjusted alphas, the beta of each beta portfolio, and average returns.\index{Performance evaluation}\index{Alpha}\index{CAPM}
 
 ```{r}
+#| label: univariate-portfolio-sorts-portfolio-summary
 beta_portfolios_summary <- beta_portfolios |>
   nest(data = c(date, ret_excess, mkt_excess)) |>
   mutate(
@@ -252,6 +261,7 @@ beta_portfolios_summary |>
 To provide more evidence against the CAPM predictions, we again form a long-short strategy that buys the high-beta portfolio and shorts the low-beta portfolio.
 
 ```{r}
+#| label: univariate-portfolio-sorts-decile-longshort
 beta_longshort <- beta_portfolios |>
   mutate(
     portfolio = case_when(
@@ -272,12 +282,14 @@ beta_longshort <- beta_portfolios |>
 Again, the resulting long-short strategy does not exhibit statistically significant returns. 
 
 ```{r}
+#| label: univariate-portfolio-sorts-decile-newey-west
 coeftest(lm(long_short ~ 1, data = beta_longshort), vcov = NeweyWest)
 ```
 
 However, the long-short portfolio yields a statistically significant negative CAPM-adjusted alpha, although, controlling for the effect of beta, the average excess stock returns should be zero according to the CAPM. The results thus provide no evidence in support of the CAPM. The negative value has been documented as the so-called betting against beta factor [@Frazzini2014]. Betting against beta corresponds to a strategy that shorts high beta stocks and takes a (levered) long position in low beta stocks. If borrowing constraints prevent investors from taking positions on the SML they are instead incentivized to buy high beta stocks, which leads to a relatively higher price (and therefore lower expected returns than implied by the CAPM) for such high beta stocks. As a result, the betting-against-beta strategy earns from providing liquidity to capital constraint investors with lower risk aversion.\index{Risk aversion}
 
 ```{r}
+#| label: univariate-portfolio-sorts-decile-capm-alpha
 coeftest(
   lm(long_short ~ 1 + mkt_excess, data = beta_longshort),
   vcov = NeweyWest

--- a/r/value-and-bivariate-sorts.qmd
+++ b/r/value-and-bivariate-sorts.qmd
@@ -18,6 +18,7 @@ We form portfolios on firm size and the book-to-market ratio. To calculate book-
 The current chapter relies on this set of R packages. 
 
 ```{r}
+#| label: value-and-bivariate-sorts-packages
 #| message: false
 library(tidyverse)
 library(arrow)
@@ -28,6 +29,7 @@ library(arrow)
 First, we load the necessary data from our Parquet files introduced in [Accessing and Managing Financial Data](accessing-and-managing-financial-data.qmd). We conduct portfolio sorts based on the CRSP sample but keep only the necessary columns in our memory. We use the same data sources for firm size as in [Size Sorts and P-Hacking](size-sorts-and-p-hacking.qmd).\index{Data!CRSP}\index{Data!Fama-French factors}
 
 ```{r}
+#| label: value-and-bivariate-sorts-load-crsp
 crsp_monthly <- read_parquet("data-r/crsp_monthly.parquet") |>
   select(
     permno,
@@ -44,6 +46,7 @@ crsp_monthly <- read_parquet("data-r/crsp_monthly.parquet") |>
 Further, we utilize accounting data. The most common source of accounting data is Compustat. We only need book equity data in this application, which we select from our database. We keep only firms with positive book equity, which is a common practice when working with book-to-market ratios [see @Fama1992 for details].\index{Book equity} Additionally, we convert the variable `datadate` to its monthly value, as we only consider monthly returns here and do not need to account for the exact date. To achieve this, we use the function `floor_date()`.\index{Data!Compustat}
 
 ```{r}
+#| label: value-and-bivariate-sorts-load-book-equity
 book_equity <- read_parquet("data-r/compustat_annual.parquet") |>
   select(gvkey, datadate, be) |>
   filter(be > 0) |>
@@ -60,6 +63,7 @@ As in the previous chapter, we continue to lag firm size by one month.\index{Mar
 Having both variables, i.e., firm size lagged by one month and book-to-market lagged by six months, we merge these sorting variables to our returns using the `sorting_date`-column created for this purpose. The final step in our data preparation deals with differences in the frequency of our variables. Returns and firm size are recorded monthly. Yet the accounting information is only released on an annual basis. Hence, we only match book-to-market to one month per year and have eleven empty observations. To solve this frequency issue, we carry the latest book-to-market ratio of each firm to the subsequent months, i.e., we fill the missing observations with the most current report. This is done via the `fill()`-function after sorting by date and firm (which we identify by `permno` and `gvkey`) and on a firm basis (which we do by `group_by()` as usual). We filter out all observations with accounting data that is older than a year. As the last step, we remove all rows with missing entries because the returns cannot be matched to any annual report.
 
 ```{r}
+#| label: value-and-bivariate-sorts-prepare-sorting-data
 size <- crsp_monthly |>
   mutate(sorting_date = date %m+% months(1)) |>
   select(permno, sorting_date, size = mktcap)
@@ -107,6 +111,7 @@ data_for_sorts <- data_for_sorts |>
 The last step of preparation for the portfolio sorts is the computation of breakpoints. We continue to use the same function allowing for the specification of exchanges to use for the breakpoints. Additionally, we reintroduce the argument `sorting_variable` into the function for defining different sorting variables.
 
 ```{r}
+#| label: value-and-bivariate-sorts-assign-portfolio-function
 assign_portfolio <- function(
   data,
   sorting_variable,
@@ -148,6 +153,7 @@ Bivariate sorts create portfolios within a two-dimensional space spanned by two 
 To implement the independent bivariate portfolio sort, we assign monthly portfolios for each of our sorting variables separately to create the variables `portfolio_bm` and `portfolio_size`, respectively.\index{Portfolio sorts!Independent bivariate} Then, these separate portfolios are combined to the final sort stored in `portfolio_combined`. After assigning the portfolios, we compute the average return within each portfolio for each month. Additionally, we keep the book-to-market portfolio as it makes the computation of the value premium easier. The alternative would be to disaggregate the combined portfolio in a separate step. Notice that we weigh the stocks within each portfolio by their market capitalization, i.e., we decide to value-weight our returns.
 
 ```{r}
+#| label: value-and-bivariate-sorts-independent-portfolios
 value_portfolios <- data_for_sorts |>
   group_by(date) |>
   mutate(
@@ -174,6 +180,7 @@ value_portfolios <- data_for_sorts |>
 Equipped with our monthly portfolio returns, we are ready to compute the value premium. However, we still have to decide how to invest in the five high and the five low book-to-market portfolios. The most common approach is to weigh these portfolios equally, but this is yet another researcher's choice. Then, we compute the return differential between the high and low book-to-market portfolios and show the average value premium.
 
 ```{r}
+#| label: value-and-bivariate-sorts-independent-value-premium
 value_premium <- value_portfolios |>
   group_by(date, portfolio_bm) |>
   summarize(ret = mean(ret), .groups = "drop_last") |>
@@ -195,6 +202,7 @@ In the previous exercise, we assigned the portfolios without considering the sec
 To implement the dependent sorts, we first create the size portfolios by calling `assign_portfolio()` with `sorting_variable = "size"`. Then, we group our data again by month and by the size portfolio before assigning the book-to-market portfolio. The rest of the implementation is the same as before. Finally, we compute the value premium.
 
 ```{r}
+#| label: value-and-bivariate-sorts-dependent-portfolios
 value_portfolios <- data_for_sorts |>
   group_by(date) |>
   mutate(
@@ -243,6 +251,7 @@ So far, we have focused exclusively on the returns of our portfolios. Yet the wa
 We start with the independent assignment. As before, we group by month and assign the size and book-to-market portfolios separately.
 
 ```{r}
+#| label: value-and-bivariate-sorts-assignments-independent
 assignments_independent <- data_for_sorts |>
   group_by(date) |>
   mutate(
@@ -266,6 +275,7 @@ assignments_independent <- data_for_sorts |>
 For the dependent assignment, we again first form the size portfolios and then assign book-to-market portfolios within each size bucket, so that the book-to-market breakpoints are specific to each size group.
 
 ```{r}
+#| label: value-and-bivariate-sorts-assignments-dependent
 assignments_dependent <- data_for_sorts |>
   group_by(date) |>
   mutate(
@@ -292,6 +302,7 @@ assignments_dependent <- data_for_sorts |>
 Next, we stack both assignments and compute the characteristics of interest. For each month and portfolio, we count the number of stocks and sum their lagged market capitalization. We then average these monthly figures across the whole sample to obtain one value per portfolio. Finally, we express market capitalization as a share of the total within each sorting method, which makes the concentration of market value across the grid directly comparable.
 
 ```{r}
+#| label: value-and-bivariate-sorts-portfolio-characteristics
 portfolio_characteristics <- bind_rows(
   assignments_independent,
   assignments_dependent

--- a/r/working-with-stock-returns.qmd
+++ b/r/working-with-stock-returns.qmd
@@ -19,6 +19,7 @@ At the start of each session, we load the required R packages. Throughout the en
 You typically have to install a package once before you can load it into your active R session. In case you have not done this yet, call, for instance, `install.packages("tidyfinance")`.\index{tidyfinance}
 
 ```{r}
+#| label: working-with-stock-returns-packages
 #| message: false
 library(tidyverse)
 library(tidyfinance)
@@ -32,6 +33,7 @@ We first download daily prices for one stock symbol, e.g., the Apple stock (*AAP
 In the following code, we request daily data from the beginning of 2000 to the end of the last year, which is a period of more than 20 years.\index{Stock prices}
 
 ```{r}
+#| label: working-with-stock-returns-download-apple-prices
 prices <- download_data(
   domain = "stock_prices",
   symbols = "AAPL",
@@ -64,6 +66,7 @@ prices |>
 Instead of analyzing prices, we compute daily returns defined as $r_t = p_t / p_{t-1} - 1$, where $p_t$ is the adjusted price at the end of day $t$.\index{Returns} In that context, the function `lag()` is helpful by returning the previous value.
 
 ```{r}
+#| label: working-with-stock-returns-compute-daily-returns
 returns <- prices |>
   arrange(date) |>
   mutate(ret = adjusted_close / lag(adjusted_close) - 1) |>
@@ -76,6 +79,7 @@ The resulting data frame has three columns, the last of which contains the daily
 For the upcoming examples, we remove missing values as these would require separate treatment for many applications. For example, missing values can affect sums and averages by reducing the number of valid data points if not properly accounted for. In general, always ensure you understand why `NA` values occur and carefully examine if you can simply get rid of these observations.
 
 ```{r}
+#| label: working-with-stock-returns-drop-missing-returns
 returns <- returns |>
   drop_na(ret)
 ```
@@ -104,6 +108,7 @@ returns |>
 Here, `bins = 100` determines the number of bins used in the illustration and, hence, implicitly sets the width of the bins. Before proceeding, make sure you understand how to use the geom `geom_vline()` to add a dashed line that indicates the historical five percent quantile of the daily returns. Before proceeding with *any* data, a typical task is to compute and analyze the summary statistics for the main variables of interest.
 
 ```{r}
+#| label: working-with-stock-returns-summary-statistics
 returns |>
   summarize(across(
     ret,
@@ -121,6 +126,7 @@ We see that the maximum *daily* return was `r returns |> pull(ret) |> max() * 10
 You can also compute these summary statistics for each year individually by imposing `group_by(year = year(date))`, where the call `year(date)` returns the year. More specifically, the few lines of code below compute the summary statistics from above for individual groups of data defined by the values of the column year. The summary statistics, therefore, allow an eyeball analysis of the time-series dynamics of the daily return distribution.\index{Summary statistics}
 
 ```{r}
+#| label: working-with-stock-returns-summary-statistics-by-year
 returns |>
   group_by(year = year(date)) |>
   summarize(across(
@@ -145,6 +151,7 @@ As a next step, we generalize the previous code so that all computations can han
 This is where the `tidyverse` magic starts: Tidy data makes it extremely easy to generalize the computations from before to as many assets or groups as you like. The following code takes any number of symbols, e.g., `symbol <- c("AAPL", "MMM", "BA")`, and automates the download as well as the plot of the price time series. In the end, we create the table of summary statistics for all assets at once. For this example, we analyze data from all current constituents of the [Dow Jones Industrial Average index.](https://en.wikipedia.org/wiki/Dow_Jones_Industrial_Average)\index{Data!Dow Jones Index}
 
 ```{r}
+#| label: working-with-stock-returns-download-dow-constituents
 #| message: false
 symbols <- download_data(
   domain = "constituents",
@@ -156,6 +163,7 @@ symbols
 Conveniently, `tidyfinance` provides the functionality to get all stock prices from an index for a specific point in time with a single call.\index{Exchange!NASDAQ}
 
 ```{r}
+#| label: working-with-stock-returns-download-dow-prices
 #| output: false
 prices_daily <- download_data(
   domain = "stock_prices",
@@ -192,6 +200,7 @@ Do you notice the small differences relative to the code we used before? All we 
 The same holds for stock returns. Before computing the returns, we use `group_by(symbol)` such that the `mutate()` command is performed for each symbol individually. The same logic also applies to the computation of summary statistics: `group_by(symbol)` is the key to aggregating the time series into symbol-specific variables of interest.\index{Summary statistics}
 
 ```{r}
+#| label: working-with-stock-returns-multi-symbol-returns-summary
 returns_daily <- prices_daily |>
   group_by(symbol) |>
   mutate(ret = adjusted_close / lag(adjusted_close) - 1) |>
@@ -222,6 +231,7 @@ Financial data often exists at different frequencies due to varying reporting sc
 So far, we have worked with daily returns, but we can easily convert our data to other frequencies. Let's create monthly returns from our daily data:
 
 ```{r}
+#| label: working-with-stock-returns-compute-monthly-returns
 returns_monthly <- returns_daily |>
   mutate(date = floor_date(date, "month")) |>
   group_by(symbol, date) |>

--- a/r/wrds-crsp-and-compustat.qmd
+++ b/r/wrds-crsp-and-compustat.qmd
@@ -20,6 +20,7 @@ If you don't have access to WRDS but still want to run the code in this book, we
 First, we load the R packages that we use throughout this chapter. Later on, we load more packages in the sections where we need them. 
 
 ```{r}
+#| label: wrds-crsp-and-compustat-packages
 #| message: false
 library(tidyverse)
 library(tidyfinance)
@@ -30,6 +31,7 @@ library(dbplyr)
 We use the same date range as in the previous chapter to ensure consistency.
 
 ```{r}
+#| label: wrds-crsp-and-compustat-date-range
 start_date <- ymd("1960-01-01")
 end_date <- ymd("2024-12-31")
 ```
@@ -39,6 +41,7 @@ end_date <- ymd("2024-12-31")
 WRDS is the most widely used source for asset and firm-specific financial data used in academic settings. WRDS is a data platform that provides data validation, flexible delivery options, and access to many different data sources. The data at WRDS is organized in an SQL database, although they use the [PostgreSQL](https://www.postgresql.org/) engine. This database engine is easy to handle with R. We use the `RPostgres` package to establish a connection to the WRDS database [@RPostgres]. Note that you could also use the `odbc` package to connect to a PostgreSQL database, but then you need to install the appropriate drivers yourself. `RPostgres` already contains a suitable driver.\index{Database!PostgreSQL}
 
 ```{r}
+#| label: wrds-crsp-and-compustat-rpostgres
 #| message: false
 library(RPostgres)
 ```
@@ -48,6 +51,7 @@ To establish a connection to WRDS, you use the function `dbConnect()` with argum
 Additionally, you have to use two-factor authentication since May 2023 when establishing a `PostgreSQL` or other remote connections. You have two choices to provide the additional identification. First, if you have Duo Push enabled for your WRDS account, you will receive a push notification on your mobile phone when trying to establish a connection with the code below. Upon accepting the notification, you can continue your work. Second, you can log in to a WRDS website that requires two-factor authentication with your username and the same IP address. Once you have successfully identified yourself on the website, your username-IP combination will be remembered for 30 days, and you can comfortably use the remote connection below.\index{Two-factor authentication}\index{WRDS:Two-factor authentication}
 
 ```{r}
+#| label: wrds-crsp-and-compustat-connect
 #| eval: !expr params$download_data
 wrds <- dbConnect(
   Postgres(),
@@ -63,6 +67,7 @@ wrds <- dbConnect(
 You can also use the `tidyfinance` package to set the login credentials and create a connection.
 
 ```{r}
+#| label: wrds-crsp-and-compustat-tidyfinance-connect
 #| eval: false
 set_wrds_credentials()
 wrds <- get_wrds_connection()
@@ -75,6 +80,7 @@ The remote connection to WRDS is very useful. Yet, the database itself contains 
 \index{Data!CRSP}[The Center for Research in Security Prices (CRSP)](https://crsp.org/) provides the most widely used data for US stocks. We use the `wrds` connection object that we just created to first access monthly CRSP return data.^[The `tbl()` function creates a lazy table in our R session based on the remote WRDS database. To look up specific tables, we use the `I("schema_name.table_name")` approach.] Actually, we need two tables to get the desired data: (i) the CRSP monthly security file,
 
 ```{r}
+#| label: wrds-crsp-and-compustat-msf-db
 #| eval: !expr params$download_data
 msf_db <- tbl(wrds, I("crsp.msf_v2"))
 ```
@@ -82,6 +88,7 @@ msf_db <- tbl(wrds, I("crsp.msf_v2"))
 and (ii) the identifying information,
 
 ```{r}
+#| label: wrds-crsp-and-compustat-stksecurityinfohist-db
 #| eval: !expr params$download_data
 stksecurityinfohist_db <- tbl(wrds, I("crsp.stksecurityinfohist"))
 ```
@@ -89,6 +96,7 @@ stksecurityinfohist_db <- tbl(wrds, I("crsp.stksecurityinfohist"))
 We use the two remote tables to fetch the data we want to put into our local folder. Just as above, the idea is that we let the WRDS database do all the work and just download the data that we actually need. We apply common filters and data selection criteria to narrow down our data of interest: (i) we use only stock prices from NYSE, Amex, and NASDAQ (`primaryexch %in% c("N", "A", "Q")`) when or after issuance (`conditionaltype %in% c("RW", "NW")`) for actively traded stocks (`tradingstatusflg == "A"`)^[These three criteria jointly replicate the filter `exchcd %in% c(1, 2, 3, 31, 32, 33)` used for the legacy version of CRSP. If you do not want to include stocks at issuance, you can set the `conditionaltype == "RW"`, which is equivalent to the restriction of `exchcd %in% c(1, 2, 3)` with the old CRSP format.], (ii) we keep only data in the time windows of interest, (iii) we keep only US-listed stocks as identified via no special share types (`sharetype = 'NS'`), security type equity (`securitytype = 'EQTY'`), security sub type common stock (`securitysubtype = 'COM'`), issuers that are a corporation (`issuertype %in% c("ACOR", "CORP")`), and (iv) we keep only months within permno-specific start dates (`secinfostartdt`) and end dates (`secinfoenddt`). As of July 2022, there is no need to additionally download delisting information since it is already contained in the most recent version of `msf` (see our blog post about [CRSP 2.0](../blog/crsp-v2-update/index.qmd) for more information). We refer to @SchwarzEtAl2026 for details on the changes in the CRSP tape rolled out in 2025. Additionally, the industry information in `stksecurityinfohist` records the historic industry and should be used instead of the one stored under same variable name in `msf_v2`.\index{Permno}\index{Returns!Delisting}\index{Industry codes}
 
 ```{r}
+#| label: wrds-crsp-and-compustat-download-crsp-monthly
 #| eval: !expr params$download_data
 crsp_monthly <- msf_db |>
   filter(mthcaldt >= start_date & mthcaldt <= end_date) |>
@@ -131,6 +139,7 @@ Now, we have all the relevant monthly return data in memory and proceed with pre
 The first additional variable we create is market capitalization (`mktcap`), which is the product of the number of outstanding shares (`shrout`) and the last traded price in a month (`prc`).\index{Market capitalization} Note that in contrast to returns (`ret`), these two variables are not adjusted ex-post for any corporate actions like stock splits. Therefore, if you want to use a stock's price, you need to adjust it with a cumulative adjustment factor.  We also keep the market cap in millions of USD just for convenience, as we do not want to print huge numbers in our figures and tables. In addition, we set zero market capitalization to missing as it makes conceptually little sense (i.e., the firm would be bankrupt).\index{Stock price}\index{Returns}
 
 ```{r}
+#| label: wrds-crsp-and-compustat-add-mktcap
 #| eval: !expr params$download_data
 crsp_monthly <- crsp_monthly |>
   mutate(
@@ -142,6 +151,7 @@ crsp_monthly <- crsp_monthly |>
 The next variable we frequently use is the one-month *lagged* market capitalization. Lagged market capitalization is typically used to compute value-weighted portfolio returns, as we demonstrate in a later chapter. The most simple and consistent way to add a column with lagged market cap values is to add one month to each observation and then join the information to our monthly CRSP data.\index{Weighting!Value}
 
 ```{r}
+#| label: wrds-crsp-and-compustat-add-mktcap-lag
 #| eval: !expr params$download_data
 mktcap_lag <- crsp_monthly |>
   mutate(date = date %m+% months(1)) |>
@@ -156,6 +166,7 @@ If you wonder why we do not use the `lag()` function, e.g., via `crsp_monthly |>
 Next, we transform primary listing exchange codes to explicit exchange names.\index{Exchange!Exchange codes}
 
 ```{r}
+#| label: wrds-crsp-and-compustat-add-exchange
 #| eval: !expr params$download_data
 crsp_monthly <- crsp_monthly |>
   mutate(
@@ -171,6 +182,7 @@ crsp_monthly <- crsp_monthly |>
 Similarly, we transform industry codes to industry descriptions following @BaliEngleMurray2016.\index{Industry codes} Notice that there are also other categorizations of industries [e.g., @FamaFrench1997] that are commonly used.
 
 ```{r}
+#| label: wrds-crsp-and-compustat-add-industry
 #| eval: !expr params$download_data
 crsp_monthly <- crsp_monthly |>
   mutate(
@@ -194,6 +206,7 @@ crsp_monthly <- crsp_monthly |>
 Next, we compute excess returns by subtracting the monthly risk-free rate provided by our Fama-French data.\index{Returns!Excess}\index{Risk-free rate} As we base all our analyses on the excess returns, we can drop the risk-free rate from our tibble. Note that we ensure excess returns are bounded by -1 from below as a return less than -100 percent makes no sense conceptually. Before we can adjust the returns, we have to load the table `factors_ff3_monthly`.
 
 ```{r}
+#| label: wrds-crsp-and-compustat-add-excess-returns
 #| eval: !expr params$download_data
 factors_ff3_monthly <- read_parquet("data-r/factors_ff3_monthly.parquet") |>
   select(date, risk_free)
@@ -209,6 +222,7 @@ crsp_monthly <- crsp_monthly |>
 The `tidyfinance` package provides a shortcut to implement all these processing steps from above.
 
 ```{r}
+#| label: wrds-crsp-and-compustat-tidyfinance-crsp-monthly
 #| eval: false
 crsp_monthly <- download_data(
   domain = "wrds",
@@ -221,6 +235,7 @@ crsp_monthly <- download_data(
 Since excess returns and market capitalization are crucial for all our analyses, we can safely exclude all observations with missing returns or market capitalization. 
 
 ```{r}
+#| label: wrds-crsp-and-compustat-drop-missing
 #| eval: !expr params$download_data
 crsp_monthly <- crsp_monthly |>
   drop_na(ret_excess, mktcap, mktcap_lag)
@@ -229,11 +244,13 @@ crsp_monthly <- crsp_monthly |>
 Finally, we store the monthly CRSP file in our data folder. 
 
 ```{r}
+#| label: wrds-crsp-and-compustat-write-crsp-monthly
 #| eval: !expr params$download_data
 write_parquet(crsp_monthly, "data-r/crsp_monthly.parquet")
 ```
 
 ```{r}
+#| label: wrds-crsp-and-compustat-read-crsp-monthly
 #| eval: !expr "!params$download_data"
 #| echo: false
 crsp_monthly <- read_parquet("data-r/crsp_monthly.parquet")
@@ -364,6 +381,7 @@ Before we turn to accounting data, we provide a proposal for downloading daily C
 There is a solution to this challenge. As with many *big data* problems, you can split up the big task into several smaller tasks that are easier to handle.\index{Big data} That is, instead of downloading data about all stocks at once, download the data in small batches of stocks consecutively. Such operations can be implemented in `for`-loops,\index{For-loops} where we download, prepare, and store the data for a small number of stocks in each iteration. This operation might nonetheless take around 5 minutes, depending on your internet connection. To keep track of the progress, we create ad-hoc progress updates using `message()`.  As for the monthly CRSP data, there is no need to adjust for delisting returns in the daily CRSP data since July 2022.\index{Returns!Delisting}
 
 ```{r}
+#| label: wrds-crsp-and-compustat-download-crsp-daily
 #| eval: !expr params$download_data
 #| output: false
 dsf_db <- tbl(wrds, I("crsp.dsf_v2"))
@@ -446,6 +464,7 @@ Eventually, we end up with more than 72 million rows of daily return data. Note 
 To download the daily CRSP data via the `tidyfinance` package, you can call:
 
 ```{r}
+#| label: wrds-crsp-and-compustat-tidyfinance-crsp-daily
 #| eval: false
 crsp_daily <- download_data(
   domain = "wrds",
@@ -464,6 +483,7 @@ Firm accounting data are an important source of information that we use in portf
 To access Compustat data, we can again tap WRDS, which hosts the `funda` table that contains annual firm-level information on North American companies.
 
 ```{r}
+#| label: wrds-crsp-and-compustat-funda-db
 #| eval: !expr params$download_data
 funda_db <- tbl(wrds, I("comp.funda"))
 ```
@@ -471,6 +491,7 @@ funda_db <- tbl(wrds, I("comp.funda"))
 We follow the typical filter conventions and pull only data that we actually need: (i) we get only records in industrial data format, which includes companies that are primarily involved in manufacturing, services, and other non-financial business activities,^[Companies that operate in the banking, insurance, or utilities sector typically report in different industry formats that reflect their specific regulatory requirements.] (ii) in the standard format (i.e., consolidated information in standard presentation), (iii) reported in USD,^[Compustat also contains reports in CAD, which can lead to a currency mismatch, e.g., when relating book equity to market equity.] and (iv) only data in the desired time window.\index{Gvkey}
 
 ```{r}
+#| label: wrds-crsp-and-compustat-download-compustat
 #| eval: !expr params$download_data
 compustat_annual <- funda_db |>
   filter(
@@ -507,6 +528,7 @@ compustat_annual <- funda_db |>
 Next, we calculate the book value of preferred stock and equity `be` and the operating profitability `op` inspired by the [variable definitions in Ken French's data library.](https://mba.tuck.dartmouth.edu/pages/faculty/ken.french/Data_Library/variable_definitions.html)\index{Book equity}\index{Preferred stock}\index{Operating profitability}
 
 ```{r}
+#| label: wrds-crsp-and-compustat-add-be-op
 #| eval: !expr params$download_data
 compustat_annual <- compustat_annual |>
   mutate(
@@ -521,6 +543,7 @@ compustat_annual <- compustat_annual |>
 We keep only the last available information for each firm-year group. Note that `datadate` defines the time the corresponding financial data refers to (e.g., annual report as of December 31, 2022). Therefore, `datadate` is not the date when data was made available to the public. Check out the exercises for more insights into the peculiarities of `datadate`.
 
 ```{r}
+#| label: wrds-crsp-and-compustat-keep-last-firm-year
 #| eval: !expr params$download_data
 compustat_annual <- compustat_annual |>
   mutate(year = year(datadate)) |>
@@ -532,6 +555,7 @@ compustat_annual <- compustat_annual |>
 We also compute the investment ratio `inv` according to Ken French's variable definitions as the change in total assets from one fiscal year to another. Note that we again use the approach using joins as introduced with the CRSP data above to construct lagged assets.\index{Investment ratio}
 
 ```{r}
+#| label: wrds-crsp-and-compustat-add-investment
 #| eval: !expr params$download_data
 compustat_annual <- compustat_annual |>
   left_join(
@@ -549,6 +573,7 @@ compustat_annual <- compustat_annual |>
 With the last step, we are already done preparing the firm fundamentals. Thus, we can store them in our local folder.
 
 ```{r}
+#| label: wrds-crsp-and-compustat-write-compustat
 #| eval: !expr params$download_data
 write_parquet(compustat_annual, "data-r/compustat_annual.parquet")
 ```
@@ -556,6 +581,7 @@ write_parquet(compustat_annual, "data-r/compustat_annual.parquet")
 The `tidyfinance` package provides a shortcut for these processing steps as well:
 
 ```{r}
+#| label: wrds-crsp-and-compustat-tidyfinance-compustat
 #| eval: false
 compustat_annual <- download_data(
   domain = "wrds",
@@ -566,6 +592,7 @@ compustat_annual <- download_data(
 ```
 
 ```{r}
+#| label: wrds-crsp-and-compustat-read-compustat
 #| eval: !expr "!params$download_data"
 #| echo: false
 compustat_annual <- read_parquet("data-r/compustat_annual.parquet")
@@ -576,6 +603,7 @@ compustat_annual <- read_parquet("data-r/compustat_annual.parquet")
 Unfortunately, CRSP and Compustat use different keys to identify stocks and firms. CRSP uses `permno` for stocks, while Compustat uses `gvkey` to identify firms. Fortunately, a curated matching table on WRDS allows us to merge CRSP and Compustat, so we create a connection to the *CRSP-Compustat Merged* table (provided by CRSP).\index{Data!Crsp-Compustat Merged}\index{Permno}\index{Gvkey}\index{Data!Linking table}
 
 ```{r}
+#| label: wrds-crsp-and-compustat-ccm-linking-table-db
 #| eval: !expr params$download_data
 ccm_linking_table_db <- tbl(wrds, I("crsp.ccmxpf_lnkhist"))
 ```
@@ -583,6 +611,7 @@ ccm_linking_table_db <- tbl(wrds, I("crsp.ccmxpf_lnkhist"))
 The linking table contains links between CRSP and Compustat identifiers from various approaches. However, we need to make sure that we keep only relevant and correct links, again following the description outlined in @BaliEngleMurray2016. Note also that currently active links have no end date, so we just enter the current date via `today()`.
 
 ```{r}
+#| label: wrds-crsp-and-compustat-download-ccm-linking-table
 #| eval: !expr params$download_data
 ccm_linking_table <- ccm_linking_table_db |>
   filter(
@@ -596,6 +625,7 @@ ccm_linking_table <- ccm_linking_table_db |>
 We use these links to create a new table with a mapping between stock identifier, firm identifier, and month. We then add these links to the Compustat `gvkey` to our monthly stock data. 
 
 ```{r}
+#| label: wrds-crsp-and-compustat-create-ccm-links
 #| eval: !expr params$download_data
 ccm_links <- crsp_monthly |>
   inner_join(
@@ -613,6 +643,7 @@ ccm_links <- crsp_monthly |>
 To fetch these links via `tidyfinance`, you can call:
 
 ```{r}
+#| label: wrds-crsp-and-compustat-tidyfinance-ccm-links
 #| eval: false
 ccm_links <- download_data(domain = "wrds", dataset = "ccm_links")
 ```
@@ -620,6 +651,7 @@ ccm_links <- download_data(domain = "wrds", dataset = "ccm_links")
 As the last step, we update the previously prepared monthly CRSP file with the linking information in our local folder.
 
 ```{r}
+#| label: wrds-crsp-and-compustat-merge-crsp-compustat
 #| eval: !expr params$download_data
 crsp_monthly <- crsp_monthly |>
   left_join(ccm_links, join_by(permno, date))
@@ -668,6 +700,7 @@ The difference arises from the distinct coverage of the two data sources. CRSP f
 As we mentioned above, the WRDS database runs on PostgreSQL rather than SQLite. Finding the right tables for your data needs can be tricky in the WRDS PostgreSQL instance, as the tables are organized in schemas.\index{Database!Schema} If you wonder what the purpose of schemas is, check out [this documentation.](https://www.postgresql.org/docs/9.1/ddl-schemas.html) For instance, if you want to find all tables that live in the `crsp` schema, you run
 
 ```{r}
+#| label: wrds-crsp-and-compustat-list-crsp-tables
 #| eval: false
 dbListObjects(wrds, Id(schema = "crsp"))
 ```
@@ -675,6 +708,7 @@ dbListObjects(wrds, Id(schema = "crsp"))
 This operation returns a list of all tables that belong to the `crsp` family on WRDS, e.g., `<Id> schema = crsp, table = msenames`. Similarly, you can fetch a list of all tables that belong to the `comp` family via
 
 ```{r}
+#| label: wrds-crsp-and-compustat-list-comp-tables
 #| eval: false
 dbListObjects(wrds, Id(schema = "comp"))
 ```
@@ -682,6 +716,7 @@ dbListObjects(wrds, Id(schema = "comp"))
 If you want to get all schemas, then run
 
 ```{r}
+#| label: wrds-crsp-and-compustat-list-all-schemas
 #| eval: false
 dbListObjects(wrds)
 ```

--- a/r/wrds-dummy-data.qmd
+++ b/r/wrds-dummy-data.qmd
@@ -13,6 +13,7 @@ We deliberately use the pseudo label because the data is not meaningful in the s
 To generate the pseudo data, we use the following packages:
 
 ```{r}
+#| label: wrds-dummy-data-packages
 #| message: false
 library(tidyverse)
 library(arrow)
@@ -21,6 +22,7 @@ library(arrow)
 We store the data in the folder `data-r`. Be careful, if you already downloaded the data from WRDS, then the code in this chapter will overwrite your data!
 
 ```{r}
+#| label: wrds-dummy-data-create-folder
 if (!dir.exists("data-r")) {
   dir.create("data-r")
 }
@@ -29,6 +31,7 @@ if (!dir.exists("data-r")) {
 Since we draw random numbers for most of the columns, we also define a seed to ensure that the generated numbers are replicable. We also initialize vectors of dates of different frequencies over ten years that we then use to create yearly, monthly, and daily data, respectively. 
 
 ```{r}
+#| label: wrds-dummy-data-seed-and-dates
 set.seed(1234)
 
 start_date <- as.Date("2003-01-01")
@@ -44,6 +47,7 @@ time_series_days <- seq(start_date, end_date, "1 day")
 Let us start with the core data used throughout the book: stock and firm characteristics. We first generate a table with a cross-section of stock identifiers with unique `permno` and `gvkey` values, as well as associated `exchcd`, `exchange`, `industry`, and `siccd` values. The generated data is based on the characteristics of stocks in the `crsp_monthly` table of the original data, ensuring that the generated stocks roughly reflect the distribution of industries and exchanges in the original data, but the identifiers and corresponding exchanges or industries do not reflect actual firms. Similarly, the `permno`-`gvkey` combinations are purely nonsensical and should not be used together with actual CRSP or Compustat data.
 
 ```{r}
+#| label: wrds-dummy-data-stock-identifiers
 number_of_stocks <- 100
 
 industries <- tibble(
@@ -122,6 +126,7 @@ Next, we construct the `stock_panel_monthly` panel. Similar to the yearly panel,
 Lastly, we create the `stock_panel_daily` panel. We combine `stock_identifiers` with a table containing the `date` variable from `pseudo_days`. After merging, we retain only the `permno` and `date` columns for our daily panel.
 
 ```{r}
+#| label: wrds-dummy-data-stock-panels
 stock_panel_yearly <- expand_grid(
   stock_identifiers,
   tibble(year = time_series_years)
@@ -146,6 +151,7 @@ stock_panel_daily <- expand_grid(
 We then proceed to create pseudo beta values for our `stock_panel_monthly` table. We generate monthly beta values `beta_monthly` using the `rnorm()` function with a mean and standard deviation of 1. For daily beta values `beta_daily`, we take the pseudo monthly beta and add a small random noise to it. This noise is generated again using the `rnorm()` function, but this time we divide the random values by 100 to ensure they are small deviations from the monthly beta.
 
 ```{r}
+#| label: wrds-dummy-data-beta
 beta_pseudo <- stock_panel_monthly |>
   mutate(
     beta_monthly = rnorm(n(), mean = 1, sd = 1),
@@ -160,6 +166,7 @@ write_parquet(beta_pseudo, "data-r/beta.parquet")
 To create pseudo firm characteristics, we take all columns from the `compustat_annual` table and create random numbers between 0 and 1. For simplicity, we set the `datadate` for each firm-year observation to the last day of the year, although it is empirically not the case. \index{Data!Compustat}
 
 ```{r}
+#| label: wrds-dummy-data-compustat
 relevant_columns <- c(
   "seq",
   "ceq",
@@ -204,6 +211,7 @@ write_parquet(compustat_pseudo, "data-r/compustat_annual.parquet")
 The `crsp_monthly` table only lacks a few more columns compared to `stock_panel_monthly`: the returns `ret` drawn from a normal distribution, the excess returns `ret_excess` with small deviations from the returns, the shares outstanding `shrout` and the last price per month `altprc` both drawn from uniform distributions, and the market capitalization `mktcap` as the product of `shrout` and `altprc`. \index{Data!CRSP}
 
 ```{r}
+#| label: wrds-dummy-data-crsp-monthly
 crsp_monthly_pseudo <- stock_panel_monthly |>
   mutate(
     ret = pmax(rnorm(n()), -1),
@@ -225,6 +233,7 @@ write_parquet(crsp_monthly_pseudo, "data-r/crsp_monthly.parquet")
 The `crsp_daily` table only contains a `date` column and the daily excess returns `ret_excess` as additional columns to `stock_panel_daily`.  
 
 ```{r}
+#| label: wrds-dummy-data-crsp-daily
 crsp_daily_pseudo <- stock_panel_daily |>
   mutate(
     ret_excess = pmax(rnorm(n()), -1)
@@ -242,6 +251,7 @@ Lastly, we move to the bond data that we use in our books.
 To create pseudo data with the structure of Mergent FISD, we calculate the empirical probabilities of actual bonds for several variables: `maturity`, `offering_amt`, `interest_frequency`, `coupon`, and `sic_code`. We use these probabilities to sample a small cross-section of bonds with completely made up `complete_cusip`, `issue_id`, and `issuer_id`.\index{Data!FISD}
 
 ```{r}
+#| label: wrds-dummy-data-fisd
 number_of_bonds <- 100
 
 fisd_pseudo <- 1:number_of_bonds |>
@@ -278,6 +288,7 @@ write_parquet(fisd_pseudo, "data-r/fisd.parquet")
 Finally, we create pseudo bond transaction data for the fictional CUSIPs of the pseudo `fisd` data. We take the date range that we also analyze in the book and ensure that we have at least five transactions per day to fulfill a filtering step in the book. \index{Data!TRACE}
 
 ```{r}
+#| label: wrds-dummy-data-trace-enhanced
 start_date <- as.Date("2014-01-01")
 end_date <- as.Date("2016-11-30")
 


### PR DESCRIPTION
## What

Adds a descriptive `#| label:` option to **every executable `{r}` and `{python}` code chunk** across the `r/` and `python/` folders. The goal is to make rendering progress easy to monitor: knitr prints the chunk label as each chunk runs, and the Quarto jupyter engine surfaces labels during execution, so meaningful names make it obvious where a (long) render currently is.

## Conventions

- **Format:** `#| label: <chapter-slug>-<descriptor>`, where `<chapter-slug>` is the file basename (e.g. `beta-estimation`) and `<descriptor>` is a short kebab-case description of what the chunk does (e.g. `packages`, `load-crsp-monthly`, `estimate-capm`, `rolling-window`, `plot-returns`).
- The label is placed as the first `#|` option line in each chunk (above any existing options like `#| echo: false`).
- Common chunks use consistent names: `-setup` for the `render-settings` chunk, `-packages` for imports/`library()` calls, and `-render-plotnine` for the plotnine-customization chunk (Python).
- Labels are unique within each document.

## Safety

- **Pre-existing crossreference labels (`fig-`/`tbl-`/`eq-`) were left untouched** — only chunks without any label received a new one.
- The diff adds only `#| label:` lines (plus a handful of incidental trailing-whitespace normalizations on fence/option lines); no code, prose, YAML, or option values were changed.
- **623** labels added in total. Verified per file that the number of executable chunks equals the number of `#| label:` lines, with no unintended duplicate labels.

## Note (pre-existing, out of scope)

`python/value-and-bivariate-sorts.qmd` already contained duplicated `fig-901`/`fig-902` crossref labels (a duplicated polars/pandas "Portfolio Composition" section). These pre-date this change and were left as-is.

https://claude.ai/code/session_012WEMQM5V232SjsjpShkkxj

---
_Generated by [Claude Code](https://claude.ai/code/session_012WEMQM5V232SjsjpShkkxj)_