### PR TITLE
Replace pyarrow with native polars in the data chapters (#254)

### DIFF
--- a/chapters/difference-in-differences.qmd
+++ b/chapters/difference-in-differences.qmd
@@ -42,7 +42,6 @@ library(broom)
 import polars as pl
 import datetime as dt
 import pyfixest as pf
-import pyarrow.dataset as ds
 
 from plotnine import *
 from scipy.stats import norm
@@ -90,10 +89,9 @@ fisd = (pl.read_parquet("data/fisd.parquet")
     .drop_nulls()
 )
 
-trace_enhanced = (pl.from_arrow(
-        ds.dataset("data/trace_enhanced")
-        .to_table(columns=["cusip_id", "trd_exctn_dt", "rptd_pr", "entrd_vol_qt", "yld_pt"])
-    )
+trace_enhanced = (pl.scan_parquet("data/trace_enhanced", hive_partitioning=True)
+    .select(["cusip_id", "trd_exctn_dt", "rptd_pr", "entrd_vol_qt", "yld_pt"])
+    .collect()
     .drop_nulls()
 )
 ```

--- a/chapters/trace-and-fisd.qmd
+++ b/chapters/trace-and-fisd.qmd
@@ -46,9 +46,6 @@ import polars as pl
 import numpy as np
 import tidyfinance as tf
 import httpimport
-import pyarrow as pa
-import pyarrow.parquet as pq
-import pyarrow.dataset as ds
 import time
 
 from datetime import date
@@ -506,14 +503,8 @@ for j in range(1, batches + 1):
         raise RuntimeError(f"Batch {j} failed after repeated connection errors.")
 
     if not trace_enhanced_sub.is_empty():
-            table = (trace_enhanced_sub.to_arrow()
-                .append_column("batch", pa.array([j] * len(trace_enhanced_sub)))
-            )
-            pq.write_to_dataset(
-                table,
-                root_path="data/trace_enhanced",
-                partition_cols=["batch"],
-                existing_data_behavior="overwrite_or_ignore"
+            trace_enhanced_sub.with_columns(batch=pl.lit(j)).write_parquet(
+                "data/trace_enhanced", partition_by="batch"
             )
 
     print(f"Batch {j} out of {batches} done ({(j/batches)*100:.2f}%)\n")
@@ -638,9 +629,9 @@ Notice that we load the complete TRACE data from our dataset, as we only have a 
 
 ```{python}
 #| label: trace-and-fisd-bonds-traded-py
-trace_enhanced = pl.from_arrow(
-    ds.dataset("data/trace_enhanced", format="parquet").to_table()
-)
+trace_enhanced = pl.read_parquet(
+    "data/trace_enhanced", hive_partitioning=True
+).drop("batch")
 
 bonds_traded = (trace_enhanced
     .with_columns(

--- a/chapters/wrds-crsp-and-compustat.qmd
+++ b/chapters/wrds-crsp-and-compustat.qmd
@@ -42,7 +42,6 @@ The last two packages are used for plotting.
 import polars as pl
 import numpy as np
 import tidyfinance as tf
-import pyarrow.parquet as pq
 
 from plotnine import *
 from mizani.formatters import comma_format, percent_format
@@ -921,7 +920,7 @@ for (j in 1:batches) {
 
 ### Python
 
-To keep track of the progress, we create ad-hoc progress updates using `print()`. Notice that we also use the method `pq.write_to_dataset()` here with the option to append the new data to an existing partitioned dataset, when we process the second and all following batches.
+To keep track of the progress, we create ad-hoc progress updates using `print()`. We write each batch to disk with polars' `write_parquet()` and `partition_by="permno"`, which stores the data in one subfolder per `permno`. Since each `permno` is processed in exactly one batch, consecutive batches extend the dataset without clobbering earlier files, and re-running the loop overwrites each partition cleanly instead of appending duplicates.
 
 ```{python}
 #| label: wrds-crsp-and-compustat-download-crsp-daily-py
@@ -986,13 +985,7 @@ for j in range(1, batches + 1):
             .select(["batch", "permno", "date", "ret_excess"])
         )
 
-        table = crsp_daily_sub.to_arrow()
-        pq.write_to_dataset(
-            table,
-            root_path="data/crsp_daily",
-            partition_cols=["permno"],
-            existing_data_behavior="overwrite_or_ignore",
-        )
+        crsp_daily_sub.write_parquet("data/crsp_daily", partition_by="permno")
 
     print(f"Batch {j} out of {batches} done ({(j / batches) * 100:.2f}%)\n")
 ```


### PR DESCRIPTION
## Summary

Implements the Python-side of #254: removes all explicit `pyarrow` usage from the three data chapters in favour of native polars — `write_parquet(partition_by=…)` for partitioned writes and `read_parquet`/`scan_parquet(hive_partitioning=True)` for partitioned reads.

## What changed

| Chapter | Change |
|---|---|
| `wrds-crsp-and-compustat.qmd` | write → `crsp_daily_sub.write_parquet("data/crsp_daily", partition_by="permno")`; dropped `import pyarrow.parquet`; updated the surrounding prose |
| `trace-and-fisd.qmd` | write → `…with_columns(batch=pl.lit(j)).write_parquet("data/trace_enhanced", partition_by="batch")`; read → `pl.read_parquet(…, hive_partitioning=True).drop("batch")`; dropped all three pyarrow imports |
| `difference-in-differences.qmd` | read → `pl.scan_parquet(…, hive_partitioning=True).select([...]).collect()`; dropped `import pyarrow.dataset` |

`beta-estimation` already used `scan_parquet`, so it needed no change.

## Why

- Simpler code — no `to_arrow()` boundary, no `pq.write_to_dataset` / `ds.dataset`.
- **Removes the `overwrite_or_ignore` re-render duplication footgun.** polars writes deterministic partition filenames (`00000000.parquet`), so re-running a download loop overwrites each partition cleanly instead of appending duplicate rows. (pyarrow used GUID filenames → a second render appended → duplicates, i.e. the "delete the folder before re-rendering" gotcha.)

## Verification

- **Old-vs-new on the real local `data/` files**: `bonds_traded`, `average_trade_size`, the projected DiD read, and a `crsp_daily` write round-trip are all **bit-identical**.
- **Re-render duplication**: pyarrow doubled row counts on a second loop; polars stayed put.
- **Local render of `difference-in-differences`** (WRDS-free) on the new read path: clean, all 51 R+Python chunks executed, figures + regressions produced.
- The two WRDS chapters (`wrds-crsp-and-compustat`, `trace-and-fisd`) need a live connection, so they go through the normal full-render pipeline rather than a local render.

## Scope / non-goals

This **does not** remove Arrow C++ from the environment, by design:

- `pyarrow` stays as a transitive dependency of `tidyfinance` (imported as `tf` in every Python data chapter), so the Arrow C++ binary remains installed.
- R-side `arrow` is untouched (`renv.lock`, `wrds-dummy-data.qmd`, the blog posts, and the `eval: false` `arrow::write_dataset` partitioned writes; `nanoparquet` has no partitioned writer).

Both are documented in #254 and left out of scope per the discussion there.

## Notes

- Reads remain **backward compatible** with existing pyarrow-written `data/` folders (no re-download needed).
- Non-blocking heads-up: polars 1.37.1 misreads pyarrow-written `time32[ms]` (`trd_exctn_tm`), collapsing distinct values. The book never uses that column and the previous `pl.from_arrow` path behaved identically, so rendered output is unaffected; polars round-trips its own writes correctly.

Refs #254
