### PR TITLE
Fix mislabeled CAPM alpha column in parametric portfolio evaluation

### DIFF
--- a/chapters/parametric-portfolio-policies.qmd
+++ b/chapters/parametric-portfolio-policies.qmd
@@ -515,7 +515,7 @@ def evaluate_portfolio(weights_data,
               smf.ols(formula="portfolio_return ~ 1 + mkt_excess", data=x)
               .fit().params
             )
-            .rename(columns={"const": "CAPM alpha",
+            .rename(columns={"Intercept": "CAPM alpha",
                              "mkt_excess": "Market beta"})
             )
         evaluation_stats = (evaluation_stats


### PR DESCRIPTION
## Summary

Fixes a pre-existing mislabeled column in the Python `evaluate_portfolio()` CAPM evaluation.

The pipeline renamed column `"const"` to `"CAPM alpha"`, but the `statsmodels` formula API (`smf.ols("portfolio_return ~ 1 + mkt_excess").fit().params`) names the intercept **`Intercept`**, not `const`. So the rename never matched (a no-op) and the alpha row rendered as **"Intercept"** instead of "CAPM alpha". The R tab already labels it "CAPM alpha".

The fix renames the correct key:

```diff
- .rename(columns={"const": "CAPM alpha",
+ .rename(columns={"Intercept": "CAPM alpha",
                   "mkt_excess": "Market beta"})
```

## Verification

Confirmed empirically (read-only multi-agent audit): under the chapter's `groupby().apply()` the intercept column is `Intercept`; after the fix the output columns are `["CAPM alpha", "Market beta"]`, matching the R tab. One-line change, no other coefficient rename is mislabeled.

## Note for reviewers

This is intentionally split out from #260 (the pyfixest migration). Both PRs edit the same block in `parametric-portfolio-policies.qmd` and will conflict on merge. **Recommended order: merge #260 first, then this PR** (the key change applies cleanly on top of the pyfixest version, which has the identical stale `"const"` key).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
