### PR TITLE
Modern landing-page redesign (sandbox: index-redesign)

### DIFF
--- a/assets/css/index-redesign.css
+++ b/assets/css/index-redesign.css
@@ -1,0 +1,518 @@
+/* =========================================================
+   Tidy Finance — modern landing (sandbox: index-redesign.qmd)
+   All rules scoped under .tf-landing to avoid leaking into
+   the shared site styles.
+   ========================================================= */
+
+.tf-landing {
+  /* Zissou1 (wesanderson) ramp — the exact anchors used across the book */
+  --tf-teal: #3B9AB2;        /* ramp 1 */
+  --tf-teal-light: #78B7C5;  /* ramp 2 */
+  --tf-yellow: #EBCC2A;      /* ramp 3 */
+  --tf-gold: #E1AF00;        /* ramp 4 */
+  --tf-coral: #F21A00;       /* ramp 5 */
+  /* darker teal shades (derived from ramp 1) for readable text + hover states */
+  --tf-teal-600: #2f7e94;
+  --tf-teal-700: #265f70;
+  --tf-ink: #0e2a31;
+  --tf-body: #41555a;
+  --tf-muted: #6b7c81;
+  --tf-line: #e4edef;
+  --tf-soft: #f4fafb;
+  --tf-radius: 16px;
+  --tf-shadow-sm: 0 1px 2px rgba(14, 42, 49, .06), 0 1px 3px rgba(14, 42, 49, .08);
+  --tf-shadow-md: 0 12px 32px rgba(14, 42, 49, .10);
+  --tf-shadow-lg: 0 32px 64px rgba(14, 42, 49, .18);
+
+  color: var(--tf-body);
+  font-feature-settings: "kern", "liga", "calt";
+  -webkit-font-smoothing: antialiased;
+}
+
+.tf-landing h1,
+.tf-landing h2,
+.tf-landing h3,
+.tf-landing h4 {
+  color: var(--tf-ink);
+  letter-spacing: -0.02em;
+}
+
+/* ---------- shared section scaffolding ---------- */
+.tf-section {
+  max-width: 1120px;
+  margin: 0 auto;
+  padding: 76px 24px;
+}
+
+.tf-section__head {
+  text-align: center;
+  max-width: 700px;
+  margin: 0 auto 44px auto;
+}
+
+.tf-eyebrow {
+  display: inline-block;
+  font-size: .8rem;
+  font-weight: 700;
+  letter-spacing: .08em;
+  text-transform: uppercase;
+  color: var(--tf-teal);
+  margin-bottom: 10px;
+}
+
+.tf-section h2 {
+  font-size: clamp(1.7rem, 3vw, 2.3rem);
+  font-weight: 800;
+  margin: 0 0 14px 0;
+}
+
+.tf-section__head p {
+  font-size: 1.12rem;
+  line-height: 1.6;
+  color: var(--tf-muted);
+  margin: 0;
+}
+
+/* a quieter, lower-emphasis section variant */
+.tf-section--quiet {
+  padding-top: 36px;
+  padding-bottom: 60px;
+}
+
+.tf-section--quiet h2 {
+  font-size: clamp(1.35rem, 2.4vw, 1.75rem);
+}
+
+.tf-section--quiet .tf-section__head {
+  margin-bottom: 30px;
+}
+
+.tf-section--quiet .tf-section__head p {
+  font-size: 1rem;
+}
+
+/* ---------- buttons ---------- */
+.tf-btn {
+  display: inline-block;
+  margin: 0 10px 10px 0;
+  padding: 13px 26px;
+  border-radius: 12px;
+  font-weight: 650;
+  font-size: 1rem;
+  text-decoration: none;
+  cursor: pointer;
+  transition: transform .2s ease, box-shadow .2s ease, background .2s ease, color .2s ease, border-color .2s ease;
+}
+
+.tf-btn--primary {
+  background: var(--tf-teal);
+  color: #fff;
+  box-shadow: 0 8px 20px rgba(59, 154, 178, .32);
+}
+
+.tf-btn--primary:hover {
+  background: var(--tf-teal-600);
+  transform: translateY(-2px);
+  box-shadow: 0 14px 30px rgba(59, 154, 178, .44);
+  color: #fff;
+}
+
+.tf-btn--ghost {
+  background: #fff;
+  color: var(--tf-ink);
+  border: 1px solid var(--tf-line);
+}
+
+.tf-btn--ghost:hover {
+  transform: translateY(-2px);
+  border-color: var(--tf-teal);
+  color: var(--tf-teal-700);
+  box-shadow: var(--tf-shadow-md);
+}
+
+/* ---------- HERO ---------- */
+.tf-hero {
+  position: relative;
+  overflow: hidden;
+  padding: 80px 24px 68px 24px;
+}
+
+.tf-hero__bg {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+  background:
+    radial-gradient(42% 55% at 10% 6%, rgba(59, 154, 178, .22), transparent 60%),
+    radial-gradient(40% 52% at 94% 10%, rgba(225, 175, 0, .18), transparent 60%),
+    radial-gradient(46% 62% at 82% 98%, rgba(59, 154, 178, .12), transparent 60%),
+    linear-gradient(180deg, var(--tf-soft) 0%, #ffffff 72%);
+}
+
+.tf-hero__inner {
+  position: relative;
+  z-index: 1;
+  max-width: 1120px;
+  margin: 0 auto;
+  display: grid;
+  grid-template-columns: 1.05fr .95fr;
+  gap: 56px;
+  align-items: center;
+}
+
+.tf-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 14px;
+  border-radius: 999px;
+  background: rgba(59, 154, 178, .10);
+  border: 1px solid rgba(59, 154, 178, .22);
+  color: var(--tf-teal-700);
+  font-size: .82rem;
+  font-weight: 600;
+  margin-bottom: 22px;
+}
+
+.tf-hero h1 {
+  font-size: clamp(2.3rem, 4.6vw, 3.5rem);
+  line-height: 1.07;
+  font-weight: 800;
+  margin: 0 0 20px 0;
+}
+
+.tf-grad {
+  background: linear-gradient(120deg, var(--tf-teal) 0%, var(--tf-gold) 100%);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+
+.tf-lead {
+  display: block;
+  font-size: 1.18rem;
+  line-height: 1.62;
+  color: var(--tf-body);
+  max-width: 40ch;
+  margin-bottom: 30px;
+}
+
+.tf-cta-row {
+  margin-bottom: 16px;
+}
+
+.tf-cta-row p {
+  margin: 0;
+}
+
+.tf-hero__note {
+  display: block;
+  font-size: .9rem;
+  color: var(--tf-muted);
+}
+
+/* code window */
+.tf-window {
+  background: #fff;
+  border: 1px solid var(--tf-line);
+  border-radius: 14px;
+  box-shadow: var(--tf-shadow-lg);
+  overflow: hidden;
+}
+
+.tf-window__bar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 12px 16px;
+  background: #f6f9fa;
+  border-bottom: 1px solid var(--tf-line);
+}
+
+.tf-dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  display: inline-block;
+}
+
+.tf-dot--r { background: #ff5f56; }
+.tf-dot--y { background: #ffbd2e; }
+.tf-dot--g { background: #27c93f; }
+
+.tf-window__file {
+  margin-left: 8px;
+  color: var(--tf-muted);
+  font-size: .82rem;
+  font-family: var(--bs-font-monospace, ui-monospace, SFMono-Regular, Menlo, monospace);
+}
+
+/* tabset toggle inside the window */
+.tf-window .panel-tabset > .nav-tabs {
+  border: none;
+  gap: 6px;
+  padding: 12px 14px 0 14px;
+  background: transparent;
+}
+
+.tf-window .panel-tabset .nav-link {
+  border: none;
+  border-radius: 8px;
+  padding: 6px 16px;
+  color: var(--tf-muted);
+  font-weight: 600;
+  font-size: .9rem;
+}
+
+.tf-window .panel-tabset .nav-link:hover {
+  color: var(--tf-teal-700);
+  background: rgba(59, 154, 178, .07);
+}
+
+.tf-window .panel-tabset .nav-link.active {
+  background: rgba(59, 154, 178, .13);
+  color: var(--tf-teal-700);
+}
+
+.tf-window .panel-tabset .tab-content {
+  border: none;
+  padding: 6px 14px 14px 14px;
+}
+
+.tf-window pre {
+  margin: 0;
+  background: #fbfdfe !important;
+  background-image: none !important;
+  border: 1px solid var(--tf-line);
+  border-radius: 10px;
+  font-size: .82rem;
+  line-height: 1.5;
+}
+
+.tf-window .sourceCode {
+  background: transparent;
+}
+
+/* ---------- STATS ---------- */
+.tf-stats {
+  border-top: 1px solid var(--tf-line);
+  border-bottom: 1px solid var(--tf-line);
+  background: var(--tf-soft);
+}
+
+.tf-stats__grid {
+  max-width: 1120px;
+  margin: 0 auto;
+  padding: 32px 24px;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 24px;
+  text-align: center;
+}
+
+.tf-stat__num {
+  display: block;
+  font-size: clamp(1.9rem, 3vw, 2.5rem);
+  font-weight: 800;
+  line-height: 1;
+  background: linear-gradient(120deg, var(--tf-teal), var(--tf-gold));
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+
+.tf-stat__label {
+  display: block;
+  margin-top: 10px;
+  font-size: .92rem;
+  color: var(--tf-muted);
+}
+
+/* ---------- FEATURES ---------- */
+.tf-features {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 20px;
+}
+
+.tf-feature {
+  background: #fff;
+  border: 1px solid var(--tf-line);
+  border-radius: var(--tf-radius);
+  padding: 28px;
+  transition: transform .2s ease, box-shadow .2s ease, border-color .2s ease;
+}
+
+.tf-feature:hover {
+  transform: translateY(-4px);
+  box-shadow: var(--tf-shadow-md);
+  border-color: rgba(59, 154, 178, .3);
+}
+
+.tf-feature__icon {
+  width: 48px;
+  height: 48px;
+  border-radius: 12px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(59, 154, 178, .10);
+  color: var(--tf-teal);
+  margin-bottom: 18px;
+}
+
+.tf-feature__icon svg {
+  width: 24px;
+  height: 24px;
+}
+
+.tf-feature h3 {
+  font-size: 1.12rem;
+  margin: 0 0 8px 0;
+}
+
+.tf-feature p {
+  margin: 0;
+  font-size: .97rem;
+  line-height: 1.55;
+  color: var(--tf-muted);
+}
+
+/* ---------- CURRICULUM TRACKS ---------- */
+.tf-tracks {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 18px;
+}
+
+.tf-track {
+  display: block;
+  padding: 24px;
+  border-radius: var(--tf-radius);
+  background: #fff;
+  border: 1px solid var(--tf-line);
+  text-decoration: none;
+  transition: transform .2s ease, box-shadow .2s ease, border-color .2s ease;
+}
+
+.tf-track:hover {
+  transform: translateY(-4px);
+  box-shadow: var(--tf-shadow-md);
+  border-color: rgba(59, 154, 178, .35);
+}
+
+.tf-track__no {
+  font-size: .78rem;
+  font-weight: 700;
+  letter-spacing: .1em;
+  color: var(--tf-teal);
+}
+
+.tf-track h3 {
+  font-size: 1.1rem;
+  margin: 6px 0 8px 0;
+}
+
+.tf-track p {
+  margin: 0;
+  font-size: .92rem;
+  line-height: 1.5;
+  color: var(--tf-muted);
+}
+
+.tf-track__cta {
+  margin-top: 14px;
+  font-weight: 600;
+  font-size: .9rem;
+  color: var(--tf-teal-700);
+}
+
+/* ---------- FINAL CTA ---------- */
+.tf-final {
+  position: relative;
+  overflow: hidden;
+  background: linear-gradient(120deg, var(--tf-teal-700), var(--tf-teal) 62%, var(--tf-teal-600));
+  color: #fff;
+}
+
+.tf-final__inner {
+  position: relative;
+  z-index: 1;
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 66px 24px;
+  text-align: center;
+}
+
+.tf-final h2 {
+  color: #fff;
+  font-size: clamp(1.8rem, 3.4vw, 2.4rem);
+  font-weight: 800;
+  margin: 0 0 14px 0;
+}
+
+.tf-final p {
+  color: rgba(255, 255, 255, .86);
+  font-size: 1.12rem;
+  margin: 0 0 26px 0;
+}
+
+.tf-final .tf-btn--primary {
+  background: #fff;
+  color: var(--tf-teal-700);
+  box-shadow: 0 10px 24px rgba(0, 0, 0, .18);
+}
+
+.tf-final .tf-btn--primary:hover {
+  color: var(--tf-teal-700);
+}
+
+.tf-final .tf-btn--ghost {
+  background: transparent;
+  color: #fff;
+  border-color: rgba(255, 255, 255, .5);
+}
+
+.tf-final .tf-btn--ghost:hover {
+  color: #fff;
+  border-color: #fff;
+  background: rgba(255, 255, 255, .10);
+}
+
+/* ---------- reused sections: tighten spacing ---------- */
+.tf-landing .swiper { margin-top: 8px; }
+
+/* ---------- entrance animation ---------- */
+@keyframes tf-fade-up {
+  from { opacity: 0; transform: translateY(14px); }
+  to   { opacity: 1; transform: none; }
+}
+
+.tf-hero__copy > * { animation: tf-fade-up .6s ease both; }
+.tf-hero__copy > *:nth-child(2) { animation-delay: .04s; }
+.tf-hero__copy > *:nth-child(3) { animation-delay: .08s; }
+.tf-hero__copy > *:nth-child(4) { animation-delay: .12s; }
+.tf-hero__visual { animation: tf-fade-up .7s ease .14s both; }
+
+@media (prefers-reduced-motion: reduce) {
+  .tf-hero__copy > *,
+  .tf-hero__visual { animation: none; }
+}
+
+/* ---------- responsive ---------- */
+@media (max-width: 900px) {
+  .tf-hero__inner { grid-template-columns: 1fr; gap: 36px; }
+  .tf-features,
+  .tf-tracks { grid-template-columns: 1fr 1fr; }
+}
+
+@media (max-width: 680px) {
+  .tf-stats__grid { grid-template-columns: repeat(2, 1fr); row-gap: 28px; }
+}
+
+@media (max-width: 560px) {
+  .tf-features,
+  .tf-tracks { grid-template-columns: 1fr; }
+  .tf-hero { padding-top: 56px; }
+  .tf-section { padding: 56px 24px; }
+}

--- a/docs/index-redesign.html
+++ b/docs/index-redesign.html
@@ -1,0 +1,1282 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en"><head>
+
+<meta charset="utf-8">
+<meta name="generator" content="quarto-1.9.38">
+
+<meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
+
+<meta name="description" content="An opinionated approach on empirical research in financial economics using the programming languages R and Python.">
+
+<title>Tidy Finance Redesign Preview – Tidy Finance</title>
+<style>
+/* Default styles provided by pandoc.
+** See https://pandoc.org/MANUAL.html#variables-for-html for config info.
+*/
+code{white-space: pre-wrap;}
+span.smallcaps{font-variant: small-caps;}
+div.columns{display: flex; gap: min(4vw, 1.5em);}
+div.column{flex: auto; overflow-x: auto;}
+div.hanging-indent{margin-left: 1.5em; text-indent: -1.5em;}
+ul.task-list{list-style: none;}
+ul.task-list li input[type="checkbox"] {
+  width: 0.8em;
+  margin: 0 0.8em 0.2em -1em; /* quarto-specific, see https://github.com/quarto-dev/quarto-cli/issues/4556 */ 
+  vertical-align: middle;
+}
+/* CSS for syntax highlighting */
+html { -webkit-text-size-adjust: 100%; }
+pre > code.sourceCode { white-space: pre; position: relative; }
+pre > code.sourceCode > span { display: inline-block; line-height: 1.25; }
+pre > code.sourceCode > span:empty { height: 1.2em; }
+.sourceCode { overflow: visible; }
+code.sourceCode > span { color: inherit; text-decoration: inherit; }
+div.sourceCode { margin: 1em 0; }
+pre.sourceCode { margin: 0; }
+@media screen {
+div.sourceCode { overflow: auto; }
+}
+@media print {
+pre > code.sourceCode { white-space: pre-wrap; }
+pre > code.sourceCode > span { text-indent: -5em; padding-left: 5em; }
+}
+pre.numberSource code
+  { counter-reset: source-line 0; }
+pre.numberSource code > span
+  { position: relative; left: -4em; counter-increment: source-line; }
+pre.numberSource code > span > a:first-child::before
+  { content: counter(source-line);
+    position: relative; left: -1em; text-align: right; vertical-align: baseline;
+    border: none; display: inline-block;
+    -webkit-touch-callout: none; -webkit-user-select: none;
+    -khtml-user-select: none; -moz-user-select: none;
+    -ms-user-select: none; user-select: none;
+    padding: 0 4px; width: 4em;
+  }
+pre.numberSource { margin-left: 3em;  padding-left: 4px; }
+div.sourceCode
+  {   }
+@media screen {
+pre > code.sourceCode > span > a:first-child::before { text-decoration: underline; }
+}
+</style>
+
+
+<script src="site_libs/quarto-nav/quarto-nav.js"></script>
+<script src="site_libs/clipboard/clipboard.min.js"></script>
+<script src="site_libs/quarto-search/autocomplete.umd.js"></script>
+<script src="site_libs/quarto-search/fuse.min.js"></script>
+<script src="site_libs/quarto-search/quarto-search.js"></script>
+<meta name="quarto:offset" content="./">
+<link href="./assets/img/favicon.png" rel="icon" type="image/png">
+<script src="site_libs/cookie-consent/cookie-consent.js"></script>
+<link href="site_libs/cookie-consent/cookie-consent.css" rel="stylesheet">
+<script src="site_libs/quarto-html/quarto.js" type="module"></script>
+<script src="site_libs/quarto-html/tabsets/tabsets.js" type="module"></script>
+<script src="site_libs/quarto-html/popper.min.js"></script>
+<script src="site_libs/quarto-html/tippy.umd.min.js"></script>
+<script src="site_libs/quarto-html/anchor.min.js"></script>
+<link href="site_libs/quarto-html/tippy.css" rel="stylesheet">
+<link href="site_libs/quarto-html/quarto-syntax-highlighting-15634bcf2e68342d4ad2dfa704d543f6.css" rel="stylesheet" id="quarto-text-highlighting-styles">
+<script src="site_libs/bootstrap/bootstrap.min.js"></script>
+<link href="site_libs/bootstrap/bootstrap-icons.css" rel="stylesheet">
+<link href="site_libs/bootstrap/bootstrap-15df67a978eff2724f248dfecb6ea2b0.min.css" rel="stylesheet" append-hash="true" id="quarto-bootstrap" data-mode="light">
+<script id="quarto-search-options" type="application/json">{
+  "location": "navbar",
+  "copy-button": false,
+  "collapse-after": 3,
+  "panel-placement": "end",
+  "type": "overlay",
+  "limit": 50,
+  "keyboard-shortcut": [
+    "f",
+    "/",
+    "s"
+  ],
+  "show-item-context": false,
+  "language": {
+    "search-no-results-text": "No results",
+    "search-matching-documents-text": "matching documents",
+    "search-copy-link-title": "Copy link to search",
+    "search-hide-matches-text": "Hide additional matches",
+    "search-more-match-text": "more match in this document",
+    "search-more-matches-text": "more matches in this document",
+    "search-clear-button-title": "Clear",
+    "search-text-placeholder": "",
+    "search-detached-cancel-button-title": "Cancel",
+    "search-submit-button-title": "Submit",
+    "search-label": "Search"
+  }
+}</script>
+<script async="" src="https://www.googletagmanager.com/gtag/js?id=G-DH3KZSMJ5W"></script>
+
+<script type="text/plain" cookie-consent="tracking">
+
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date());
+gtag('config', 'G-DH3KZSMJ5W', { 'anonymize_ip': true});
+</script>
+
+<script type="text/javascript" charset="UTF-8">
+document.addEventListener('DOMContentLoaded', function () {
+cookieconsent.run({
+  "notice_banner_type":"interstitial",
+  "consent_type":"express",
+  "palette":"light",
+  "language":"en",
+  "page_load_consent_levels":["strictly-necessary"],
+  "notice_banner_reject_button_hide":false,
+  "preferences_center_close_button_hide":false,
+  "website_name":""
+  ,
+"language":"en"
+  });
+});
+</script> 
+  
+<style>html{ scroll-behavior: smooth; }</style>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/swiper@10/swiper-bundle.min.css">
+
+
+
+<script src="https://cdn.jsdelivr.net/npm/swiper@10/swiper-bundle.min.js"></script>
+
+
+
+<link rel="stylesheet" href="assets/css/global.css">
+<link rel="stylesheet" href="assets/css/index.css">
+<link rel="stylesheet" href="assets/css/index-redesign.css">
+<meta property="og:title" content="Welcome to Tidy Finance">
+<meta property="og:description" content="An opinionated approach on empirical research in financial economics.">
+<meta property="og:image" content="https://www.tidy-finance.org/assets/img/cover.png">
+<meta property="og:site_name" content="Tidy Finance">
+<meta property="og:image:height" content="1800">
+<meta property="og:image:width" content="3000">
+</head>
+
+<body class="nav-fixed fullcontent quarto-light">
+
+<div id="quarto-search-results"></div>
+  <header id="quarto-header" class="headroom fixed-top">
+    <nav class="navbar navbar-expand-lg " data-bs-theme="dark">
+      <div class="navbar-container container-fluid">
+      <div class="navbar-brand-container mx-auto">
+    <a href="./index.html" class="navbar-brand navbar-brand-logo">
+    <img src="./assets/img/logo-website-white.png" alt="" class="navbar-logo light-content">
+    <img src="./assets/img/logo-website-white.png" alt="" class="navbar-logo dark-content">
+    </a>
+    <a class="navbar-brand" href="./index.html">
+    <span class="navbar-title">Tidy Finance</span>
+    </a>
+  </div>
+            <div id="quarto-search" class="" title="Search"></div>
+          <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarCollapse" aria-controls="navbarCollapse" role="menu" aria-expanded="false" aria-label="Toggle navigation" onclick="if (window.quartoToggleHeadroom) { window.quartoToggleHeadroom(); }">
+  <span class="navbar-toggler-icon"></span>
+</button>
+          <div class="collapse navbar-collapse" id="navbarCollapse">
+            <ul class="navbar-nav navbar-nav-scroll me-auto">
+  <li class="nav-item">
+    <a class="nav-link" href="./chapters/working-with-stock-returns.html"> 
+<span class="menu-text">Chapters</span></a>
+  </li>  
+  <li class="nav-item">
+    <a class="nav-link" href="./blog.html"> 
+<span class="menu-text">Blog</span></a>
+  </li>  
+  <li class="nav-item">
+    <a class="nav-link" href="./contribute.html"> 
+<span class="menu-text">Contribute</span></a>
+  </li>  
+  <li class="nav-item">
+    <a class="nav-link" href="./support.html"> 
+<span class="menu-text">Support</span></a>
+  </li>  
+  <li class="nav-item">
+    <a class="nav-link" href="https://talks.tidy-finance.org"> 
+<span class="menu-text">Talks</span></a>
+  </li>  
+  <li class="nav-item">
+    <a class="nav-link" href="./workshops/reproducible-research-workflows.html"> 
+<span class="menu-text">Workshops</span></a>
+  </li>  
+  <li class="nav-item">
+    <a class="nav-link" href="https://bse.eu/summer-school/data-science-finance/tidy-finance-reproducible-research-in-data-science" target="_blank"> 
+<span class="menu-text">Summer School</span></a>
+  </li>  
+</ul>
+          </div> <!-- /navcollapse -->
+            <div class="quarto-navbar-tools">
+</div>
+      </div> <!-- /container-fluid -->
+    </nav>
+</header>
+<!-- content -->
+<div id="quarto-content" class="quarto-container page-layout-custom page-navbar">
+<!-- sidebar -->
+<!-- margin-sidebar -->
+<!-- main -->
+
+
+
+
+<div class="tf-landing">
+<!-- ============================ HERO ============================ -->
+<div class="tf-hero">
+<div class="tf-hero__bg">
+
+</div>
+<div class="tf-hero__inner">
+<div class="tf-hero__copy">
+<p><span class="tf-badge">★ Open-source · R &amp; Python · Reproducible</span></p>
+<h1 id="empirical-finance-reproducible-in-r-and-python">Empirical finance, <span class="tf-grad">reproducible</span> in R and Python</h1>
+<p><span class="tf-lead">Tidy Finance takes an opinionated, fully transparent approach to empirical research in financial economics. One open-source code base now covers R and Python, side by side in every chapter.</span></p>
+<div class="tf-cta-row">
+<p><a href="chapters/working-with-stock-returns.html" class="tf-btn tf-btn--primary">Start here</a> <a href="https://package.tidy-finance.org" class="tf-btn tf-btn--ghost">R &amp; Python docs</a> <a href="https://factors.tidy-finance.org" class="tf-btn tf-btn--ghost">Data platform</a></p>
+</div>
+</div>
+<div class="tf-hero__visual">
+<div class="tf-window">
+<div class="tf-window__bar">
+<span class="tf-dot tf-dot--r"></span><span class="tf-dot tf-dot--y"></span><span class="tf-dot tf-dot--g"></span><span class="tf-window__file">download &amp; plot prices</span>
+</div>
+<div class="panel-tabset" data-group="language">
+<ul class="nav nav-tabs" role="tablist"><li class="nav-item" role="presentation"><a class="nav-link active" id="tabset-1-1-tab" data-bs-toggle="tab" data-bs-target="#tabset-1-1" role="tab" aria-controls="tabset-1-1" aria-selected="true" href="">R</a></li><li class="nav-item" role="presentation"><a class="nav-link" id="tabset-1-2-tab" data-bs-toggle="tab" data-bs-target="#tabset-1-2" role="tab" aria-controls="tabset-1-2" aria-selected="false" href="">Python</a></li></ul>
+<div class="tab-content" data-group="language">
+<div id="tabset-1-1" class="tab-pane active" role="tabpanel" aria-labelledby="tabset-1-1-tab">
+<div class="code-copy-outer-scaffold"><div class="sourceCode" id="cb1"><pre class="sourceCode r code-with-copy"><code class="sourceCode r"><span id="cb1-1"><a href="#cb1-1" aria-hidden="true" tabindex="-1"></a><span class="fu">library</span>(tidyfinance)</span>
+<span id="cb1-2"><a href="#cb1-2" aria-hidden="true" tabindex="-1"></a><span class="fu">library</span>(ggplot2)</span>
+<span id="cb1-3"><a href="#cb1-3" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb1-4"><a href="#cb1-4" aria-hidden="true" tabindex="-1"></a>prices <span class="ot">&lt;-</span> <span class="fu">download_data</span>(</span>
+<span id="cb1-5"><a href="#cb1-5" aria-hidden="true" tabindex="-1"></a>  <span class="at">domain =</span> <span class="st">"stock_prices"</span>,</span>
+<span id="cb1-6"><a href="#cb1-6" aria-hidden="true" tabindex="-1"></a>  <span class="at">symbols =</span> <span class="st">"AAPL"</span>,</span>
+<span id="cb1-7"><a href="#cb1-7" aria-hidden="true" tabindex="-1"></a>  <span class="at">start_date =</span> <span class="st">"2000-01-01"</span>,</span>
+<span id="cb1-8"><a href="#cb1-8" aria-hidden="true" tabindex="-1"></a>  <span class="at">end_date =</span> <span class="st">"2024-12-31"</span></span>
+<span id="cb1-9"><a href="#cb1-9" aria-hidden="true" tabindex="-1"></a>)</span>
+<span id="cb1-10"><a href="#cb1-10" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb1-11"><a href="#cb1-11" aria-hidden="true" tabindex="-1"></a>prices <span class="sc">|&gt;</span></span>
+<span id="cb1-12"><a href="#cb1-12" aria-hidden="true" tabindex="-1"></a>  <span class="fu">ggplot</span>(<span class="fu">aes</span>(date, adjusted_close)) <span class="sc">+</span></span>
+<span id="cb1-13"><a href="#cb1-13" aria-hidden="true" tabindex="-1"></a>  <span class="fu">geom_line</span>()</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
+</div>
+<div id="tabset-1-2" class="tab-pane" role="tabpanel" aria-labelledby="tabset-1-2-tab">
+<div class="code-copy-outer-scaffold"><div class="sourceCode" id="cb2"><pre class="sourceCode python code-with-copy"><code class="sourceCode python"><span id="cb2-1"><a href="#cb2-1" aria-hidden="true" tabindex="-1"></a><span class="im">import</span> tidyfinance <span class="im">as</span> tf</span>
+<span id="cb2-2"><a href="#cb2-2" aria-hidden="true" tabindex="-1"></a><span class="im">from</span> plotnine <span class="im">import</span> ggplot, aes, geom_line</span>
+<span id="cb2-3"><a href="#cb2-3" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb2-4"><a href="#cb2-4" aria-hidden="true" tabindex="-1"></a>prices <span class="op">=</span> tf.download_data(</span>
+<span id="cb2-5"><a href="#cb2-5" aria-hidden="true" tabindex="-1"></a>  domain<span class="op">=</span><span class="st">"stock_prices"</span>,</span>
+<span id="cb2-6"><a href="#cb2-6" aria-hidden="true" tabindex="-1"></a>  symbols<span class="op">=</span><span class="st">"AAPL"</span>,</span>
+<span id="cb2-7"><a href="#cb2-7" aria-hidden="true" tabindex="-1"></a>  start_date<span class="op">=</span><span class="st">"2000-01-01"</span>,</span>
+<span id="cb2-8"><a href="#cb2-8" aria-hidden="true" tabindex="-1"></a>  end_date<span class="op">=</span><span class="st">"2024-12-31"</span></span>
+<span id="cb2-9"><a href="#cb2-9" aria-hidden="true" tabindex="-1"></a>)</span>
+<span id="cb2-10"><a href="#cb2-10" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb2-11"><a href="#cb2-11" aria-hidden="true" tabindex="-1"></a>(prices</span>
+<span id="cb2-12"><a href="#cb2-12" aria-hidden="true" tabindex="-1"></a>  .pipe(ggplot, aes(<span class="st">"date"</span>, <span class="st">"adjusted_close"</span>))</span>
+<span id="cb2-13"><a href="#cb2-13" aria-hidden="true" tabindex="-1"></a>  <span class="op">+</span> geom_line())</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<!-- ============================ STATS ============================ -->
+<div class="tf-stats">
+<div class="tf-stats__grid">
+<div class="tf-stat">
+<p><span class="tf-stat__num">20+</span> <span class="tf-stat__label">Hands-on chapters</span></p>
+</div>
+<div class="tf-stat">
+<p><span class="tf-stat__num">2</span> <span class="tf-stat__label">Languages, one code base</span></p>
+</div>
+<div class="tf-stat">
+<p><span class="tf-stat__num">100%</span> <span class="tf-stat__label">Open source &amp; reproducible</span></p>
+</div>
+</div>
+</div>
+<script>
+(function () {
+  function animate(el) {
+    var raw = el.getAttribute('data-target');
+    var m = raw.match(/^(\D*)(\d+(?:\.\d+)?)(\D*)$/);
+    if (!m) { el.textContent = raw; return; }
+    var prefix = m[1], target = parseFloat(m[2]), suffix = m[3];
+    var decimals = (m[2].split('.')[1] || '').length;
+    var dur = 1300, start = null, finished = false;
+    function ease(t) { return 1 - Math.pow(1 - t, 3); }
+    function finish() {
+      if (finished) return;
+      finished = true;
+      el.textContent = prefix + target.toFixed(decimals) + suffix;
+    }
+    function step(ts) {
+      if (finished) return;
+      if (start === null) start = ts;
+      var p = Math.min((ts - start) / dur, 1);
+      el.textContent = prefix + (ease(p) * target).toFixed(decimals) + suffix;
+      if (p < 1) { requestAnimationFrame(step); } else { finish(); }
+    }
+    // Safety net: if rAF is throttled/paused, still land on the final value.
+    setTimeout(finish, dur + 800);
+    requestAnimationFrame(step);
+  }
+
+  function init() {
+    var nums = document.querySelectorAll('.tf-stat__num');
+    if (!nums.length) return;
+    nums.forEach(function (el) { el.setAttribute('data-target', el.textContent.trim()); });
+
+    var reduce = window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    if (reduce || !('IntersectionObserver' in window)) return; // leave final values in place
+
+    nums.forEach(function (el) { el.textContent = el.textContent.replace(/\d+(\.\d+)?/, '0'); });
+
+    var band = document.querySelector('.tf-stats');
+    var fired = false;
+    function trigger() {
+      if (fired) return;
+      fired = true;
+      if (io) { io.disconnect(); }
+      nums.forEach(animate);
+    }
+
+    var io = new IntersectionObserver(function (entries) {
+      entries.forEach(function (e) { if (e.isIntersecting) { trigger(); } });
+    }, { threshold: 0.4 });
+    if (band) { io.observe(band); }
+
+    // Fallback if IntersectionObserver does not deliver: animate once the band is on screen.
+    setTimeout(function () {
+      if (fired) { return; }
+      var r = (band || document.body).getBoundingClientRect();
+      if (r.top < window.innerHeight && r.bottom > 0) { trigger(); }
+    }, 1200);
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();
+</script>
+<!-- ============================ FEATURES ============================ -->
+<div class="tf-section">
+<section id="everything-you-need-for-reproducible-finance" class="tf-section__head">
+<h2>Everything you need for reproducible finance</h2>
+<p>A single, transparent code base takes you from raw data to publication-quality results, in whichever language you prefer.</p>
+</section>
+<div class="tf-features">
+<div class="tf-feature">
+<div class="tf-feature__icon"><svg viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="16 18 22 12 16 6"></polyline><polyline points="8 6 2 12 8 18"></polyline></svg></div>
+<h3 id="one-code-base-two-languages">One code base, two languages</h3>
+<p>Every chapter ships R and Python side by side from a single source. Switch with a tab. Your choice follows you through the book.</p>
+</div>
+<div class="tf-feature">
+<div class="tf-feature__icon"><svg viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="23 4 23 10 17 10"></polyline><polyline points="1 20 1 14 7 14"></polyline><path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15"></path></svg></div>
+<h3 id="fully-transparent-reproducible">Fully transparent &amp; reproducible</h3>
+<p>Open code you can run end to end, from raw data to every figure and table, with no black boxes.</p>
+</div>
+<div class="tf-feature">
+<div class="tf-feature__icon"><svg viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="16.5" y1="9.4" x2="7.5" y2="4.21"></line><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"></path><polyline points="3.27 6.96 12 12.01 20.73 6.96"></polyline><line x1="12" y1="22.08" x2="12" y2="12"></line></svg></div>
+<h3 id="powered-by-tidyfinance">Powered by <code>tidyfinance</code></h3>
+<p>A companion package for R and Python that wraps data downloads and the routines we use throughout the book.</p>
+</div>
+<div class="tf-feature">
+<div class="tf-feature__icon"><svg viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><ellipse cx="12" cy="5" rx="9" ry="3"></ellipse><path d="M21 12c0 1.66-4 3-9 3s-9-1.34-9-3"></path><path d="M3 5v14c0 1.66 4 3 9 3s9-1.34 9-3V5"></path></svg></div>
+<h3 id="real-financial-data">Real financial data</h3>
+<p>Work with the data professionals use, like CRSP, Compustat, and TRACE, through clean, documented access patterns.</p>
+</div>
+<div class="tf-feature">
+<div class="tf-feature__icon"><svg viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="23 6 13.5 15.5 8.5 10.5 1 18"></polyline><polyline points="17 6 23 6 23 12"></polyline></svg></div>
+<h3 id="from-sorts-to-machine-learning">From sorts to machine learning</h3>
+<p>Portfolio sorts, factor models, fixed effects, causal inference, and modern ML give you the full empirical toolkit.</p>
+</div>
+<div class="tf-feature">
+<div class="tf-feature__icon"><svg viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"></path><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"></path></svg></div>
+<h3 id="a-free-open-book">A free, open book</h3>
+<p>Read the whole book online for free, dive into the blog, or join a workshop, all in the open.</p>
+</div>
+</div>
+</div>
+<!-- ============================ CURRICULUM ============================ -->
+<div class="tf-section tf-section--quiet">
+<section id="browse-the-book-by-topic" class="tf-section__head">
+<h2>Browse the book by topic</h2>
+<p>Five parts take you from your first stock return to constrained portfolio backtests.</p>
+</section>
+<div class="tf-tracks">
+  <a class="tf-track" href="chapters/working-with-stock-returns.html">
+    <div class="tf-track__no">PART 01</div>
+    <h3>Getting Started</h3>
+    <p>Stock returns, modern portfolio theory, the CAPM, and financial statement analysis.</p>
+    <div class="tf-track__cta">Start here →</div>
+  </a>
+  <a class="tf-track" href="chapters/accessing-and-managing-financial-data.html">
+    <div class="tf-track__no">PART 02</div>
+    <h3>Financial Data</h3>
+    <p>Access and manage WRDS, CRSP, Compustat, TRACE, and FISD with documented workflows.</p>
+    <div class="tf-track__cta">Explore data →</div>
+  </a>
+  <a class="tf-track" href="chapters/beta-estimation.html">
+    <div class="tf-track__no">PART 03</div>
+    <h3>Asset Pricing</h3>
+    <p>Beta estimation, univariate and bivariate sorts, Fama-French factors, and Fama-MacBeth.</p>
+    <div class="tf-track__cta">Price assets →</div>
+  </a>
+  <a class="tf-track" href="chapters/fixed-effects-and-clustered-standard-errors.html">
+    <div class="tf-track__no">PART 04</div>
+    <h3>Modeling &amp; Machine Learning</h3>
+    <p>Fixed effects, difference-in-differences, factor selection, and option pricing via ML.</p>
+    <div class="tf-track__cta">Model it →</div>
+  </a>
+  <a class="tf-track" href="chapters/parametric-portfolio-policies.html">
+    <div class="tf-track__no">PART 05</div>
+    <h3>Portfolio Optimization</h3>
+    <p>Parametric portfolio policies and constrained optimization with realistic backtesting.</p>
+    <div class="tf-track__cta">Optimize →</div>
+  </a>
+</div>
+</div>
+<!-- ============================ TESTIMONIALS ============================ -->
+<div class="tf-section">
+<div class="tf-section__head">
+<p><span class="tf-eyebrow">Praise</span></p>
+<h2 id="what-experts-say-about-tidy-finance">What experts say about Tidy Finance</h2>
+</div>
+<!-- Slider main container -->
+<div class="swiper">
+  <!-- Additional required wrapper -->
+  <div class="swiper-wrapper" id="swiper-wrapper">
+    <!-- Slides -->
+
+    <div class="swiper-slide">
+      <div class="quote-image">
+        <img src="assets/img/quotes/harald_lohre.jpg" alt="A portrait of Harald Lohre">
+      </div>
+      <p><i>A clean coding environment is a prerequisite for building a relevant investment platform and conducting meaningful factor research. Tidy Finance is the name of the game, giving aspiring academics and finance practitioners just what they need to perform clean and reproducible  research. Highly recommended.</i></p>
+      <div class="quote-author">
+          <p><strong>Harald Lohre</strong></p>
+          <p>Executive Director at Robeco</p>
+          <p>Honorary Researcher at Lancaster University Management School</p>
+      </div>
+    </div>
+
+    <div class="swiper-slide">
+      <div class="quote-image">
+        <img src="assets/img/quotes/albert_j_menkveld.jpeg" alt="A portrait of Albert J. Menkveld">
+      </div>
+      <p><i>From our crowd-sourced paper on non-standard errors, I learned how important clean coding is. Tidy Finance is a rich resource for empirical finance researchers, offering clean coding techniques that benefit both beginners and experts.</i></p>
+      <div class="quote-author">
+          <p><strong>Albert J. Menkveld</strong></p>
+          <p>Professor of Finance at Vrije Universiteit Amsterdam</p>
+          <p>Fellow at Tinbergen Institute</p>
+      </div>
+    </div>
+
+    <div class="swiper-slide">
+      <div class="quote-image">
+        <img src="assets/img/quotes/nikolaus_hautsch.jpeg" alt="A portrait of Nikolaus Hautsch">
+      </div>
+      <p><i>A fantastic book bringing together financial theory, sound econometrics, thorough data processing and powerful programming techniques. An absolute must for every student and scholar in empirical finance.</i></p>
+      <div class="quote-author">
+          <p><strong>Nikolaus Hautsch</strong></p>
+          <p>Professor of Finance &amp; Statistics at University of Vienna</p>
+      </div>
+    </div>
+
+    <div class="swiper-slide">
+      <div class="quote-image">
+        <img src="assets/img/quotes/bjoern_hagstroemer.jpeg" alt="A portrait of Björn Hagströmer">
+      </div>
+      <p><i>Tidy Finance is a fantastic resource that lowers the threshold for entry into empirical finance, all in the spirit of open and reproducible science.</i></p>
+      <div class="quote-author">
+          <p><strong>Björn Hagströmer</strong></p>
+          <p>Professor of Finance at Stockholm Business School</p>
+      </div>
+    </div>
+
+    <div class="swiper-slide">
+      <div class="quote-image">
+        <img src="assets/img/quotes/raman_uppal.jpeg" alt="A portrait of Raman Uppal">
+      </div>
+      <p><i>To have a deep understanding of empirical asset pricing, one needs to write code using actual data. To learn how to do this, there is no better starting point than Tidy Finance. [...] I strongly recommend Tidy Finance to both beginners and experts.</i></p>
+      <div class="quote-author">
+          <p><strong>Raman Uppal</strong></p>
+          <p>Professor of Finance at EDHEC Business School</p>
+      </div>
+    </div>
+
+    <div class="swiper-slide">
+      <div class="quote-image">
+        <img src="assets/img/quotes/mark_salmon.jpeg" alt="A portrait of Mark Salmon">
+      </div>
+      <p><i>Students and professionals alike are led step by step until they suddenly find themselves coding on their own. A brilliant and required resource!</i></p>
+      <div class="quote-author">
+          <p><strong>Mark Salmon</strong></p>
+          <p>Professor of Economics at University of Cambridge</p>
+      </div>
+    </div>
+
+  </div>
+
+  <!-- Pagination buttons -->
+  <div class="swiper-button-prev"></div>
+  <div class="swiper-button-next"></div>
+
+</div>
+</div>
+<!-- ============================ TEAM ============================ -->
+<div class="tf-section">
+<div class="tf-section__head">
+<p><span class="tf-eyebrow">The team</span></p>
+<h2 id="who-maintains-tidy-finance">Who maintains Tidy Finance</h2>
+</div>
+<div class="team-grid">
+  <div class="team-member" onclick="openInNewTab('https://www.linkedin.com/in/christophscheuch/');">
+    <img src="assets/img/christoph_scheuch.jpeg" alt="A portrait of Christoph Scheuch">
+    <h3>Christoph Scheuch</h3>
+    <p>Independent Expert in Finance &amp; Data</p>
+    <span class="team-member-cta">LinkedIn →</span>
+  </div>
+  <div class="team-member" onclick="openInNewTab('https://www.voigtstefan.me/');">
+    <img src="assets/img/stefan_voigt.jpeg" alt="A portrait of Stefan Voigt">
+    <h3>Stefan Voigt</h3>
+    <p>Assistant Professor of Finance at University of Copenhagen</p>
+    <span class="team-member-cta">Website →</span>
+  </div>
+  <div class="team-member" onclick="openInNewTab('https://sites.google.com/view/patrick-weiss');">
+    <img src="assets/img/patrick_weiss.jpeg" alt="A portrait of Patrick Weiss">
+    <h3>Patrick Weiss</h3>
+    <p>Assistant Professor of Finance at Reykjavik University </p>
+    <span class="team-member-cta">Website →</span>
+  </div>
+  <div class="team-member" onclick="openInNewTab('https://sites.google.com/site/christophfrey/');">
+    <img src="assets/img/christoph_frey.jpeg" alt="A portrait of Christoph Frey">
+    <h3>Christoph Frey</h3>
+    <p>Quantitative Researcher</p>
+    <span class="team-member-cta">Website →</span>
+  </div>
+</div>
+
+<script>
+function openInNewTab(url) {
+  window.open(url, '_blank').focus();
+}
+</script>
+</div>
+</div>
+
+
+
+
+<div class="custom-footer">
+
+  <div class="copyright">© Christoph Frey, Christoph Scheuch, Stefan Voigt &amp; Patrick Weiss</div>
+
+  <a href="disclaimer.html">Disclaimer</a>
+
+  <a href="#" id="open_preferences_center">Cookie Preferences</a>
+
+</div>
+
+<div id="presale-banner" hidden="">
+
+  <div class="presale-banner__inner">
+
+    <span class="presale-banner__text">
+
+      🎓 <strong>Applications open: Summer School "Foundations for Reproducible Research" — closes June 22.</strong>
+
+      <a href="https://bse.eu/summer-school/data-science-finance/tidy-finance-reproducible-research-in-data-science" target="_blank" rel="noopener">Apply now →</a>
+
+    </span>
+
+    <button type="button" id="presale-banner-close" class="presale-banner__close" aria-label="Dismiss banner">×</button>
+
+  </div>
+
+</div>
+
+
+
+<style>
+
+  #presale-banner {
+
+    background: #E1AF00;
+
+    color: #fff;
+
+    border-bottom: 1px solid rgba(255,255,255,0.1);
+
+    font-size: 0.95rem;
+
+  }
+
+  #presale-banner[hidden] { display: none; }
+
+  .presale-banner__inner {
+
+    max-width: 1200px;
+
+    margin: 0 auto;
+
+    padding: 0.6rem 3rem 0.6rem 1rem;
+
+    display: flex;
+
+    align-items: center;
+
+    justify-content: center;
+
+    gap: 1rem;
+
+    position: relative;
+
+    text-align: center;
+
+  }
+
+  .presale-banner__text a {
+
+    color: black;
+
+    text-decoration: none;
+
+    font-weight: 600;
+
+    margin-left: 0.25rem;
+
+  }
+
+  .presale-banner__text a:hover { color: #3B9AB2; }
+
+  .presale-banner__close {
+
+    position: absolute;
+
+    right: 0.75rem;
+
+    top: 50%;
+
+    transform: translateY(-50%);
+
+    background: transparent;
+
+    border: 0;
+
+    color: #fff;
+
+    font-size: 1.4rem;
+
+    line-height: 1;
+
+    cursor: pointer;
+
+    padding: 0.25rem 0.5rem;
+
+    border-radius: 4px;
+
+  }
+
+  .presale-banner__close:hover { background: rgba(255,255,255,0.15); }
+
+  @media (max-width: 600px) {
+
+    .presale-banner__inner { font-size: 0.8rem; padding: 0.5rem 2.5rem 0.5rem 0.75rem; }
+
+  }
+
+
+
+</style>
+
+
+
+<script>
+
+(function () {
+
+  var STORAGE_KEY = 'presale-banner-dismissed-2026-06-22';
+
+  var PRESALE_END = new Date('2026-06-22T23:59:59');
+
+
+
+  // Don't show if expired or previously dismissed
+
+  if (new Date() > PRESALE_END) return;
+
+  try {
+
+    if (localStorage.getItem(STORAGE_KEY) === '1') return;
+
+  } catch (e) { /* ignore */ }
+
+
+
+  function init() {
+
+    var banner = document.getElementById('presale-banner');
+
+    if (!banner) return;
+
+
+
+    // Move banner to sit directly below the navbar
+
+    var navbar = document.querySelector('header.quarto-secondary-nav') 
+
+              || document.querySelector('nav.navbar')
+
+              || document.querySelector('header#quarto-header')
+
+              || document.querySelector('header');
+
+    if (navbar && navbar.parentNode) {
+
+      navbar.parentNode.insertBefore(banner, navbar.nextSibling);
+
+    }
+
+    banner.hidden = false;
+
+
+
+    document.getElementById('presale-banner-close')
+
+      .addEventListener('click', function () {
+
+        banner.hidden = true;
+
+        try { localStorage.setItem(STORAGE_KEY, '1'); } catch (e) {}
+
+      });
+
+  }
+
+
+
+  if (document.readyState === 'loading') {
+
+    document.addEventListener('DOMContentLoaded', init);
+
+  } else {
+
+    init();
+
+  }
+
+})();
+
+</script>
+<script>
+
+  const swiper = new Swiper('.swiper', {
+
+    
+
+  // Optional parameters
+
+  direction: 'horizontal',
+
+  loop: true,
+
+  autoHeight: false,
+
+  spaceBetween: 200,
+
+  centeredSlides: true,
+
+  slidesPerView: 'auto',
+
+
+
+  // If we need pagination
+
+  pagination: {
+
+    el: '.swiper-pagination',
+
+    clickable: true,
+
+  },
+
+
+
+  // Navigation arrows
+
+  navigation: {
+
+    nextEl: '.swiper-button-next',
+
+    prevEl: '.swiper-button-prev',
+
+  },
+
+
+
+  // Automatically show next item
+
+  autoplay: {
+
+    delay: 7500,
+
+    disableOnInteraction: false,
+
+  },
+
+});
+
+</script>
+
+
+
+<script>
+
+  document.addEventListener("DOMContentLoaded", function() {
+
+    shuffleSwiperSlides();
+
+  });
+
+
+
+  function shuffleSwiperSlides() {
+
+    var swiperWrapper = document.getElementById('swiper-wrapper');
+
+    for (var i = swiperWrapper.children.length; i >= 0; i--) {
+
+      swiperWrapper.appendChild(swiperWrapper.children[Math.random() * i | 0]);
+
+    }
+
+  }
+
+</script>
+<script id="quarto-html-after-body" type="application/javascript">
+  window.document.addEventListener("DOMContentLoaded", function (event) {
+    const icon = "";
+    const anchorJS = new window.AnchorJS();
+    anchorJS.options = {
+      placement: 'right',
+      icon: icon
+    };
+    anchorJS.add('.anchored');
+    const isCodeAnnotation = (el) => {
+      for (const clz of el.classList) {
+        if (clz.startsWith('code-annotation-')) {                     
+          return true;
+        }
+      }
+      return false;
+    }
+    const onCopySuccess = function(e) {
+      // button target
+      const button = e.trigger;
+      // don't keep focus
+      button.blur();
+      // flash "checked"
+      button.classList.add('code-copy-button-checked');
+      var currentTitle = button.getAttribute("title");
+      button.setAttribute("title", "Copied!");
+      let tooltip;
+      if (window.bootstrap) {
+        button.setAttribute("data-bs-toggle", "tooltip");
+        button.setAttribute("data-bs-placement", "left");
+        button.setAttribute("data-bs-title", "Copied!");
+        tooltip = new bootstrap.Tooltip(button, 
+          { trigger: "manual", 
+            customClass: "code-copy-button-tooltip",
+            offset: [0, -8]});
+        tooltip.show();    
+      }
+      setTimeout(function() {
+        if (tooltip) {
+          tooltip.hide();
+          button.removeAttribute("data-bs-title");
+          button.removeAttribute("data-bs-toggle");
+          button.removeAttribute("data-bs-placement");
+        }
+        button.setAttribute("title", currentTitle);
+        button.classList.remove('code-copy-button-checked');
+      }, 1000);
+      // clear code selection
+      e.clearSelection();
+    }
+    const getTextToCopy = function(trigger) {
+      const outerScaffold = trigger.parentElement.cloneNode(true);
+      const codeEl = outerScaffold.querySelector('code');
+      for (const childEl of codeEl.children) {
+        if (isCodeAnnotation(childEl)) {
+          childEl.remove();
+        }
+      }
+      return codeEl.innerText;
+    }
+    const clipboard = new window.ClipboardJS('.code-copy-button:not([data-in-quarto-modal])', {
+      text: getTextToCopy
+    });
+    clipboard.on('success', onCopySuccess);
+    if (window.document.getElementById('quarto-embedded-source-code-modal')) {
+      const clipboardModal = new window.ClipboardJS('.code-copy-button[data-in-quarto-modal]', {
+        text: getTextToCopy,
+        container: window.document.getElementById('quarto-embedded-source-code-modal')
+      });
+      clipboardModal.on('success', onCopySuccess);
+    }
+      var localhostRegex = new RegExp(/^(?:http|https):\/\/localhost\:?[0-9]*\//);
+      var mailtoRegex = new RegExp(/^mailto:/);
+        var filterRegex = new RegExp("^(?:http:|https:)\/\/www\.tidy-finance\.org");
+      var isInternal = (href) => {
+          return filterRegex.test(href) || localhostRegex.test(href) || mailtoRegex.test(href);
+      }
+      // Inspect non-navigation links and adorn them if external
+     var links = window.document.querySelectorAll('a[href]:not(.nav-link):not(.navbar-brand):not(.toc-action):not(.sidebar-link):not(.sidebar-item-toggle):not(.pagination-link):not(.no-external):not([aria-hidden]):not(.dropdown-item):not(.quarto-navigation-tool):not(.about-link)');
+      for (var i=0; i<links.length; i++) {
+        const link = links[i];
+        if (!isInternal(link.href)) {
+          // undo the damage that might have been done by quarto-nav.js in the case of
+          // links that we want to consider external
+          if (link.dataset.originalHref !== undefined) {
+            link.href = link.dataset.originalHref;
+          }
+            // target, if specified
+            link.setAttribute("target", "_blank");
+            if (link.getAttribute("rel") === null) {
+              link.setAttribute("rel", "noopener");
+            }
+        }
+      }
+    function tippyHover(el, contentFn, onTriggerFn, onUntriggerFn) {
+      const config = {
+        allowHTML: true,
+        maxWidth: 500,
+        delay: 100,
+        arrow: false,
+        appendTo: function(el) {
+            return el.parentElement;
+        },
+        interactive: true,
+        interactiveBorder: 10,
+        theme: 'quarto',
+        placement: 'bottom-start',
+      };
+      if (contentFn) {
+        config.content = contentFn;
+      }
+      if (onTriggerFn) {
+        config.onTrigger = onTriggerFn;
+      }
+      if (onUntriggerFn) {
+        config.onUntrigger = onUntriggerFn;
+      }
+      window.tippy(el, config); 
+    }
+    const noterefs = window.document.querySelectorAll('a[role="doc-noteref"]');
+    for (var i=0; i<noterefs.length; i++) {
+      const ref = noterefs[i];
+      tippyHover(ref, function() {
+        // use id or data attribute instead here
+        let href = ref.getAttribute('data-footnote-href') || ref.getAttribute('href');
+        try { href = new URL(href).hash; } catch {}
+        const id = href.replace(/^#\/?/, "");
+        const note = window.document.getElementById(id);
+        if (note) {
+          return note.innerHTML;
+        } else {
+          return "";
+        }
+      });
+    }
+    const xrefs = window.document.querySelectorAll('a.quarto-xref');
+    const processXRef = (id, note) => {
+      // Strip column container classes
+      const stripColumnClz = (el) => {
+        el.classList.remove("page-full", "page-columns");
+        if (el.children) {
+          for (const child of el.children) {
+            stripColumnClz(child);
+          }
+        }
+      }
+      stripColumnClz(note)
+      if (id === null || id.startsWith('sec-')) {
+        // Special case sections, only their first couple elements
+        const container = document.createElement("div");
+        if (note.children && note.children.length > 2) {
+          container.appendChild(note.children[0].cloneNode(true));
+          for (let i = 1; i < note.children.length; i++) {
+            const child = note.children[i];
+            if (child.tagName === "P" && child.innerText === "") {
+              continue;
+            } else {
+              container.appendChild(child.cloneNode(true));
+              break;
+            }
+          }
+          if (window.Quarto?.typesetMath) {
+            window.Quarto.typesetMath(container);
+          }
+          return container.innerHTML
+        } else {
+          if (window.Quarto?.typesetMath) {
+            window.Quarto.typesetMath(note);
+          }
+          return note.innerHTML;
+        }
+      } else {
+        // Remove any anchor links if they are present
+        const anchorLink = note.querySelector('a.anchorjs-link');
+        if (anchorLink) {
+          anchorLink.remove();
+        }
+        if (window.Quarto?.typesetMath) {
+          window.Quarto.typesetMath(note);
+        }
+        if (note.classList.contains("callout")) {
+          return note.outerHTML;
+        } else {
+          return note.innerHTML;
+        }
+      }
+    }
+    for (var i=0; i<xrefs.length; i++) {
+      const xref = xrefs[i];
+      tippyHover(xref, undefined, function(instance) {
+        instance.disable();
+        let url = xref.getAttribute('href');
+        let hash = undefined; 
+        if (url.startsWith('#')) {
+          hash = url;
+        } else {
+          try { hash = new URL(url).hash; } catch {}
+        }
+        if (hash) {
+          const id = hash.replace(/^#\/?/, "");
+          const note = window.document.getElementById(id);
+          if (note !== null) {
+            try {
+              const html = processXRef(id, note.cloneNode(true));
+              instance.setContent(html);
+            } finally {
+              instance.enable();
+              instance.show();
+            }
+          } else {
+            // See if we can fetch this
+            fetch(url.split('#')[0])
+            .then(res => res.text())
+            .then(html => {
+              const parser = new DOMParser();
+              const htmlDoc = parser.parseFromString(html, "text/html");
+              const note = htmlDoc.getElementById(id);
+              if (note !== null) {
+                const html = processXRef(id, note);
+                instance.setContent(html);
+              } 
+            }).finally(() => {
+              instance.enable();
+              instance.show();
+            });
+          }
+        } else {
+          // See if we can fetch a full url (with no hash to target)
+          // This is a special case and we should probably do some content thinning / targeting
+          fetch(url)
+          .then(res => res.text())
+          .then(html => {
+            const parser = new DOMParser();
+            const htmlDoc = parser.parseFromString(html, "text/html");
+            const note = htmlDoc.querySelector('main.content');
+            if (note !== null) {
+              // This should only happen for chapter cross references
+              // (since there is no id in the URL)
+              // remove the first header
+              if (note.children.length > 0 && note.children[0].tagName === "HEADER") {
+                note.children[0].remove();
+              }
+              const html = processXRef(null, note);
+              instance.setContent(html);
+            } 
+          }).finally(() => {
+            instance.enable();
+            instance.show();
+          });
+        }
+      }, function(instance) {
+      });
+    }
+        let selectedAnnoteEl;
+        const selectorForAnnotation = ( cell, annotation) => {
+          let cellAttr = 'data-code-cell="' + cell + '"';
+          let lineAttr = 'data-code-annotation="' +  annotation + '"';
+          const selector = 'span[' + cellAttr + '][' + lineAttr + ']';
+          return selector;
+        }
+        const selectCodeLines = (annoteEl) => {
+          const doc = window.document;
+          const targetCell = annoteEl.getAttribute("data-target-cell");
+          const targetAnnotation = annoteEl.getAttribute("data-target-annotation");
+          const annoteSpan = window.document.querySelector(selectorForAnnotation(targetCell, targetAnnotation));
+          const lines = annoteSpan.getAttribute("data-code-lines").split(",");
+          const lineIds = lines.map((line) => {
+            return targetCell + "-" + line;
+          })
+          let top = null;
+          let height = null;
+          let parent = null;
+          if (lineIds.length > 0) {
+              //compute the position of the single el (top and bottom and make a div)
+              const el = window.document.getElementById(lineIds[0]);
+              top = el.offsetTop;
+              height = el.offsetHeight;
+              parent = el.parentElement.parentElement;
+            if (lineIds.length > 1) {
+              const lastEl = window.document.getElementById(lineIds[lineIds.length - 1]);
+              const bottom = lastEl.offsetTop + lastEl.offsetHeight;
+              height = bottom - top;
+            }
+            if (top !== null && height !== null && parent !== null) {
+              // cook up a div (if necessary) and position it 
+              let div = window.document.getElementById("code-annotation-line-highlight");
+              if (div === null) {
+                div = window.document.createElement("div");
+                div.setAttribute("id", "code-annotation-line-highlight");
+                div.style.position = 'absolute';
+                parent.appendChild(div);
+              }
+              div.style.top = top - 2 + "px";
+              div.style.height = height + 4 + "px";
+              div.style.left = 0;
+              let gutterDiv = window.document.getElementById("code-annotation-line-highlight-gutter");
+              if (gutterDiv === null) {
+                gutterDiv = window.document.createElement("div");
+                gutterDiv.setAttribute("id", "code-annotation-line-highlight-gutter");
+                gutterDiv.style.position = 'absolute';
+                const codeCell = window.document.getElementById(targetCell);
+                const gutter = codeCell.querySelector('.code-annotation-gutter');
+                gutter.appendChild(gutterDiv);
+              }
+              gutterDiv.style.top = top - 2 + "px";
+              gutterDiv.style.height = height + 4 + "px";
+            }
+            selectedAnnoteEl = annoteEl;
+          }
+        };
+        const unselectCodeLines = () => {
+          const elementsIds = ["code-annotation-line-highlight", "code-annotation-line-highlight-gutter"];
+          elementsIds.forEach((elId) => {
+            const div = window.document.getElementById(elId);
+            if (div) {
+              div.remove();
+            }
+          });
+          selectedAnnoteEl = undefined;
+        };
+          // Handle positioning of the toggle
+      window.addEventListener(
+        "resize",
+        throttle(() => {
+          elRect = undefined;
+          if (selectedAnnoteEl) {
+            selectCodeLines(selectedAnnoteEl);
+          }
+        }, 10)
+      );
+      function throttle(fn, ms) {
+      let throttle = false;
+      let timer;
+        return (...args) => {
+          if(!throttle) { // first call gets through
+              fn.apply(this, args);
+              throttle = true;
+          } else { // all the others get throttled
+              if(timer) clearTimeout(timer); // cancel #2
+              timer = setTimeout(() => {
+                fn.apply(this, args);
+                timer = throttle = false;
+              }, ms);
+          }
+        };
+      }
+        // Attach click handler to the DT
+        const annoteDls = window.document.querySelectorAll('dt[data-target-cell]');
+        for (const annoteDlNode of annoteDls) {
+          annoteDlNode.addEventListener('click', (event) => {
+            const clickedEl = event.target;
+            if (clickedEl !== selectedAnnoteEl) {
+              unselectCodeLines();
+              const activeEl = window.document.querySelector('dt[data-target-cell].code-annotation-active');
+              if (activeEl) {
+                activeEl.classList.remove('code-annotation-active');
+              }
+              selectCodeLines(clickedEl);
+              clickedEl.classList.add('code-annotation-active');
+            } else {
+              // Unselect the line
+              unselectCodeLines();
+              clickedEl.classList.remove('code-annotation-active');
+            }
+          });
+        }
+    const findCites = (el) => {
+      const parentEl = el.parentElement;
+      if (parentEl) {
+        const cites = parentEl.dataset.cites;
+        if (cites) {
+          return {
+            el,
+            cites: cites.split(' ')
+          };
+        } else {
+          return findCites(el.parentElement)
+        }
+      } else {
+        return undefined;
+      }
+    };
+    var bibliorefs = window.document.querySelectorAll('a[role="doc-biblioref"]');
+    for (var i=0; i<bibliorefs.length; i++) {
+      const ref = bibliorefs[i];
+      const citeInfo = findCites(ref);
+      if (citeInfo) {
+        tippyHover(citeInfo.el, function() {
+          var popup = window.document.createElement('div');
+          citeInfo.cites.forEach(function(cite) {
+            var citeDiv = window.document.createElement('div');
+            citeDiv.classList.add('hanging-indent');
+            citeDiv.classList.add('csl-entry');
+            var biblioDiv = window.document.getElementById('ref-' + cite);
+            if (biblioDiv) {
+              citeDiv.innerHTML = biblioDiv.innerHTML;
+            }
+            popup.appendChild(citeDiv);
+          });
+          return popup.innerHTML;
+        });
+      }
+    }
+  });
+  </script>
+</div> <!-- /content -->
+<footer class="footer">
+  <div class="nav-footer">
+    <div class="nav-footer-left">
+      &nbsp;
+    </div>   
+    <div class="nav-footer-center">
+
+<div class="toc-actions"><ul><li><a href="https://github.com/tidy-finance/website/blob/main/index-redesign.qmd" class="toc-action"><i class="bi bi-github"></i>View source</a></li></ul></div></div>
+    <div class="nav-footer-right">
+      &nbsp;
+    </div>
+  </div>
+</footer>
+
+
+
+
+<script src="site_libs/quarto-html/zenscroll-min.js"></script>
+</body></html>

--- a/docs/index-redesign.llms.md
+++ b/docs/index-redesign.llms.md
@@ -1,0 +1,235 @@
+★ Open-source · R & Python · Reproducible
+
+# Empirical finance, reproducible in R and Python
+
+Tidy Finance takes an opinionated, fully transparent approach to empirical research in financial economics. One open-source code base now covers R and Python, side by side in every chapter.
+
+[Start here](chapters/working-with-stock-returns.llms.md) [R & Python docs](https://package.tidy-finance.org) [Data platform](https://factors.tidy-finance.org)
+
+download & plot prices
+
+## R
+
+``` r
+library(tidyfinance)
+library(ggplot2)
+
+prices <- download_data(
+  domain = "stock_prices",
+  symbols = "AAPL",
+  start_date = "2000-01-01",
+  end_date = "2024-12-31"
+)
+
+prices |>
+  ggplot(aes(date, adjusted_close)) +
+  geom_line()
+```
+
+## Python
+
+``` python
+import tidyfinance as tf
+from plotnine import ggplot, aes, geom_line
+
+prices = tf.download_data(
+  domain="stock_prices",
+  symbols="AAPL",
+  start_date="2000-01-01",
+  end_date="2024-12-31"
+)
+
+(prices
+  .pipe(ggplot, aes("date", "adjusted_close"))
+  + geom_line())
+```
+
+20+ Hands-on chapters
+
+2 Languages, one code base
+
+100% Open source & reproducible
+
+## Everything you need for reproducible finance
+
+A single, transparent code base takes you from raw data to publication-quality results, in whichever language you prefer.
+
+![](data:image/svg+xml;base64,PHN2ZyB2aWV3Ym94PSIwIDAgMjQgMjQiIGZpbGw9Im5vbmUiIHN0cm9rZT0iY3VycmVudENvbG9yIiBzdHJva2Utd2lkdGg9IjIiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCI+PHBvbHlsaW5lIHBvaW50cz0iMTYgMTggMjIgMTIgMTYgNiI+PC9wb2x5bGluZT48cG9seWxpbmUgcG9pbnRzPSI4IDYgMiAxMiA4IDE4Ij48L3BvbHlsaW5lPjwvc3ZnPg==)
+
+### One code base, two languages
+
+Every chapter ships R and Python side by side from a single source. Switch with a tab. Your choice follows you through the book.
+
+![](data:image/svg+xml;base64,PHN2ZyB2aWV3Ym94PSIwIDAgMjQgMjQiIGZpbGw9Im5vbmUiIHN0cm9rZT0iY3VycmVudENvbG9yIiBzdHJva2Utd2lkdGg9IjIiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCI+PHBvbHlsaW5lIHBvaW50cz0iMjMgNCAyMyAxMCAxNyAxMCI+PC9wb2x5bGluZT48cG9seWxpbmUgcG9pbnRzPSIxIDIwIDEgMTQgNyAxNCI+PC9wb2x5bGluZT48cGF0aCBkPSJNMy41MSA5YTkgOSAwIDAgMSAxNC44NS0zLjM2TDIzIDEwTTEgMTRsNC42NCA0LjM2QTkgOSAwIDAgMCAyMC40OSAxNSIgLz48L3N2Zz4=)
+
+### Fully transparent & reproducible
+
+Open code you can run end to end, from raw data to every figure and table, with no black boxes.
+
+![](data:image/svg+xml;base64,PHN2ZyB2aWV3Ym94PSIwIDAgMjQgMjQiIGZpbGw9Im5vbmUiIHN0cm9rZT0iY3VycmVudENvbG9yIiBzdHJva2Utd2lkdGg9IjIiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCI+PGxpbmUgeDE9IjE2LjUiIHkxPSI5LjQiIHgyPSI3LjUiIHkyPSI0LjIxIj48L2xpbmU+PHBhdGggZD0iTTIxIDE2VjhhMiAyIDAgMCAwLTEtMS43M2wtNy00YTIgMiAwIDAgMC0yIDBsLTcgNEEyIDIgMCAwIDAgMyA4djhhMiAyIDAgMCAwIDEgMS43M2w3IDRhMiAyIDAgMCAwIDIgMGw3LTRBMiAyIDAgMCAwIDIxIDE2eiIgLz48cG9seWxpbmUgcG9pbnRzPSIzLjI3IDYuOTYgMTIgMTIuMDEgMjAuNzMgNi45NiI+PC9wb2x5bGluZT48bGluZSB4MT0iMTIiIHkxPSIyMi4wOCIgeDI9IjEyIiB5Mj0iMTIiPjwvbGluZT48L3N2Zz4=)
+
+### Powered by `tidyfinance`
+
+A companion package for R and Python that wraps data downloads and the routines we use throughout the book.
+
+![](data:image/svg+xml;base64,PHN2ZyB2aWV3Ym94PSIwIDAgMjQgMjQiIGZpbGw9Im5vbmUiIHN0cm9rZT0iY3VycmVudENvbG9yIiBzdHJva2Utd2lkdGg9IjIiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCI+PGVsbGlwc2UgY3g9IjEyIiBjeT0iNSIgcng9IjkiIHJ5PSIzIj48L2VsbGlwc2U+PHBhdGggZD0iTTIxIDEyYzAgMS42Ni00IDMtOSAzcy05LTEuMzQtOS0zIiAvPjxwYXRoIGQ9Ik0zIDV2MTRjMCAxLjY2IDQgMyA5IDNzOS0xLjM0IDktM1Y1IiAvPjwvc3ZnPg==)
+
+### Real financial data
+
+Work with the data professionals use, like CRSP, Compustat, and TRACE, through clean, documented access patterns.
+
+![](data:image/svg+xml;base64,PHN2ZyB2aWV3Ym94PSIwIDAgMjQgMjQiIGZpbGw9Im5vbmUiIHN0cm9rZT0iY3VycmVudENvbG9yIiBzdHJva2Utd2lkdGg9IjIiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCI+PHBvbHlsaW5lIHBvaW50cz0iMjMgNiAxMy41IDE1LjUgOC41IDEwLjUgMSAxOCI+PC9wb2x5bGluZT48cG9seWxpbmUgcG9pbnRzPSIxNyA2IDIzIDYgMjMgMTIiPjwvcG9seWxpbmU+PC9zdmc+)
+
+### From sorts to machine learning
+
+Portfolio sorts, factor models, fixed effects, causal inference, and modern ML give you the full empirical toolkit.
+
+![](data:image/svg+xml;base64,PHN2ZyB2aWV3Ym94PSIwIDAgMjQgMjQiIGZpbGw9Im5vbmUiIHN0cm9rZT0iY3VycmVudENvbG9yIiBzdHJva2Utd2lkdGg9IjIiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCI+PHBhdGggZD0iTTQgMTkuNUEyLjUgMi41IDAgMCAxIDYuNSAxN0gyMCIgLz48cGF0aCBkPSJNNi41IDJIMjB2MjBINi41QTIuNSAyLjUgMCAwIDEgNCAxOS41di0xNUEyLjUgMi41IDAgMCAxIDYuNSAyeiIgLz48L3N2Zz4=)
+
+### A free, open book
+
+Read the whole book online for free, dive into the blog, or join a workshop, all in the open.
+
+## Browse the book by topic
+
+Five parts take you from your first stock return to constrained portfolio backtests.
+
+PART 01
+
+### Getting Started
+
+Stock returns, modern portfolio theory, the CAPM, and financial statement analysis.
+
+Start here →
+
+PART 02
+
+### Financial Data
+
+Access and manage WRDS, CRSP, Compustat, TRACE, and FISD with documented workflows.
+
+Explore data →
+
+PART 03
+
+### Asset Pricing
+
+Beta estimation, univariate and bivariate sorts, Fama-French factors, and Fama-MacBeth.
+
+Price assets →
+
+PART 04
+
+### Modeling & Machine Learning
+
+Fixed effects, difference-in-differences, factor selection, and option pricing via ML.
+
+Model it →
+
+PART 05
+
+### Portfolio Optimization
+
+Parametric portfolio policies and constrained optimization with realistic backtesting.
+
+Optimize →
+
+Praise
+
+## What experts say about Tidy Finance
+
+![A portrait of Harald Lohre](assets/img/quotes/harald_lohre.jpg)
+
+*A clean coding environment is a prerequisite for building a relevant investment platform and conducting meaningful factor research. Tidy Finance is the name of the game, giving aspiring academics and finance practitioners just what they need to perform clean and reproducible research. Highly recommended.*
+
+**Harald Lohre**
+
+Executive Director at Robeco
+
+Honorary Researcher at Lancaster University Management School
+
+![A portrait of Albert J. Menkveld](assets/img/quotes/albert_j_menkveld.jpeg)
+
+*From our crowd-sourced paper on non-standard errors, I learned how important clean coding is. Tidy Finance is a rich resource for empirical finance researchers, offering clean coding techniques that benefit both beginners and experts.*
+
+**Albert J. Menkveld**
+
+Professor of Finance at Vrije Universiteit Amsterdam
+
+Fellow at Tinbergen Institute
+
+![A portrait of Nikolaus Hautsch](assets/img/quotes/nikolaus_hautsch.jpeg)
+
+*A fantastic book bringing together financial theory, sound econometrics, thorough data processing and powerful programming techniques. An absolute must for every student and scholar in empirical finance.*
+
+**Nikolaus Hautsch**
+
+Professor of Finance & Statistics at University of Vienna
+
+![A portrait of Björn Hagströmer](assets/img/quotes/bjoern_hagstroemer.jpeg)
+
+*Tidy Finance is a fantastic resource that lowers the threshold for entry into empirical finance, all in the spirit of open and reproducible science.*
+
+**Björn Hagströmer**
+
+Professor of Finance at Stockholm Business School
+
+![A portrait of Raman Uppal](assets/img/quotes/raman_uppal.jpeg)
+
+*To have a deep understanding of empirical asset pricing, one needs to write code using actual data. To learn how to do this, there is no better starting point than Tidy Finance. \[...\] I strongly recommend Tidy Finance to both beginners and experts.*
+
+**Raman Uppal**
+
+Professor of Finance at EDHEC Business School
+
+![A portrait of Mark Salmon](assets/img/quotes/mark_salmon.jpeg)
+
+*Students and professionals alike are led step by step until they suddenly find themselves coding on their own. A brilliant and required resource!*
+
+**Mark Salmon**
+
+Professor of Economics at University of Cambridge
+
+The team
+
+## Who maintains Tidy Finance
+
+![A portrait of Christoph Scheuch](assets/img/christoph_scheuch.jpeg)
+
+### Christoph Scheuch
+
+Independent Expert in Finance & Data
+
+LinkedIn →
+
+![A portrait of Stefan Voigt](assets/img/stefan_voigt.jpeg)
+
+### Stefan Voigt
+
+Assistant Professor of Finance at University of Copenhagen
+
+Website →
+
+![A portrait of Patrick Weiss](assets/img/patrick_weiss.jpeg)
+
+### Patrick Weiss
+
+Assistant Professor of Finance at Reykjavik University
+
+Website →
+
+![A portrait of Christoph Frey](assets/img/christoph_frey.jpeg)
+
+### Christoph Frey
+
+Quantitative Researcher
+
+Website →
+
+© Christoph Frey, Christoph Scheuch, Stefan Voigt & Patrick Weiss
+
+[Disclaimer](disclaimer.llms.md) [Cookie Preferences](#)
+
+🎓 **Applications open: Summer School "Foundations for Reproducible Research" — closes June 22.** [Apply now →](https://bse.eu/summer-school/data-science-finance/tidy-finance-reproducible-research-in-data-science)
+
+×

--- a/index-redesign.qmd
+++ b/index-redesign.qmd
@@ -1,0 +1,431 @@
+---
+pagetitle: "Tidy Finance Redesign Preview"
+page-layout: custom
+section-divs: false
+toc: false
+css:
+  - assets/css/index.css
+  - assets/css/index-redesign.css
+editor: source
+description: |
+  An opinionated approach on empirical research in financial economics.
+hide-description: true
+format:
+  html:
+    include-in-header: assets/html/swiper-header.html
+    include-after-body: assets/html/swiper-bottom.html
+metadata:
+  pagetitle: Welcome to Tidy Finance
+  description-meta: An opinionated approach on empirical research in financial economics using the programming languages R and Python.
+---
+
+::: {.tf-landing}
+
+<!-- ============================ HERO ============================ -->
+::: {.tf-hero}
+::: {.tf-hero__bg}
+:::
+::: {.tf-hero__inner}
+::: {.tf-hero__copy}
+[★ Open-source · R & Python · Reproducible]{.tf-badge}
+
+# Empirical finance, [reproducible]{.tf-grad} in R and Python
+
+[Tidy Finance takes an opinionated, fully transparent approach to empirical research in financial economics. One open-source code base now covers R and Python, side by side in every chapter.]{.tf-lead}
+
+::: {.tf-cta-row}
+[Start here](chapters/working-with-stock-returns.html){.tf-btn .tf-btn--primary}
+[R & Python docs](https://package.tidy-finance.org){.tf-btn .tf-btn--ghost}
+[Data platform](https://factors.tidy-finance.org){.tf-btn .tf-btn--ghost}
+:::
+:::
+
+::: {.tf-hero__visual}
+::: {.tf-window}
+::: {.tf-window__bar}
+```{=html}
+<span class="tf-dot tf-dot--r"></span><span class="tf-dot tf-dot--y"></span><span class="tf-dot tf-dot--g"></span><span class="tf-window__file">download &amp; plot prices</span>
+```
+:::
+
+::: {.panel-tabset group="language"}
+
+### R
+
+```r
+library(tidyfinance)
+library(ggplot2)
+
+prices <- download_data(
+  domain = "stock_prices",
+  symbols = "AAPL",
+  start_date = "2000-01-01",
+  end_date = "2024-12-31"
+)
+
+prices |>
+  ggplot(aes(date, adjusted_close)) +
+  geom_line()
+```
+
+### Python
+
+```python
+import tidyfinance as tf
+from plotnine import ggplot, aes, geom_line
+
+prices = tf.download_data(
+  domain="stock_prices",
+  symbols="AAPL",
+  start_date="2000-01-01",
+  end_date="2024-12-31"
+)
+
+(prices
+  .pipe(ggplot, aes("date", "adjusted_close"))
+  + geom_line())
+```
+
+:::
+:::
+:::
+:::
+:::
+
+<!-- ============================ STATS ============================ -->
+::: {.tf-stats}
+::: {.tf-stats__grid}
+::: {.tf-stat}
+[20+]{.tf-stat__num}
+[Hands-on chapters]{.tf-stat__label}
+:::
+::: {.tf-stat}
+[2]{.tf-stat__num}
+[Languages, one code base]{.tf-stat__label}
+:::
+::: {.tf-stat}
+[100%]{.tf-stat__num}
+[Open source & reproducible]{.tf-stat__label}
+:::
+:::
+:::
+
+```{=html}
+<script>
+(function () {
+  function animate(el) {
+    var raw = el.getAttribute('data-target');
+    var m = raw.match(/^(\D*)(\d+(?:\.\d+)?)(\D*)$/);
+    if (!m) { el.textContent = raw; return; }
+    var prefix = m[1], target = parseFloat(m[2]), suffix = m[3];
+    var decimals = (m[2].split('.')[1] || '').length;
+    var dur = 1300, start = null, finished = false;
+    function ease(t) { return 1 - Math.pow(1 - t, 3); }
+    function finish() {
+      if (finished) return;
+      finished = true;
+      el.textContent = prefix + target.toFixed(decimals) + suffix;
+    }
+    function step(ts) {
+      if (finished) return;
+      if (start === null) start = ts;
+      var p = Math.min((ts - start) / dur, 1);
+      el.textContent = prefix + (ease(p) * target).toFixed(decimals) + suffix;
+      if (p < 1) { requestAnimationFrame(step); } else { finish(); }
+    }
+    // Safety net: if rAF is throttled/paused, still land on the final value.
+    setTimeout(finish, dur + 800);
+    requestAnimationFrame(step);
+  }
+
+  function init() {
+    var nums = document.querySelectorAll('.tf-stat__num');
+    if (!nums.length) return;
+    nums.forEach(function (el) { el.setAttribute('data-target', el.textContent.trim()); });
+
+    var reduce = window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    if (reduce || !('IntersectionObserver' in window)) return; // leave final values in place
+
+    nums.forEach(function (el) { el.textContent = el.textContent.replace(/\d+(\.\d+)?/, '0'); });
+
+    var band = document.querySelector('.tf-stats');
+    var fired = false;
+    function trigger() {
+      if (fired) return;
+      fired = true;
+      if (io) { io.disconnect(); }
+      nums.forEach(animate);
+    }
+
+    var io = new IntersectionObserver(function (entries) {
+      entries.forEach(function (e) { if (e.isIntersecting) { trigger(); } });
+    }, { threshold: 0.4 });
+    if (band) { io.observe(band); }
+
+    // Fallback if IntersectionObserver does not deliver: animate once the band is on screen.
+    setTimeout(function () {
+      if (fired) { return; }
+      var r = (band || document.body).getBoundingClientRect();
+      if (r.top < window.innerHeight && r.bottom > 0) { trigger(); }
+    }, 1200);
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();
+</script>
+```
+
+<!-- ============================ FEATURES ============================ -->
+::: {.tf-section}
+::: {.tf-section__head}
+## Everything you need for reproducible finance
+
+A single, transparent code base takes you from raw data to publication-quality results, in whichever language you prefer.
+:::
+
+::: {.tf-features}
+
+::: {.tf-feature}
+```{=html}
+<div class="tf-feature__icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/></svg></div>
+```
+### One code base, two languages
+
+Every chapter ships R and Python side by side from a single source. Switch with a tab. Your choice follows you through the book.
+:::
+
+::: {.tf-feature}
+```{=html}
+<div class="tf-feature__icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="23 4 23 10 17 10"/><polyline points="1 20 1 14 7 14"/><path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15"/></svg></div>
+```
+### Fully transparent & reproducible
+
+Open code you can run end to end, from raw data to every figure and table, with no black boxes.
+:::
+
+::: {.tf-feature}
+```{=html}
+<div class="tf-feature__icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="16.5" y1="9.4" x2="7.5" y2="4.21"/><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"/><polyline points="3.27 6.96 12 12.01 20.73 6.96"/><line x1="12" y1="22.08" x2="12" y2="12"/></svg></div>
+```
+### Powered by `tidyfinance`
+
+A companion package for R and Python that wraps data downloads and the routines we use throughout the book.
+:::
+
+::: {.tf-feature}
+```{=html}
+<div class="tf-feature__icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><ellipse cx="12" cy="5" rx="9" ry="3"/><path d="M21 12c0 1.66-4 3-9 3s-9-1.34-9-3"/><path d="M3 5v14c0 1.66 4 3 9 3s9-1.34 9-3V5"/></svg></div>
+```
+### Real financial data
+
+Work with the data professionals use, like CRSP, Compustat, and TRACE, through clean, documented access patterns.
+:::
+
+::: {.tf-feature}
+```{=html}
+<div class="tf-feature__icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="23 6 13.5 15.5 8.5 10.5 1 18"/><polyline points="17 6 23 6 23 12"/></svg></div>
+```
+### From sorts to machine learning
+
+Portfolio sorts, factor models, fixed effects, causal inference, and modern ML give you the full empirical toolkit.
+:::
+
+::: {.tf-feature}
+```{=html}
+<div class="tf-feature__icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/></svg></div>
+```
+### A free, open book
+
+Read the whole book online for free, dive into the blog, or join a workshop, all in the open.
+:::
+
+:::
+:::
+
+<!-- ============================ CURRICULUM ============================ -->
+::: {.tf-section .tf-section--quiet}
+::: {.tf-section__head}
+## Browse the book by topic
+
+Five parts take you from your first stock return to constrained portfolio backtests.
+:::
+
+```{=html}
+<div class="tf-tracks">
+  <a class="tf-track" href="chapters/working-with-stock-returns.html">
+    <div class="tf-track__no">PART 01</div>
+    <h3>Getting Started</h3>
+    <p>Stock returns, modern portfolio theory, the CAPM, and financial statement analysis.</p>
+    <div class="tf-track__cta">Start here →</div>
+  </a>
+  <a class="tf-track" href="chapters/accessing-and-managing-financial-data.html">
+    <div class="tf-track__no">PART 02</div>
+    <h3>Financial Data</h3>
+    <p>Access and manage WRDS, CRSP, Compustat, TRACE, and FISD with documented workflows.</p>
+    <div class="tf-track__cta">Explore data →</div>
+  </a>
+  <a class="tf-track" href="chapters/beta-estimation.html">
+    <div class="tf-track__no">PART 03</div>
+    <h3>Asset Pricing</h3>
+    <p>Beta estimation, univariate and bivariate sorts, Fama-French factors, and Fama-MacBeth.</p>
+    <div class="tf-track__cta">Price assets →</div>
+  </a>
+  <a class="tf-track" href="chapters/fixed-effects-and-clustered-standard-errors.html">
+    <div class="tf-track__no">PART 04</div>
+    <h3>Modeling &amp; Machine Learning</h3>
+    <p>Fixed effects, difference-in-differences, factor selection, and option pricing via ML.</p>
+    <div class="tf-track__cta">Model it →</div>
+  </a>
+  <a class="tf-track" href="chapters/parametric-portfolio-policies.html">
+    <div class="tf-track__no">PART 05</div>
+    <h3>Portfolio Optimization</h3>
+    <p>Parametric portfolio policies and constrained optimization with realistic backtesting.</p>
+    <div class="tf-track__cta">Optimize →</div>
+  </a>
+</div>
+```
+
+:::
+
+<!-- ============================ TESTIMONIALS ============================ -->
+::: {.tf-section}
+::: {.tf-section__head}
+[Praise]{.tf-eyebrow}
+
+## What experts say about Tidy Finance
+:::
+
+```{=html}
+<!-- Slider main container -->
+<div class="swiper">
+  <!-- Additional required wrapper -->
+  <div class="swiper-wrapper" id="swiper-wrapper">
+    <!-- Slides -->
+
+    <div class="swiper-slide">
+      <div class="quote-image">
+        <img src="assets/img/quotes/harald_lohre.jpg" alt="A portrait of Harald Lohre">
+      </div>
+      <p><i>A clean coding environment is a prerequisite for building a relevant investment platform and conducting meaningful factor research. Tidy Finance is the name of the game, giving aspiring academics and finance practitioners just what they need to perform clean and reproducible  research. Highly recommended.</i></p>
+      <div class="quote-author">
+          <p><strong>Harald Lohre</strong></p>
+          <p>Executive Director at Robeco</p>
+          <p>Honorary Researcher at Lancaster University Management School</p>
+      </div>
+    </div>
+
+    <div class="swiper-slide">
+      <div class="quote-image">
+        <img src="assets/img/quotes/albert_j_menkveld.jpeg" alt="A portrait of Albert J. Menkveld">
+      </div>
+      <p><i>From our crowd-sourced paper on non-standard errors, I learned how important clean coding is. Tidy Finance is a rich resource for empirical finance researchers, offering clean coding techniques that benefit both beginners and experts.</i></p>
+      <div class="quote-author">
+          <p><strong>Albert J. Menkveld</strong></p>
+          <p>Professor of Finance at Vrije Universiteit Amsterdam</p>
+          <p>Fellow at Tinbergen Institute</p>
+      </div>
+    </div>
+
+    <div class="swiper-slide">
+      <div class="quote-image">
+        <img src="assets/img/quotes/nikolaus_hautsch.jpeg" alt="A portrait of Nikolaus Hautsch">
+      </div>
+      <p><i>A fantastic book bringing together financial theory, sound econometrics, thorough data processing and powerful programming techniques. An absolute must for every student and scholar in empirical finance.</i></p>
+      <div class="quote-author">
+          <p><strong>Nikolaus Hautsch</strong></p>
+          <p>Professor of Finance & Statistics at University of Vienna</p>
+      </div>
+    </div>
+
+    <div class="swiper-slide">
+      <div class="quote-image">
+        <img src="assets/img/quotes/bjoern_hagstroemer.jpeg" alt="A portrait of Björn Hagströmer">
+      </div>
+      <p><i>Tidy Finance is a fantastic resource that lowers the threshold for entry into empirical finance, all in the spirit of open and reproducible science.</i></p>
+      <div class="quote-author">
+          <p><strong>Björn Hagströmer</strong></p>
+          <p>Professor of Finance at Stockholm Business School</p>
+      </div>
+    </div>
+
+    <div class="swiper-slide">
+      <div class="quote-image">
+        <img src="assets/img/quotes/raman_uppal.jpeg" alt="A portrait of Raman Uppal">
+      </div>
+      <p><i>To have a deep understanding of empirical asset pricing, one needs to write code using actual data. To learn how to do this, there is no better starting point than Tidy Finance. [...] I strongly recommend Tidy Finance to both beginners and experts.</i></p>
+      <div class="quote-author">
+          <p><strong>Raman Uppal</strong></p>
+          <p>Professor of Finance at EDHEC Business School</p>
+      </div>
+    </div>
+
+    <div class="swiper-slide">
+      <div class="quote-image">
+        <img src="assets/img/quotes/mark_salmon.jpeg" alt="A portrait of Mark Salmon">
+      </div>
+      <p><i>Students and professionals alike are led step by step until they suddenly find themselves coding on their own. A brilliant and required resource!</i></p>
+      <div class="quote-author">
+          <p><strong>Mark Salmon</strong></p>
+          <p>Professor of Economics at University of Cambridge</p>
+      </div>
+    </div>
+
+  </div>
+
+  <!-- Pagination buttons -->
+  <div class="swiper-button-prev"></div>
+  <div class="swiper-button-next"></div>
+
+</div>
+```
+:::
+
+<!-- ============================ TEAM ============================ -->
+::: {.tf-section}
+::: {.tf-section__head}
+[The team]{.tf-eyebrow}
+
+## Who maintains Tidy Finance
+:::
+
+```{=html}
+<div class="team-grid">
+  <div class="team-member" onclick="openInNewTab('https://www.linkedin.com/in/christophscheuch/');">
+    <img src="assets/img/christoph_scheuch.jpeg" alt="A portrait of Christoph Scheuch">
+    <h3>Christoph Scheuch</h3>
+    <p>Independent Expert in Finance & Data</p>
+    <span class="team-member-cta">LinkedIn &#x2192;</span>
+  </div>
+  <div class="team-member" onclick="openInNewTab('https://www.voigtstefan.me/');">
+    <img src="assets/img/stefan_voigt.jpeg" alt="A portrait of Stefan Voigt">
+    <h3>Stefan Voigt</h3>
+    <p>Assistant Professor of Finance at University of Copenhagen</p>
+    <span class="team-member-cta">Website &#x2192;</span>
+  </div>
+  <div class="team-member"  onclick="openInNewTab('https://sites.google.com/view/patrick-weiss');">
+    <img src="assets/img/patrick_weiss.jpeg" alt="A portrait of Patrick Weiss">
+    <h3>Patrick Weiss</h3>
+    <p>Assistant Professor of Finance at Reykjavik University </p>
+    <span class="team-member-cta">Website &#x2192;</span>
+  </div>
+  <div class="team-member" onclick="openInNewTab('https://sites.google.com/site/christophfrey/');">
+    <img src="assets/img/christoph_frey.jpeg" alt="A portrait of Christoph Frey">
+    <h3>Christoph Frey</h3>
+    <p>Quantitative Researcher</p>
+    <span class="team-member-cta">Website &#x2192;</span>
+  </div>
+</div>
+
+<script>
+function openInNewTab(url) {
+  window.open(url, '_blank').focus();
+}
+</script>
+```
+:::
+
+:::


### PR DESCRIPTION
## Summary

A standalone, **modern redesign of the homepage** built around the unified R + Python framework. It lives entirely in its own page and stylesheet, so production `index.qmd` and the shared `assets/css/index.css` are **untouched** until we decide to promote it.

Preview the rendered page at `docs/index-redesign.html` (or `quarto render index-redesign.qmd` and open it).

## Why

The current landing page still tells an R-first story (a single R-hexagon "Get Started" button, copy that mentions "multiple languages" without showing them). Now that the book is one unified source with R/Python tabsets, the homepage should make that the headline. This sandbox does exactly that, and modernizes the visual system.

## What's in it

- **Hero** — two-column layout with a soft gradient-mesh band, a Zissou1 `teal → gold` headline accent, and an editor-style **code window with a live R/Python tabset** showing the same download-and-plot in both languages (the Python plot chains `prices.pipe(ggplot, …)` to mirror the tidyverse pipe line-for-line).
- **Hero CTAs** — `Start here` (first chapter, solid teal matching the site navbar), `R & Python docs` (package.tidy-finance.org), `Data platform` (factors.tidy-finance.org).
- **Stats band** — counts up from zero on scroll into view (`20+` chapters, `2` languages, `100%` open source); reduced-motion-safe with a timer fallback so it never sticks at zero.
- **Features** — six cards with inline SVG icons.
- **"Browse the book by topic"** — a deliberately quieter section mapping the five book parts (Part 01–05) to their first chapters.
- **Testimonials + maintainer grid** — reused from the current page.
- **Color** — pinned to the exact `wesanderson::Zissou1` ramp used across the book (`#3B9AB2`, `#78B7C5`, `#EBCC2A`, `#E1AF00`, `#F21A00`); the two darker teal *shades* are derived from ramp-1 for readable small text and hover states only.
- **Copy** — audited for active voice and no em-dashes.

## Files

| File | Purpose |
|---|---|
| `index-redesign.qmd` | The redesign page (source) |
| `assets/css/index-redesign.css` | Scoped styles (all rules under `.tf-landing`) |
| `docs/index-redesign.html`, `docs/index-redesign.llms.md` | Rendered output |

## Scope / not in this PR

- Production `index.qmd` and `assets/css/index.css` are intentionally left as-is.
- **Promotion path** (separate follow-up once approved): copy `index-redesign.qmd` → `index.qmd`, fold `index-redesign.css` into `index.css`, update internal nav/links, retire the sandbox files.

## Open options (not applied)

- A bolder, full-ramp accent (`teal → light-teal → yellow → gold → red`) on the headline/stats for a stronger tie to the book's figure palette — left out to keep the current subtle two-tone look.
- Swapping testimonials that read R-only for language-neutral versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
