### PR TITLE
Rewrite WRDS pseudo data appendix to use tidyfinance backend (#246)

### DIFF
--- a/chapters/wrds-dummy-data.qmd
+++ b/chapters/wrds-dummy-data.qmd
@@ -11,14 +11,20 @@ eval: false
 ---
 
 ```{python}
-#| label: wrds-dummy-data-setup
+#| label: wrds-pseudo-data-setup
 #| echo: false
 exec(open("assets/render-settings.py").read())
 ```
 
-In this appendix chapter, we alleviate the constraints of readers who do not have access to WRDS and hence cannot run the code that we provide. We show how to create pseudo data that contains the WRDS tables and corresponding columns such that all code chunks in this book can be executed with this pseudo data. We do not create pseudo data for tables of open-source data sources because they can be freely downloaded from the original sources; check out [Accessing and Managing Financial Data](accessing-and-managing-financial-data.qmd).\index{WRDS}
+In this appendix chapter, we show how readers without access to WRDS can still run the WRDS-based code chunks in this book. Instead of building these tables by hand, we rely on the pseudo data backend that ships with the `tidyfinance` package. The package mirrors the structure of the WRDS tables we use, so the same `download_data()` call that retrieves data from WRDS can also return pseudo data with an identical schema. We do not create pseudo data for tables from open-source data providers because you can freely download them from the original sources; see [Accessing and Managing Financial Data](accessing-and-managing-financial-data.qmd).\index{WRDS}
 
-We deliberately use the pseudo label because the data is not meaningful in the sense that it allows readers to actually replicate the results of the book. For legal reasons, the data does not contain any samples of the original data. We merely generate random numbers for all columns of the tables that we use throughout the books.
+The idea is simple: wherever the book calls `download_data()` with `domain = "wrds"`, you can switch to `domain = "pseudo"` to obtain a table with the same columns, types, and panel structure. The `tidyfinance` package is the single source of truth for the pseudo data, which keeps the pseudo data in sync with the schema returned by WRDS without us re-implementing any generators in the book.\index{Data!Pseudo}
+
+We deliberately use the *pseudo* label because the data does not allow you to replicate any results of the book. For legal reasons, it does not contain any samples of the original data. Instead, the package draws independent random numbers for all columns. As a consequence, returns and characteristics carry no economic signal, and any factor premia or other estimates you obtain from pseudo data are pure noise and not economically interpretable.
+
+Two arguments control how the pseudo data is generated. `seed` makes the generated panels reproducible across runs, and `n_assets` sets the size of the cross-section (the package default is 1,000). We use the same `seed` and `n_assets` for all stock tables below so that the identifiers line up across CRSP and Compustat, which is what makes the joins in later chapters work.
+
+If you do have WRDS access, you do not need this chapter. Set your credentials once via `set_wrds_credentials()` (in Python, `tf.set_wrds_credentials()`), which stores them in your `.Renviron`, and every `download_data()` call with `domain = "wrds"` connects to WRDS automatically.
 
 To generate the pseudo data, we use the following packages:
 
@@ -26,30 +32,33 @@ To generate the pseudo data, we use the following packages:
 ### R
 
 ```{r}
-#| label: wrds-dummy-data-packages
+#| label: wrds-pseudo-data-packages
 #| message: false
 library(tidyverse)
-library(arrow)
+library(tidyfinance)
+library(nanoparquet)
 ```
 
 ### Python
 
 ```{python}
-#| label: wrds-dummy-data-packages-py
+#| label: wrds-pseudo-data-packages-py
 import polars as pl
 import numpy as np
+import tidyfinance as tf
 import string
+import os
 ```
 
 :::
 
-We store the data in the folder `data`. Be careful, if you already downloaded the data from WRDS, then the code in this chapter will overwrite your data!
+We store the data in the folder `data`. Be careful: if you already downloaded the data from WRDS, the code in this chapter overwrites your local files!
 
 ::: {.panel-tabset group="language"}
 ### R
 
 ```{r}
-#| label: wrds-dummy-data-create-folder
+#| label: wrds-pseudo-data-create-folder
 if (!dir.exists("data")) {
   dir.create("data")
 }
@@ -58,525 +67,183 @@ if (!dir.exists("data")) {
 ### Python
 
 ```{python}
-#| label: wrds-dummy-data-create-folder-py
-import os
-
+#| label: wrds-pseudo-data-create-folder-py
 if not os.path.exists("data"):
     os.makedirs("data")
 ```
 
 :::
 
-Since we draw random numbers for most of the columns, we also define a seed to ensure that the generated numbers are replicable. We also initialize vectors of dates of different frequencies over ten years that we then use to create yearly, monthly, and daily data, respectively.
+Next, we fix the parameters that control the pseudo data. We set a seed for reproducibility, choose the size of the cross-section, and define the sample period that we want the pseudo data to span. We use the same range as in [WRDS, CRSP, and Compustat](wrds-crsp-and-compustat.qmd).
 
 ::: {.panel-tabset group="language"}
 ### R
 
 ```{r}
-#| label: wrds-dummy-data-seed-and-dates
-set.seed(1234)
+#| label: wrds-pseudo-data-parameters
+seed <- 1234
+set.seed(seed)
 
-start_date <- as.Date("2003-01-01")
-end_date <- as.Date("2022-12-31")
+n_assets <- 100
 
-time_series_years <- seq(year(start_date), year(end_date), 1)
-time_series_months <- seq(start_date, end_date, "1 month")
-time_series_days <- seq(start_date, end_date, "1 day")
+start_date <- "1960-01-01"
+end_date <- "2024-12-31"
 ```
 
 ### Python
 
 ```{python}
-#| label: wrds-dummy-data-seed-and-dates-py
-np.random.seed(1234)
+#| label: wrds-pseudo-data-parameters-py
+seed = 1234
+np.random.seed(seed)
 
-start_date = pl.date(2003, 1, 1)
-end_date = pl.date(2022, 12, 31)
+n_assets = 100
 
-time_series_years = np.arange(2003, 2023, 1)
-time_series_months = pl.date_range(
-    start_date, end_date, interval="1mo", eager=True
-).to_numpy()
-time_series_days = pl.date_range(
-    start_date, end_date, interval="1d", eager=True
-).to_numpy()
+start_date = "1960-01-01"
+end_date = "2024-12-31"
 ```
 
 :::
 
-## Create Stock Pseudo Data
+## Stock Pseudo Data
 
-Let us start with the core data used throughout the book: stock and firm characteristics. We first generate a table with a cross-section of stock identifiers with unique `permno` and `gvkey` values, as well as associated `exchcd`, `exchange`, `industry`, and `siccd` values. The generated data is based on the characteristics of stocks in the `crsp_monthly` table of the original data, ensuring that the generated stocks roughly reflect the distribution of industries and exchanges in the original data, but the identifiers and corresponding exchanges or industries do not reflect actual firms. Similarly, the `permno`-`gvkey` combinations are purely nonsensical and should not be used together with actual CRSP or Compustat data.
-
-::: {.panel-tabset group="language"}
-### R
-
-```{r}
-#| label: wrds-dummy-data-stock-identifiers
-number_of_stocks <- 100
-
-industries <- tibble(
-  industry = c(
-    "Agriculture",
-    "Construction",
-    "Finance",
-    "Manufacturing",
-    "Mining",
-    "Public",
-    "Retail",
-    "Services",
-    "Transportation",
-    "Utilities",
-    "Wholesale"
-  ),
-  n = c(81, 287, 4682, 8584, 1287, 1974, 1571, 4277, 1249, 457, 904),
-  prob = c(
-    0.00319,
-    0.0113,
-    0.185,
-    0.339,
-    0.0508,
-    0.0779,
-    0.0620,
-    0.169,
-    0.0493,
-    0.0180,
-    0.0357
-  )
-)
-
-exchanges <- exchanges <- tibble(
-  exchange = c("AMEX", "NASDAQ", "NYSE"),
-  n = c(2893, 17236, 5553),
-  prob = c(0.113, 0.671, 0.216)
-)
-
-stock_identifiers <- 1:number_of_stocks |>
-  map_df(
-    function(x) {
-      tibble(
-        permno = x,
-        gvkey = as.character(x + 10000),
-        exchange = sample(exchanges$exchange, 1, prob = exchanges$prob),
-        industry = sample(industries$industry, 1, prob = industries$prob)
-      ) |>
-        mutate(
-          exchcd = case_when(
-            exchange == "NYSE" ~ sample(c(1, 31), n()),
-            exchange == "AMEX" ~ sample(c(2, 32), n()),
-            exchange == "NASDAQ" ~ sample(c(3, 33), n())
-          ),
-          siccd = case_when(
-            industry == "Agriculture" ~ sample(1:999, n()),
-            industry == "Mining" ~ sample(1000:1499, n()),
-            industry == "Construction" ~ sample(1500:1799, n()),
-            industry == "Manufacturing" ~ sample(1800:3999, n()),
-            industry == "Transportation" ~ sample(4000:4899, n()),
-            industry == "Utilities" ~ sample(4900:4999, n()),
-            industry == "Wholesale" ~ sample(5000:5199, n()),
-            industry == "Retail" ~ sample(5200:5999, n()),
-            industry == "Finance" ~ sample(6000:6799, n()),
-            industry == "Services" ~ sample(7000:8999, n()),
-            industry == "Public" ~ sample(9000:9999, n())
-          )
-        )
-    }
-  )
-```
-
-### Python
-
-```{python}
-#| label: wrds-dummy-data-stock-identifiers-py
-number_of_stocks = 100
-
-industries = pl.DataFrame(
-    {
-        "industry": [
-            "Agriculture",
-            "Construction",
-            "Finance",
-            "Manufacturing",
-            "Mining",
-            "Public",
-            "Retail",
-            "Services",
-            "Transportation",
-            "Utilities",
-            "Wholesale",
-        ],
-        "n": [81, 287, 4682, 8584, 1287, 1974, 1571, 4277, 1249, 457, 904],
-        "prob": [
-            0.00319,
-            0.0113,
-            0.185,
-            0.339,
-            0.0508,
-            0.0779,
-            0.0620,
-            0.169,
-            0.0493,
-            0.0180,
-            0.03451,
-        ],
-    }
-)
-
-exchanges = pl.DataFrame(
-    {
-        "exchange": ["AMEX", "NASDAQ", "NYSE"],
-        "n": [2893, 17236, 5553],
-        "prob": [0.113, 0.671, 0.216],
-    }
-)
-
-stock_identifiers_list = []
-for x in range(1, number_of_stocks + 1):
-    exchange = np.random.choice(
-        exchanges["exchange"].to_numpy(), p=exchanges["prob"].to_numpy()
-    )
-    industry = np.random.choice(
-        industries["industry"].to_numpy(), p=industries["prob"].to_numpy()
-    )
-
-    exchcd_mapping = {
-        "NYSE": np.random.choice([1, 31]),
-        "AMEX": np.random.choice([2, 32]),
-        "NASDAQ": np.random.choice([3, 33]),
-    }
-
-    siccd_mapping = {
-        "Agriculture": np.random.randint(1, 1000),
-        "Mining": np.random.randint(1000, 1500),
-        "Construction": np.random.randint(1500, 1800),
-        "Manufacturing": np.random.randint(1800, 4000),
-        "Transportation": np.random.randint(4000, 4900),
-        "Utilities": np.random.randint(4900, 5000),
-        "Wholesale": np.random.randint(5000, 5200),
-        "Retail": np.random.randint(5200, 6000),
-        "Finance": np.random.randint(6000, 6800),
-        "Services": np.random.randint(7000, 9000),
-        "Public": np.random.randint(9000, 10000),
-    }
-
-    stock_identifiers_list.append(
-        {
-            "permno": x,
-            "gvkey": str(x + 10000),
-            "exchange": exchange,
-            "industry": industry,
-            "exchcd": exchcd_mapping[exchange],
-            "siccd": siccd_mapping[industry],
-        }
-    )
-
-stock_identifiers = pl.DataFrame(stock_identifiers_list)
-```
-
-:::
-
-Next, we construct three panels of stock data with varying frequencies: yearly, monthly, and daily. We begin by creating the `stock_panel_yearly` panel. To achieve this, we combine the `stock_identifiers` table with a new table containing the variable `year` from `time_series_years`. We get all possible combinations of the two tables. After combining, we select only the `gvkey` and `year` columns for our final yearly panel.
-
-Next, we construct the `stock_panel_monthly` panel. Similar to the yearly panel, we combine `stock_identifiers` with a new table that has the `date` variable from `time_series_months`. After merging, we select the columns `permno`, `gvkey`, `date`, `siccd`, `industry`, `exchcd`, and `exchange` to form our monthly panel.
-
-Lastly, we create the `stock_panel_daily` panel. We combine `stock_identifiers` with a table containing the `date` variable from `time_series_days`. After merging, we retain only the `permno` and `date` columns for our daily panel.
-
-::: {.panel-tabset group="language"}
-### R
-
-The `expand_grid()` function ensures that we get all possible combinations of the two tables.
-
-```{r}
-#| label: wrds-dummy-data-stock-panels
-stock_panel_yearly <- expand_grid(
-  stock_identifiers,
-  tibble(year = time_series_years)
-) |>
-  select(gvkey, year)
-
-stock_panel_monthly <- expand_grid(
-  stock_identifiers,
-  tibble(date = time_series_months)
-) |>
-  select(permno, gvkey, date, siccd, industry, exchcd, exchange)
-
-stock_panel_daily <- expand_grid(
-  stock_identifiers,
-  tibble(date = time_series_days)
-) |>
-  select(permno, date)
-```
-
-### Python
-
-We use `np.tile()` and `np.repeat()` to construct all possible combinations of the two tables.
-
-```{python}
-#| label: wrds-dummy-data-stock-panels-py
-stock_panel_yearly = pl.DataFrame(
-    {
-        "gvkey": np.tile(stock_identifiers["gvkey"], len(time_series_years)),
-        "year": np.repeat(time_series_years, len(stock_identifiers)),
-    }
-)
-
-stock_panel_monthly = pl.DataFrame(
-    {
-        "permno": np.tile(stock_identifiers["permno"], len(time_series_months)),
-        "gvkey": np.tile(stock_identifiers["gvkey"], len(time_series_months)),
-        "date": np.repeat(time_series_months, len(stock_identifiers)),
-        "siccd": np.tile(stock_identifiers["siccd"], len(time_series_months)),
-        "industry": np.tile(stock_identifiers["industry"], len(time_series_months)),
-        "exchcd": np.tile(stock_identifiers["exchcd"], len(time_series_months)),
-        "exchange": np.tile(stock_identifiers["exchange"], len(time_series_months)),
-    }
-)
-
-stock_panel_daily = pl.DataFrame(
-    {
-        "permno": np.tile(stock_identifiers["permno"], len(time_series_days)),
-        "date": np.repeat(time_series_days, len(stock_identifiers)),
-    }
-)
-```
-
-:::
-
-### Pseudo `beta` table
-
-We then proceed to create pseudo beta values for our `stock_panel_monthly` table. We generate monthly beta values `beta_monthly` using a normal distribution with a mean and standard deviation of 1. For daily beta values `beta_daily`, we take the pseudo monthly beta and add a small random noise to it. This noise is generated again using a normal distribution, but this time we scale the random values to ensure they are small deviations from the monthly beta.
-
-::: {.panel-tabset group="language"}
-### R
-
-```{r}
-#| label: wrds-dummy-data-beta
-#| eval: false
-beta_pseudo <- stock_panel_monthly |>
-  mutate(
-    beta_monthly = rnorm(n(), mean = 1, sd = 1),
-    beta_daily = beta_monthly + rnorm(n()) / 100
-  )
-
-write_parquet(beta_pseudo, "data/beta.parquet")
-```
-
-### Python
-
-```{python}
-#| label: wrds-dummy-data-beta-py
-beta_pseudo = (stock_panel_monthly
-    .with_columns(
-        beta_monthly=np.random.normal(
-            loc=1, scale=1, size=len(stock_panel_monthly)
-        )
-    )
-    .with_columns(
-        beta_daily=(
-            pl.col("beta_monthly")
-            + np.random.normal(scale=0.01, size=len(stock_panel_monthly))
-        )
-    )
-)
-
-beta_pseudo.write_parquet("data/beta.parquet")
-```
-
-:::
-
-### Pseudo `compustat_annual` table
-
-To create pseudo firm characteristics, we take all columns from the `compustat_annual` table and create random numbers between 0 and 1. For simplicity, we set the `datadate` for each firm-year observation to the last day of the year, although it is empirically not the case. \index{Data!Compustat}
-
-::: {.panel-tabset group="language"}
-### R
-
-```{r}
-#| label: wrds-dummy-data-compustat
-#| eval: false
-relevant_columns <- c(
-  "seq",
-  "ceq",
-  "at",
-  "lt",
-  "txditc",
-  "txdb",
-  "itcb",
-  "pstkrv",
-  "pstkl",
-  "pstk",
-  "capx",
-  "oancf",
-  "sale",
-  "cogs",
-  "xint",
-  "xsga",
-  "be",
-  "op",
-  "at_lag",
-  "inv"
-)
-
-commands <- unlist(
-  map(
-    relevant_columns,
-    ~ rlang::exprs(!!..1 := runif(n()))
-  )
-)
-
-compustat_pseudo <- stock_panel_yearly |>
-  mutate(
-    datadate = ymd(str_c(year, "12", "31")),
-    !!!commands
-  )
-
-write_parquet(compustat_pseudo, "data/compustat_annual.parquet")
-```
-
-### Python
-
-```{python}
-#| label: wrds-dummy-data-compustat-py
-relevant_columns = [
-    "seq",
-    "ceq",
-    "at",
-    "lt",
-    "txditc",
-    "txdb",
-    "itcb",
-    "pstkrv",
-    "pstkl",
-    "pstk",
-    "capx",
-    "oancf",
-    "sale",
-    "cogs",
-    "xint",
-    "xsga",
-    "be",
-    "op",
-    "at_lag",
-    "inv",
-]
-
-commands = {
-    col: np.random.rand(len(stock_panel_yearly)) for col in relevant_columns
-}
-
-compustat_pseudo = (stock_panel_yearly
-    .with_columns(
-        datadate=pl.date(pl.col("year"), 12, 31)
-    )
-    .with_columns(**commands)
-)
-
-compustat_pseudo.write_parquet("data/compustat_annual.parquet")
-```
-
-:::
+We start with the core data used throughout the book: CRSP stock returns and Compustat firm fundamentals. Each of the following calls returns a table with exactly the schema of its WRDS counterpart, but with pseudo values. We then write each table to the `data` folder under the same file name that the WRDS chapters use, so the rest of the book can read them without any further changes.
 
 ### Pseudo `crsp_monthly` table
 
-The `crsp_monthly` table only lacks a few more columns compared to `stock_panel_monthly`: the returns `ret` drawn from a normal distribution, the excess returns `ret_excess` with small deviations from the returns, the shares outstanding `shrout` and the last price per month (`altprc` in R, `prc` in Python) both drawn from uniform distributions, and the market capitalization `mktcap` as the product of `shrout` and the price. \index{Data!CRSP}
+The monthly CRSP table is the backbone of most analyses. We set `add_ccm_links = TRUE` so that the table carries the Compustat firm identifier `gvkey`, just like the merged file produced in [WRDS, CRSP, and Compustat](wrds-crsp-and-compustat.qmd). Because we reuse the same `seed` and `n_assets` below, the `gvkey` values match those in the pseudo Compustat table.\index{Data!CRSP}
 
 ::: {.panel-tabset group="language"}
 ### R
 
 ```{r}
-#| label: wrds-dummy-data-crsp-monthly
-#| eval: false
-crsp_monthly_pseudo <- stock_panel_monthly |>
-  mutate(
-    ret = pmax(rnorm(n()), -1),
-    ret_excess = ret - runif(n(), 0, 0.0025),
-    shrout = runif(n(), 1, 50) * 1000,
-    altprc = runif(n(), 0, 1000),
-    mktcap = shrout * altprc
-  ) |>
-  group_by(permno) |>
-  arrange(date) |>
-  mutate(mktcap_lag = lag(mktcap)) |>
-  ungroup()
+#| label: wrds-pseudo-data-crsp-monthly
+crsp_monthly <- download_data(
+  domain = "pseudo",
+  dataset = "crsp_monthly",
+  start_date = start_date,
+  end_date = end_date,
+  n_assets = n_assets,
+  add_ccm_links = TRUE,
+  seed = seed
+)
 
-write_parquet(crsp_monthly_pseudo, "data/crsp_monthly.parquet")
+write_parquet(crsp_monthly, "data/crsp_monthly.parquet")
 ```
 
 ### Python
 
 ```{python}
-#| label: wrds-dummy-data-crsp-monthly-py
-crsp_monthly_pseudo = (
-    stock_panel_monthly
-    .with_columns(
-        ret=np.fmax(np.random.normal(size=len(stock_panel_monthly)), -1),
-        shrout=1000 * np.random.uniform(1, 50, len(stock_panel_monthly)),
-        prc=np.random.uniform(0, 1000, len(stock_panel_monthly)),
-    )
-    .with_columns(
-        ret_excess=(
-            pl.col("ret")
-            - np.random.uniform(0, 0.0025, len(stock_panel_monthly))
-        ),
-        mktcap=pl.col("shrout") * pl.col("prc"),
-    )
-    .sort(["permno", "date"])
-    .with_columns(mktcap_lag=pl.col("mktcap").shift(1).over("permno"))
-)
+#| label: wrds-pseudo-data-crsp-monthly-py
+crsp_monthly = pl.from_pandas(tf.download_data(
+    domain="pseudo",
+    dataset="crsp_monthly",
+    start_date=start_date,
+    end_date=end_date,
+    n_assets=n_assets,
+    add_ccm_links=True,
+    seed=seed
+))
 
-crsp_monthly_pseudo.write_parquet("data/crsp_monthly.parquet")
+crsp_monthly.write_parquet("data/crsp_monthly.parquet")
 ```
 
 :::
 
 ### Pseudo `crsp_daily` table
 
-The `crsp_daily` table only contains a `date` column and the daily excess returns `ret_excess` as additional columns to `stock_panel_daily`.
+The daily CRSP table contains the daily (excess) returns that we use, for instance, to estimate betas from daily data.
 
 ::: {.panel-tabset group="language"}
 ### R
 
 ```{r}
-#| label: wrds-dummy-data-crsp-daily
-#| eval: false
-crsp_daily_pseudo <- stock_panel_daily |>
-  mutate(
-    ret_excess = pmax(rnorm(n()), -1)
-  )
+#| label: wrds-pseudo-data-crsp-daily
+crsp_daily <- download_data(
+  domain = "pseudo",
+  dataset = "crsp_daily",
+  start_date = start_date,
+  end_date = end_date,
+  n_assets = n_assets,
+  seed = seed
+)
 
-write_parquet(crsp_daily_pseudo, "data/crsp_daily.parquet")
+write_parquet(crsp_daily, "data/crsp_daily.parquet")
 ```
 
 ### Python
 
 ```{python}
-#| label: wrds-dummy-data-crsp-daily-py
-crsp_daily_pseudo = (stock_panel_daily
-    .with_columns(
-        ret_excess=np.fmax(np.random.normal(size=len(stock_panel_daily)), -1)
-    )
-)
+#| label: wrds-pseudo-data-crsp-daily-py
+crsp_daily = pl.from_pandas(tf.download_data(
+    domain="pseudo",
+    dataset="crsp_daily",
+    start_date=start_date,
+    end_date=end_date,
+    n_assets=n_assets,
+    seed=seed
+))
 
-crsp_daily_pseudo.write_parquet("data/crsp_daily.parquet")
+crsp_daily.write_parquet("data/crsp_daily.parquet")
 ```
 
 :::
 
-## Create Bond Pseudo Data
+### Pseudo `compustat_annual` table
 
-Lastly, we move to the bond data that we use in our books.
-
-### Pseudo `fisd` data
-
-To create pseudo data with the structure of Mergent FISD, we calculate the empirical probabilities of actual bonds for several variables: `maturity`, `offering_amt`, `interest_frequency`, `coupon`, and `sic_code`. We use these probabilities to sample a small cross-section of bonds with completely made up `complete_cusip`, `issue_id`, and `issuer_id`.\index{Data!FISD}
+Finally, we generate the annual Compustat fundamentals. The table shares the `gvkey` identifiers with the pseudo `crsp_monthly` table above, so the firm-level joins in later chapters return matched observations.\index{Data!Compustat}
 
 ::: {.panel-tabset group="language"}
 ### R
 
 ```{r}
-#| label: wrds-dummy-data-fisd
-#| eval: false
+#| label: wrds-pseudo-data-compustat
+compustat_annual <- download_data(
+  domain = "pseudo",
+  dataset = "compustat_annual",
+  start_date = start_date,
+  end_date = end_date,
+  n_assets = n_assets,
+  seed = seed
+)
+
+write_parquet(compustat_annual, "data/compustat_annual.parquet")
+```
+
+### Python
+
+```{python}
+#| label: wrds-pseudo-data-compustat-py
+compustat_annual = pl.from_pandas(tf.download_data(
+    domain="pseudo",
+    dataset="compustat_annual",
+    start_date=start_date,
+    end_date=end_date,
+    n_assets=n_assets,
+    seed=seed
+))
+
+compustat_annual.write_parquet("data/compustat_annual.parquet")
+```
+
+:::
+
+## Bond Pseudo Data
+
+The pseudo backend of `tidyfinance` does not yet cover the bond data sources, so we generate Mergent FISD and enhanced TRACE manually, as in earlier editions of the book. We merely draw random numbers for all columns that we use in [TRACE and FISD](trace-and-fisd.qmd) and [Difference in Differences](difference-in-differences.qmd).
+
+### Pseudo `fisd` data
+
+To create pseudo data with the structure of Mergent FISD, we sample a small cross-section of bonds with completely made-up `complete_cusip`, `issue_id`, and `issuer_id` and draw random values for the remaining columns.\index{Data!FISD}
+
+::: {.panel-tabset group="language"}
+### R
+
+```{r}
+#| label: wrds-pseudo-data-fisd
 number_of_bonds <- 100
+
+bond_dates <- seq(ymd("2003-01-01"), ymd("2022-12-31"), "1 day")
 
 fisd_pseudo <- 1:number_of_bonds |>
   map_df(
@@ -592,7 +259,7 @@ fisd_pseudo <- 1:number_of_bonds |>
     }
   ) |>
   mutate(
-    maturity = sample(time_series_days, n(), replace = TRUE),
+    maturity = sample(bond_dates, n(), replace = TRUE),
     offering_amt = sample(seq(1:100) * 100000, n(), replace = TRUE),
     offering_date = maturity - sample(seq(1:25) * 365, n(), replace = TRUE),
     dated_date = offering_date - sample(-10:10, n(), replace = TRUE),
@@ -610,15 +277,18 @@ write_parquet(fisd_pseudo, "data/fisd.parquet")
 ### Python
 
 ```{python}
-#| label: wrds-dummy-data-fisd-py
-#| eval: false
+#| label: wrds-pseudo-data-fisd-py
 number_of_bonds = 100
+
+bond_dates = pl.date_range(
+    pl.date(2003, 1, 1), pl.date(2022, 12, 31), interval="1d", eager=True
+).to_numpy()
 
 
 def generate_cusip():
     """Generate cusip."""
 
-    characters = list(string.ascii_uppercase + string.digits)  # Convert to list
+    characters = list(string.ascii_uppercase + string.digits)
     cusip = ("".join(np.random.choice(characters, size=12))).upper()
 
     return cusip
@@ -629,7 +299,7 @@ fisd_pseudo = (
         {"complete_cusip": [generate_cusip() for _ in range(number_of_bonds)]}
     )
     .with_columns(
-        maturity=np.random.choice(time_series_days, number_of_bonds, replace=True),
+        maturity=np.random.choice(bond_dates, number_of_bonds, replace=True),
         offering_amt=np.random.choice(
             np.arange(1, 101) * 100000, number_of_bonds, replace=True
         ),
@@ -687,22 +357,21 @@ fisd_pseudo.write_parquet("data/fisd.parquet")
 
 ### Pseudo `trace_enhanced` data
 
-Finally, we create pseudo bond transaction data for the fictional CUSIPs of the pseudo `fisd` data. We take the date range that we also analyze in the book and ensure that we have at least five transactions per day to fulfill a filtering step in the book. \index{Data!TRACE}
+Finally, we create pseudo bond transaction data for the fictional CUSIPs of the pseudo `fisd` data. We take the date range that we also analyze in the book and ensure that we have at least five transactions per day to fulfill a filtering step in the book. We store the result in the `data/trace_enhanced` folder, which is the partitioned dataset layout that the book reads.\index{Data!TRACE}
 
 ::: {.panel-tabset group="language"}
 ### R
 
 ```{r}
-#| label: wrds-dummy-data-trace-enhanced
-#| eval: false
-start_date <- as.Date("2014-01-01")
-end_date <- as.Date("2016-11-30")
+#| label: wrds-pseudo-data-trace-enhanced
+trace_start_date <- as.Date("2014-01-01")
+trace_end_date <- as.Date("2016-11-30")
 
 bonds_panel <- expand_grid(
   fisd_pseudo |>
     select(cusip_id = complete_cusip),
   tibble(
-    trd_exctn_dt = seq(start_date, end_date, "1 day")
+    trd_exctn_dt = seq(trace_start_date, trace_end_date, "1 day")
   )
 )
 
@@ -728,19 +397,24 @@ trace_enhanced_pseudo <- bind_rows(
     cntra_mp_id = sample(c("C", "D"), n(), replace = TRUE)
   )
 
-write_parquet(trace_enhanced_pseudo, "data/trace_enhanced.parquet")
+if (!dir.exists("data/trace_enhanced")) {
+  dir.create("data/trace_enhanced")
+}
+
+write_parquet(
+  trace_enhanced_pseudo, "data/trace_enhanced/trace_enhanced.parquet"
+)
 ```
 
 ### Python
 
 ```{python}
-#| label: wrds-dummy-data-trace-enhanced-py
-number_of_bonds = 100
-start_date = pl.date(2014, 1, 1)
-end_date = pl.date(2016, 11, 30)
+#| label: wrds-pseudo-data-trace-enhanced-py
+trace_start_date = pl.date(2014, 1, 1)
+trace_end_date = pl.date(2016, 11, 30)
 
 trading_dates = pl.date_range(
-    start_date, end_date, interval="1d", eager=True
+    trace_start_date, trace_end_date, interval="1d", eager=True
 ).to_numpy()
 
 bonds_panel = pl.DataFrame(
@@ -780,9 +454,12 @@ trace_enhanced_pseudo = (
     )
 )
 
-trace_enhanced_pseudo.write_parquet("data/trace_enhanced.parquet")
+os.makedirs("data/trace_enhanced", exist_ok=True)
+trace_enhanced_pseudo.write_parquet(
+    "data/trace_enhanced/trace_enhanced.parquet"
+)
 ```
 
 :::
 
-As stated in the introduction, the data does *not* contain any samples of the original data. We merely generate random numbers for all columns of the tables that we use throughout this book.
+With these files in place, you can run the WRDS-based chapters of the book without access to WRDS. Tables that the book derives from these inputs, such as the estimated betas in `data/beta.parquet`, are written by the chapters that compute them (here, [Beta Estimation](beta-estimation.qmd)). As stated in the introduction, the data does *not* contain any samples of the original data, and the pseudo values carry no economic signal.


### PR DESCRIPTION
Closes #246.

Rewrites the WRDS Pseudo Data appendix (`chapters/wrds-dummy-data.qmd`) so it teaches the one-line switch the issue asked for — wherever the book calls `download_data(domain = "wrds", ...)`, readers use `domain = "pseudo"` — instead of hand-building dummy tables.

## What changed
- **CRSP & Compustat** now come from the package's pseudo backend:
  - `crsp_monthly` via `download_data(domain = "pseudo", dataset = "crsp_monthly", add_ccm_links = TRUE)` so the table carries `gvkey` (matching the merged WRDS file)
  - `crsp_daily` and `compustat_annual` via pseudo
  - shared `seed` + `n_assets` across all three so the CRSP↔Compustat identifiers line up (the joins in later chapters return matched rows)
- **`eval: false`** kept — the appendix is instructional and never overwrites real WRDS data during a render.
- **R parquet library** switched from `arrow` to `nanoparquet` (the convention in 14 other chapters).
- **Terminology:** "pseudo data" throughout (no "synthetic"/"dummy"/"simulated").

## Two latent bugs fixed along the way
- `trace_enhanced` was written as a single file, but the bond chapters read the **partitioned directory** `data/trace_enhanced/`. Now writes the directory layout.
- `beta.parquet` was written in a stale *wide* schema while downstream chapters expect the long `beta`/`return_type` format. **Dropped** here — the Beta Estimation chapter produces it correctly.

## Heads-up: bonds are not in the package
Despite the issue comment listing FISD/TRACE as covered, the installed packages (R `tidyfinance` 0.6.0 / Python 0.2.5) only generate pseudo CRSP/Compustat/ccm_links. To keep the *TRACE & FISD* and *Difference-in-Differences* chapters runnable offline, I **kept a corrected manual generator** for `fisd`/`trace_enhanced`. Happy to drop these (and require WRDS for bond chapters) or file a `tidyfinance` issue to add pseudo bonds — let me know.

## Verification
Confirmed the real package API, then smoke-tested both R and Python end-to-end: identical row counts, `gvkey` present, CRSP×Compustat join fully populated, and the bond data round-trips through the exact readers the downstream chapters use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)