### PR TITLE
Replace statsmodels with pyfixest in Python chapters

### DIFF
--- a/blog/fast-beta-estimation/index.qmd
+++ b/blog/fast-beta-estimation/index.qmd
@@ -270,7 +270,7 @@ cat(sprintf(
 The estimates are numerically identical to the regression-based approach of the chapter — closed-form OLS is still OLS. We verify this claim for one stock and window: the latest five-year window of Apple's returns, estimated via the standard regression routine.
 
 ```{python}
-import statsmodels.formula.api as smf
+import pyfixest as pf
 
 apple_window = (crsp_monthly
     .filter(pl.col("permno") == 14593)
@@ -278,7 +278,7 @@ apple_window = (crsp_monthly
     .tail(60)
 )
 
-fit = smf.ols("ret_excess ~ mkt_excess", data=apple_window.to_pandas()).fit()
+fit = pf.feols("ret_excess ~ mkt_excess", data=apple_window)
 
 apple_vectorized = (capm_monthly
     .filter(
@@ -288,10 +288,10 @@ apple_vectorized = (capm_monthly
     )
 )
 
-print(f"statsmodels beta: {fit.params['mkt_excess']:.12f}")
-print(f"vectorized beta:  {apple_vectorized['estimate'][0]:.12f}")
-print(f"statsmodels t:    {fit.tvalues['mkt_excess']:.12f}")
-print(f"vectorized t:     {apple_vectorized['t_statistic'][0]:.12f}")
+print(f"pyfixest beta:   {fit.coef()['mkt_excess']:.12f}")
+print(f"vectorized beta: {apple_vectorized['estimate'][0]:.12f}")
+print(f"pyfixest t:      {fit.tstat()['mkt_excess']:.12f}")
+print(f"vectorized t:    {apple_vectorized['t_statistic'][0]:.12f}")
 ```
 
 ## Daily Betas Without Batching

--- a/chapters/beta-estimation.qmd
+++ b/chapters/beta-estimation.qmd
@@ -40,7 +40,7 @@ Compared to previous chapters, we introduce `slider` [@slider] for sliding windo
 #| label: beta-estimation-packages-py
 import polars as pl
 import numpy as np
-import statsmodels.formula.api as smf
+import pyfixest as pf
 import os
 
 from plotnine import *
@@ -50,7 +50,7 @@ from itertools import product
 from dateutil.relativedelta import relativedelta
 ```
 
-Compared to previous chapters, we introduce `statsmodels` [@seabold2010statsmodels] for regression analysis and for sliding-window regressions and `joblib` [@joblib] for parallelization.\index{Parallelization}
+Compared to previous chapters, we introduce `pyfixest` [@pyfixest] for regression analysis and for sliding-window regressions and `joblib` [@joblib] for parallelization.\index{Parallelization}
 
 :::
 
@@ -126,19 +126,19 @@ coefficients
 
 ### Python
 
-Python provides a simple solution to estimate (linear) models with the function `smf.ols()`. The function requires a formula as input that is specified in a compact symbolic form. An expression of the form `y ~ model` is interpreted as a specification that the response `y` is modeled by a linear predictor specified symbolically by `model`. Such a model consists of a series of terms separated by `+` operators. In addition to standard linear models, `smf.ols()` provides a lot of flexibility. You should check out the documentation for more information. To start, we restrict the data only to the time series of observations in CRSP that correspond to Apple’s stock (i.e., to `permno` 14593 for Apple) and compute $\hat\alpha_i$ as well as $\hat\beta_i$.\index{Linear regression}
+Python provides a simple solution to estimate (linear) models with the function `pf.feols()`. The function requires a formula as input that is specified in a compact symbolic form. An expression of the form `y ~ model` is interpreted as a specification that the response `y` is modeled by a linear predictor specified symbolically by `model`. Such a model consists of a series of terms separated by `+` operators. In addition to standard linear models, `pf.feols()` provides a lot of flexibility. You should check out the documentation for more information. To start, we restrict the data only to the time series of observations in CRSP that correspond to Apple’s stock (i.e., to `permno` 14593 for Apple) and compute $\hat\alpha_i$ as well as $\hat\beta_i$.\index{Linear regression}
 
 ```{python}
 #| label: beta-estimation-capm-apple-py
-model_fit = smf.ols(
-    formula="ret_excess ~ mkt_excess",
-    data=crsp_monthly.filter(pl.col("permno") == 14593).to_pandas()
-).fit()
-coefficients = model_fit.summary2().tables[1]
+model_fit = pf.feols(
+    "ret_excess ~ mkt_excess",
+    data=crsp_monthly.filter(pl.col("permno") == 14593)
+)
+coefficients = model_fit.tidy()
 coefficients
 ```
 
-`smf.ols()` returns an object of class `RegressionModel`, which contains all the information we usually care about with linear models. `summary2()` returns information about the estimated parameters. The output above indicates that Apple moves excessively with the market as the estimated $\hat\beta_i$ is above one ($\hat\beta_i \approx 1.4$).
+`pf.feols()` returns an object of class `Feols`, which contains all the information we usually care about with linear models. The `tidy()` method returns information about the estimated parameters. The output above indicates that Apple moves excessively with the market as the estimated $\hat\beta_i$ is above one ($\hat\beta_i \approx 1.4$).
 
 :::
 
@@ -184,16 +184,15 @@ def estimate_capm(data, min_obs=1):
     if data.shape[0] < min_obs:
         capm = pl.DataFrame()
     else:
-        fit = smf.ols(
-            formula="ret_excess ~ mkt_excess", data=data.to_pandas()
-        ).fit()
-        coefficients = fit.summary2().tables[1]
+        coefficients = pf.feols(
+            "ret_excess ~ mkt_excess", data=data
+        ).tidy()
 
         capm = pl.DataFrame(
             {
                 "coefficient": coefficients.index.tolist(),
-                "estimate": coefficients["Coef."].to_numpy(),
-                "t_statistic": coefficients["t"].to_numpy(),
+                "estimate": coefficients["Estimate"].to_numpy(),
+                "t_statistic": coefficients["t value"].to_numpy(),
             }
         ).with_columns(
             coefficient=pl.when(pl.col("coefficient") == "Intercept")

--- a/chapters/capital-asset-pricing-model.qmd
+++ b/chapters/capital-asset-pricing-model.qmd
@@ -39,7 +39,7 @@ library(ggrepel)
 import polars as pl
 import numpy as np
 import tidyfinance as tf
-import statsmodels.formula.api as smf
+import pyfixest as pf
 
 from plotnine import *
 from mizani.formatters import percent_format
@@ -549,7 +549,7 @@ returns_excess_monthly |>
 
 ### Python
 
-The `estimate_capm()` function then implements the regression equation we previously discussed. We partition the data by symbol and run these regressions for all assets, looping over the symbol-specific sub-frames. Because `statsmodels` expects a `pandas` data frame, we convert each sub-frame at the boundary with `to_pandas()`. Collecting the coefficients gives us a clean data frame of assets and their corresponding betas.
+The `estimate_capm()` function then implements the regression equation we previously discussed. We partition the data by symbol and run these regressions for all assets, looping over the symbol-specific sub-frames. Because `pyfixest` accepts `polars` data frames directly, we pass each sub-frame without any conversion. Collecting the coefficients gives us a clean data frame of assets and their corresponding betas.
 
 ```{python}
 #| label: capital-asset-pricing-model-estimate-capm-py
@@ -560,12 +560,12 @@ returns_excess_monthly = (returns_monthly
 )
 
 def estimate_capm(data):
-    model = smf.ols("ret_excess ~ mkt_excess", data=data.to_pandas()).fit()
+    model = pf.feols("ret_excess ~ mkt_excess", data=data)
     result = pl.DataFrame({
         "symbol": data["symbol"][0],
         "coefficient": ["alpha", "beta"],
-        "estimate": model.params.values,
-        "t_statistic": model.tvalues.values
+        "estimate": model.coef().values,
+        "t_statistic": model.tstat().values
     })
     return result
 

--- a/chapters/discounted-cash-flow-analysis.qmd
+++ b/chapters/discounted-cash-flow-analysis.qmd
@@ -54,7 +54,7 @@ library(fmpapi)
 #| label: discounted-cash-flow-analysis-packages-py
 import polars as pl
 import numpy as np
-import statsmodels.formula.api as smf
+import pyfixest as pf
 
 from dotenv import load_dotenv
 from fmpapi import fmp_get
@@ -463,9 +463,9 @@ dcf_data <- dcf_data |>
 
 ```{python}
 #| label: discounted-cash-flow-analysis-revenue-growth-model-py
-revenue_growth_model = smf.ols(
-  "revenue_growth ~ gdp_growth", data=dcf_data.to_pandas()
-).fit().params
+revenue_growth_model = pf.feols(
+  "revenue_growth ~ gdp_growth", data=dcf_data
+).coef()
 
 dcf_data = (dcf_data
   .with_columns(

--- a/chapters/fama-macbeth-regressions.qmd
+++ b/chapters/fama-macbeth-regressions.qmd
@@ -50,7 +50,7 @@ library(broom)
 ```{python}
 #| label: fama-macbeth-regressions-packages-py
 import polars as pl
-import statsmodels.formula.api as smf
+import pyfixest as pf
 ```
 
 :::
@@ -210,10 +210,10 @@ risk_premiums <- data_fama_macbeth |>
 ```{python}
 #| label: fama-macbeth-regressions-cross-sectional-py
 def estimate_cross_section(group):
-    params = smf.ols(
-        formula="ret_excess_lead ~ beta + log_mktcap + bm",
-        data=group.to_pandas()
-    ).fit().params
+    params = pf.feols(
+        "ret_excess_lead ~ beta + log_mktcap + bm",
+        data=group
+    ).coef()
     return pl.DataFrame(params.to_frame().transpose()).with_columns(
         date=group["date"].first()
     )
@@ -302,10 +302,11 @@ We compute the Newey-West $t$-statistics by fitting a constant-only model for ea
 ```{python}
 #| label: fama-macbeth-regressions-newey-west-py
 def estimate_newey_west(group):
-    fit = smf.ols(
-        "estimate ~ 1", group.to_pandas()
-    ).fit(cov_type="HAC", cov_kwds={"maxlags": 6})
-    t_statistic = group["estimate"].mean()/fit.bse["Intercept"]
+    fit = pf.feols(
+        "estimate ~ 1", data=group.sort("date"),
+        vcov="NW", vcov_kwargs={"lag": 6, "time_id": "date"}
+    )
+    t_statistic = group["estimate"].mean()/fit.se()["Intercept"]
     return pl.DataFrame({
         "factor": group["factor"].first(),
         "t_statistic_newey_west": t_statistic

--- a/chapters/parametric-portfolio-policies.qmd
+++ b/chapters/parametric-portfolio-policies.qmd
@@ -36,7 +36,7 @@ library(nanoparquet)
 import polars as pl
 import pandas as pd
 import numpy as np
-import statsmodels.formula.api as smf
+import pyfixest as pf
 
 from itertools import product, starmap
 from scipy.optimize import minimize
@@ -512,8 +512,8 @@ def evaluate_portfolio(weights_data,
             .to_pandas()
             .groupby("model")
             .apply(lambda x:
-              smf.ols(formula="portfolio_return ~ 1 + mkt_excess", data=x)
-              .fit().params
+              pf.feols("portfolio_return ~ 1 + mkt_excess", data=x)
+              .coef()
             )
             .rename(columns={"const": "CAPM alpha",
                              "mkt_excess": "Market beta"})

--- a/chapters/replicating-fama-and-french-factors.qmd
+++ b/chapters/replicating-fama-and-french-factors.qmd
@@ -39,9 +39,7 @@ library(nanoparquet)
 #| label: replicating-fama-and-french-factors-packages-py
 import polars as pl
 import numpy as np
-import statsmodels.formula.api as smf
-
-from regtabletotext import prettify_result
+import pyfixest as pf
 ```
 
 :::
@@ -388,7 +386,7 @@ test <- factors_ff3_monthly |>
 
 ### Python
 
-We run the regressions using `smf.ols()`.
+We run the regressions using `pf.feols()`.
 
 ```{python}
 #| label: replicating-fama-and-french-factors-test-data-ff3-py
@@ -417,16 +415,14 @@ The results for the SMB factor are really convincing, as all three criteria outl
 
 ```{python}
 #| label: replicating-fama-and-french-factors-smb-regression-ff3-py
-model_smb = (smf.ols(
-        formula="smb ~ smb_replicated",
-        data=test.to_pandas()
-    )
-    .fit()
+model_smb = pf.feols(
+    fml="smb ~ smb_replicated",
+    data=test
 )
-prettify_result(model_smb)
+model_smb.summary()
 ```
 
-The results for the SMB factor are really convincing, as all three criteria outlined above are met and the coefficient is `{python} np.round(model_smb.params["smb_replicated"], 2)` and the R-squared is at `{python} int(np.round(model_smb.rsquared_adj, 2) * 100)` percent.
+The results for the SMB factor are really convincing, as all three criteria outlined above are met and the coefficient is `{python} np.round(model_smb.coef()["smb_replicated"], 2)` and the R-squared is at `{python} int(np.round(model_smb._adj_r2, 2) * 100)` percent.
 
 :::
 
@@ -445,16 +441,14 @@ The replication of the HML factor is also a success, although at a slightly lowe
 
 ```{python}
 #| label: replicating-fama-and-french-factors-hml-regression-ff3-py
-model_hml = (smf.ols(
-        formula="hml ~ hml_replicated",
-        data=test.to_pandas()
-    )
-    .fit()
+model_hml = pf.feols(
+    fml="hml ~ hml_replicated",
+    data=test
 )
-prettify_result(model_hml)
+model_hml.summary()
 ```
 
-The replication of the HML factor is also a success, although at a slightly lower coefficient of `{python} np.round(model_hml.params["hml_replicated"], 2)` and an R-squared around `{python} int(np.round(model_hml.rsquared_adj, 2) * 100)` percent.
+The replication of the HML factor is also a success, although at a slightly lower coefficient of `{python} np.round(model_hml.coef()["hml_replicated"], 2)` and an R-squared around `{python} int(np.round(model_hml._adj_r2, 2) * 100)` percent.
 
 :::
 
@@ -812,16 +806,14 @@ The results for the SMB factor are quite convincing as all three criteria outlin
 
 ```{python}
 #| label: replicating-fama-and-french-factors-smb-regression-ff5-py
-model_smb = (smf.ols(
-        formula="smb ~ smb_replicated",
-        data=test.to_pandas()
-    )
-    .fit()
+model_smb = pf.feols(
+    fml="smb ~ smb_replicated",
+    data=test
 )
-prettify_result(model_smb)
+model_smb.summary()
 ```
 
-The results for the SMB factor are quite convincing, as all three criteria outlined above are met and the coefficient is `{python} np.round(model_smb.params["smb_replicated"], 2)` and the R-squared is at `{python} int(np.round(model_smb.rsquared_adj, 2) * 100)` percent.
+The results for the SMB factor are quite convincing, as all three criteria outlined above are met and the coefficient is `{python} np.round(model_smb.coef()["smb_replicated"], 2)` and the R-squared is at `{python} int(np.round(model_smb._adj_r2, 2) * 100)` percent.
 
 :::
 
@@ -840,16 +832,14 @@ The replication of the HML factor is also a success, although at a slightly high
 
 ```{python}
 #| label: replicating-fama-and-french-factors-hml-regression-ff5-py
-model_hml = (smf.ols(
-        formula="hml ~ hml_replicated",
-        data=test.to_pandas()
-    )
-    .fit()
+model_hml = pf.feols(
+    fml="hml ~ hml_replicated",
+    data=test
 )
-prettify_result(model_hml)
+model_hml.summary()
 ```
 
-The replication of the HML factor is also a success, although at a slightly higher coefficient of `{python} np.round(model_hml.params["hml_replicated"], 2)` and an R-squared around `{python} int(np.round(model_hml.rsquared_adj, 2) * 100)` percent.
+The replication of the HML factor is also a success, although at a slightly higher coefficient of `{python} np.round(model_hml.coef()["hml_replicated"], 2)` and an R-squared around `{python} int(np.round(model_hml._adj_r2, 2) * 100)` percent.
 
 :::
 
@@ -868,16 +858,14 @@ We are also able to replicate the RMW factor quite well with a coefficient of `r
 
 ```{python}
 #| label: replicating-fama-and-french-factors-rmw-regression-ff5-py
-model_rmw = (smf.ols(
-        formula="rmw ~ rmw_replicated",
-        data=test.to_pandas()
-    )
-    .fit()
+model_rmw = pf.feols(
+    fml="rmw ~ rmw_replicated",
+    data=test
 )
-prettify_result(model_rmw)
+model_rmw.summary()
 ```
 
-We are also able to replicate the RMW factor quite well with a coefficient of `{python} np.round(model_rmw.params["rmw_replicated"], 2)` and an R-squared around `{python} int(np.round(model_rmw.rsquared_adj, 2) * 100)` percent.
+We are also able to replicate the RMW factor quite well with a coefficient of `{python} np.round(model_rmw.coef()["rmw_replicated"], 2)` and an R-squared around `{python} int(np.round(model_rmw._adj_r2, 2) * 100)` percent.
 
 :::
 
@@ -896,16 +884,14 @@ Finally, the CMA factor also replicates well with a coefficient of `r round(mode
 
 ```{python}
 #| label: replicating-fama-and-french-factors-cma-regression-ff5-py
-model_cma = (smf.ols(
-        formula="cma ~ cma_replicated",
-        data=test.to_pandas()
-    )
-    .fit()
+model_cma = pf.feols(
+    fml="cma ~ cma_replicated",
+    data=test
 )
-prettify_result(model_cma)
+model_cma.summary()
 ```
 
-Finally, the CMA factor also replicates well with a coefficient of `{python} np.round(model_cma.params["cma_replicated"], 2)` and an R-squared around `{python} int(np.round(model_cma.rsquared_adj, 2) * 100)` percent.
+Finally, the CMA factor also replicates well with a coefficient of `{python} np.round(model_cma.coef()["cma_replicated"], 2)` and an R-squared around `{python} int(np.round(model_cma._adj_r2, 2) * 100)` percent.
 
 :::
 

--- a/chapters/univariate-portfolio-sorts.qmd
+++ b/chapters/univariate-portfolio-sorts.qmd
@@ -42,11 +42,10 @@ Compared to previous chapters, we introduce `lmtest` [@lmtest] for inference for
 ```{python}
 #| label: univariate-portfolio-sorts-packages-py
 import polars as pl
-import statsmodels.api as sm
+import pyfixest as pf
 
 from plotnine import *
 from mizani.formatters import percent_format
-from regtabletotext import prettify_result
 ```
 
 :::
@@ -226,17 +225,16 @@ coeftest(model_fit, vcov = NeweyWest)
 
 ### Python
 
-Researchers often default to choosing a pre-specified lag length of six months (which is not a data-driven approach). We do so in the `fit()` function by indicating the `cov_type` as `HAC` and providing the maximum lag length through an additional keywords dictionary.
+Researchers often default to choosing a pre-specified lag length of six months (which is not a data-driven approach). We do so by setting `vcov` to `"NW"` (Newey-West) in `pf.feols()` and providing the maximum lag length together with the time identifier through the `vcov_kwargs` dictionary.
 
 ```{python}
 #| label: univariate-portfolio-sorts-median-newey-west-py
-model_fit = (sm.OLS.from_formula(
-    formula="long_short ~ 1",
-    data=beta_longshort.to_pandas()
-  )
-  .fit(cov_type="HAC", cov_kwds={"maxlags": 6})
+model_fit = pf.feols(
+    "long_short ~ 1",
+    data=beta_longshort,
+    vcov="NW", vcov_kwargs={"lag": 6, "time_id": "date"}
 )
-prettify_result(model_fit)
+model_fit.summary()
 ```
 
 :::
@@ -388,16 +386,14 @@ beta_portfolios_summary <- beta_portfolios |>
 #| label: univariate-portfolio-sorts-portfolio-summary-py
 beta_portfolios_summary = []
 for portfolio, portfolio_data in beta_portfolios.group_by("portfolio"):
-    model_fit = (sm.OLS.from_formula(
-        formula="ret ~ 1 + mkt_excess",
-        data=portfolio_data.to_pandas()
-      )
-      .fit()
+    model_fit = pf.feols(
+        "ret ~ 1 + mkt_excess",
+        data=portfolio_data
     )
     beta_portfolios_summary.append({
         "portfolio": portfolio[0],
-        "alpha": model_fit.params.iloc[0],
-        "beta": model_fit.params.iloc[1],
+        "alpha": model_fit.coef().iloc[0],
+        "beta": model_fit.coef().iloc[1],
         "ret": portfolio_data["ret"].mean()
     })
 
@@ -511,13 +507,10 @@ beta_portfolios_summary |>
 #| fig-cap: "The figure shows average portfolio excess returns and beta estimates. Excess returns are computed as CAPM alphas of the beta-sorted portfolios. The horizontal axis indicates the CAPM beta of the resulting beta-sorted portfolio return time series. The dashed line indicates the slope coefficient of a linear regression of excess returns on portfolio betas."
 #| fig-alt: "Title: Average portfolio excess returns and beta estimates. The figure shows a scatter plot of the average excess returns per beta portfolio with average beta estimates per portfolio on the horizontal axis and average excess returns on the vertical axis. An increasing solid line indicates the security market line. A dashed increasing line with lower slope than the security market line indicates that the CAPM prediction is not valid for CRSP data."
 #| fig-pos: "htb"
-sml_capm = (sm.OLS.from_formula(
-    formula="ret ~ 1 + beta",
-    data=beta_portfolios_summary.to_pandas()
-  )
-  .fit()
-  .params
-)
+sml_capm = pf.feols(
+    "ret ~ 1 + beta",
+    data=beta_portfolios_summary
+).coef()
 
 sml_figure = (
   ggplot(
@@ -606,13 +599,12 @@ coeftest(lm(long_short ~ 1, data = beta_longshort), vcov = NeweyWest)
 
 ```{python}
 #| label: univariate-portfolio-sorts-decile-newey-west-py
-model_fit = (sm.OLS.from_formula(
-    formula="long_short ~ 1",
-    data=beta_longshort.to_pandas()
-  )
-  .fit(cov_type="HAC", cov_kwds={"maxlags": 1})
+model_fit = pf.feols(
+    "long_short ~ 1",
+    data=beta_longshort,
+    vcov="NW", vcov_kwargs={"lag": 1, "time_id": "date"}
 )
-prettify_result(model_fit)
+model_fit.summary()
 ```
 
 :::
@@ -634,13 +626,12 @@ coeftest(
 
 ```{python}
 #| label: univariate-portfolio-sorts-decile-capm-alpha-py
-model_fit = (sm.OLS.from_formula(
-    formula="long_short ~ 1 + mkt_excess",
-    data=beta_longshort.to_pandas()
-  )
-  .fit(cov_type="HAC", cov_kwds={"maxlags": 1})
+model_fit = pf.feols(
+    "long_short ~ 1 + mkt_excess",
+    data=beta_longshort,
+    vcov="NW", vcov_kwargs={"lag": 1, "time_id": "date"}
 )
-prettify_result(model_fit)
+model_fit.summary()
 ```
 
 :::

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,12 +21,10 @@ dependencies = [
     "plotnine>=0.15.1",
     "polars>=1.37.1",
     "pyfixest>=0.40.0",
-    "regtabletotext>=0.0.12",
     "scikit-learn>=1.7.2",
     "scipy>=1.15.3",
     "seaborn>=0.13.2",
     "sqlalchemy>=2.0.45",
-    "statsmodels>=0.14.6",
     "tidyfinance>=0.2.5",
     "tqdm>=4.67.1",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -2849,20 +2849,6 @@ wheels = [
 ]
 
 [[package]]
-name = "regtabletotext"
-version = "0.0.12"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "numpy" },
-    { name = "pandas" },
-    { name = "tabulate" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/81/b3/e84a07cd8182494d34fe24a9fc254fdc9578aba48f83db4199445b376fd7/regtabletotext-0.0.12.tar.gz", hash = "sha256:e02268ef40c7a00d790c11f7fb18be9ca5b232fe57b599b59b60883baadba0f0", size = 2216855, upload-time = "2023-12-19T08:38:33.722Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/75/13/8bbc22000d1b46553220fea0ff27b36cbbfdb9306fe6d40251e5e313cf71/regtabletotext-0.0.12-py3-none-any.whl", hash = "sha256:b6f7ef3c2101cd4b2d150eada5de599f4f8764ac5e03224f11b64b46f432d44e", size = 9895, upload-time = "2023-12-19T08:38:26.291Z" },
-]
-
-[[package]]
 name = "requests"
 version = "2.32.5"
 source = { registry = "https://pypi.org/simple" }
@@ -3475,14 +3461,12 @@ dependencies = [
     { name = "plotnine" },
     { name = "polars" },
     { name = "pyfixest" },
-    { name = "regtabletotext" },
     { name = "scikit-learn", version = "1.7.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "scikit-learn", version = "1.8.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "scipy", version = "1.17.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "seaborn" },
     { name = "sqlalchemy" },
-    { name = "statsmodels" },
     { name = "tidyfinance" },
     { name = "tqdm" },
 ]
@@ -3506,12 +3490,10 @@ requires-dist = [
     { name = "plotnine", specifier = ">=0.15.1" },
     { name = "polars", specifier = ">=1.37.1" },
     { name = "pyfixest", specifier = ">=0.40.0" },
-    { name = "regtabletotext", specifier = ">=0.0.12" },
     { name = "scikit-learn", specifier = ">=1.7.2" },
     { name = "scipy", specifier = ">=1.15.3" },
     { name = "seaborn", specifier = ">=0.13.2" },
     { name = "sqlalchemy", specifier = ">=2.0.45" },
-    { name = "statsmodels", specifier = ">=0.14.6" },
     { name = "tidyfinance", specifier = ">=0.2.5" },
     { name = "tqdm", specifier = ">=4.67.1" },
 ]


### PR DESCRIPTION
## Summary

`statsmodels` requires a `pandas` DataFrame, forcing a `polars → pandas` round-trip at every regression in the Python chapters. This switches all regressions to **`pyfixest`** (already a dependency), which accepts `polars` frames natively via `narwhals` — so the `.to_pandas()` conversions are removed. Resolves the direction agreed in #253.

## What changed

| File | Change |
|---|---|
| `chapters/beta-estimation.qmd` | `smf.ols → pf.feols`; `.summary2().tables[1] → .tidy()`; intro prose + `@pyfixest` citation |
| `chapters/capital-asset-pricing-model.qmd` | `.params/.tvalues → .coef()/.tstat()`; prose updated |
| `chapters/discounted-cash-flow-analysis.qmd` | `.fit().params → .coef()` |
| `chapters/fama-macbeth-regressions.qmd` | cross-section `.coef()`; HAC → `vcov="NW"` |
| `chapters/parametric-portfolio-policies.qmd` | `.fit().params → .coef()` inside the existing pandas groupby |
| `chapters/replicating-fama-and-french-factors.qmd` | 6 regressions; `prettify_result → .summary()`; `.rsquared_adj → ._adj_r2` |
| `chapters/univariate-portfolio-sorts.qmd` | 3 HAC → `vcov="NW"`; `prettify_result → .summary()`; loop `.coef()` |
| `blog/fast-beta-estimation/index.qmd` | cross-check now uses pyfixest |
| `pyproject.toml` / `uv.lock` | dropped `statsmodels` + `regtabletotext` as direct deps |

API mapping: `.params→.coef()`, `.tvalues→.tstat()`, `.bse→.se()`, `.summary2().tables[1]→.tidy()`, `.rsquared_adj→._adj_r2`, `prettify_result(m)→m.summary()`, and HAC `.fit(cov_type="HAC", cov_kwds={"maxlags": k})` → `vcov="NW", vcov_kwargs={"lag": k, "time_id": "date"}`.

## Verification

Multi-agent read-only audit on `pyfixest 0.40.0` / `polars 1.37.1`:
- **Result-preserving:** coefficients bit-identical; `.tidy()` column names, `.coef()/.tstat()/.se()` indexing, `._adj_r2`, and intercept naming (`Intercept`) all confirmed empirically.
- **Newey-West:** coefficients identical; SEs differ only by the deterministic finite-sample DoF factor (<0.5% on n=240, smaller on the book's larger samples) — cosmetic at the book's reporting precision. All NW sites pass a date-sorted frame with the `date` `time_id`.
- `statsmodels` remains in the lockfile transitively (plotnine, tidyfinance) — it was only removed as a *direct* dependency. `tidyfinance.estimate_fama_macbeth` (a separate call) still uses it; that line is unchanged.

Full Quarto render not run here (requires WRDS data).

## Note for reviewers

This PR does **not** fix the pre-existing mislabeled "CAPM alpha" column in `parametric-portfolio-policies.qmd` (the `{"const": ...}` rename is a no-op against `Intercept`). That is intentionally a **separate PR** to keep concerns isolated. The two PRs touch the same code block and will conflict on merge — **recommended order: merge this PR first, then the label-fix PR.**

Closes #253

🤖 Generated with [Claude Code](https://claude.com/claude-code)
