### PR TITLE
Rework uv and Quarto-document wording in Setting Up Tidy Finance

### DIFF
--- a/chapters/setting-up-your-environment.qmd
+++ b/chapters/setting-up-your-environment.qmd
@@ -13,14 +13,12 @@ Tidy Finance supports both R and Python, and both languages follow the same proj
 
 ## Install Positron
 
-We recommend [Positron](https://positron.posit.co/) for all Tidy Finance work.\index{Positron} Positron is a data-science environment from Posit that supports R and Python in a single application, with an integrated editor, console, terminal, notebooks, and data viewer. Download and install it from the [official website](https://positron.posit.co/).
+We recommend [Positron](https://positron.posit.co/) for all Tidy Finance work.\index{Positron} Positron is a data-science environment from Posit that supports R and Python in a single application, with an integrated editor, console, terminal, and data viewer, as well as first-class support for Quarto documents. Download and install it from the [official website](https://positron.posit.co/).
 
-Positron runs your code but does not bundle the languages themselves, so install the one you plan to use:
+Positron runs your code but does not bundle the languages themselves:
 
-- R users need an R installation from [CRAN](https://cran.r-project.org/).\index{CRAN}
-- Python users need [uv](https://docs.astral.sh/uv/), a fast Python package and project manager that installs Python for you.\index{uv}
-
-Follow the official installation instructions linked above for your operating system. There is nothing Tidy Finance-specific about this step.
+- R users need an R installation from [CRAN](https://cran.r-project.org/). Follow the official installation instructions for your operating system; there is nothing Tidy Finance-specific about this step.\index{CRAN}
+- Python users do not need to install anything upfront. When you click *Start Session* in Positron and no suitable Python installation is available, Positron offers to install Python via [uv](https://docs.astral.sh/uv/), a fast Python package and project manager, and takes care of the setup for you (see the [Positron blog](https://opensource.posit.co/blog/2026-07-08_positron-uv/) for details).\index{uv}
 
 ## Open a Tidy Finance Project
 
@@ -55,6 +53,8 @@ Python dependencies are declared in `pyproject.toml` and pinned in `uv.lock`. Re
 uv sync
 ```
 
+When Positron detects a `pyproject.toml` in the open folder, it may also offer to create the virtual environment with all dependencies pre-installed for you, in which case you can skip the command above.
+
 :::
 
 ## Working in Positron
@@ -62,7 +62,7 @@ uv sync
 Positron is the primary development environment we use throughout the book. A few features cover everything you need:
 
 - **Scripts.** Write and run `.R` or `.py` files line by line, or run them as a whole.
-- **Notebooks.** Combine code, output, and prose in a single document for exploratory work.
+- **Quarto documents.** Combine code, output, and prose in a single `.qmd` document for exploratory work.
 - **Terminal.** Run shell commands, such as the environment commands above, in the integrated terminal.
 - **Interpreters.** Select the project's R or Python interpreter from Positron's interpreter picker. Choose the interpreter that belongs to the restored project environment (the `renv` library for R, the project `.venv` for Python).
 
@@ -124,3 +124,4 @@ Make sure `.env` is listed in your `.gitignore` so it is never committed.
 - [Positron documentation](https://positron.posit.co/) for everything about the development environment.
 - [R for Data Science](https://r4ds.hadley.nz/) for a free, thorough introduction to data analysis with R and the tidyverse.
 - [uv documentation](https://docs.astral.sh/uv/) for managing Python versions, environments, and dependencies.
+- [Quarto documentation](https://quarto.org/) for authoring Quarto documents that combine code and prose.


### PR DESCRIPTION
Closes #284.

Proposed wording changes for `chapters/setting-up-your-environment.qmd`:

- **uv installation**: Instead of telling Python users to install uv themselves, the chapter now explains that clicking *Start Session* in Positron takes care of installing Python via uv automatically (per the [Positron + uv blog post](https://opensource.posit.co/blog/2026-07-08_positron-uv/)). The R bullet keeps its CRAN instructions.
- **"Notebooks" → "Quarto documents"**: The Positron feature list and the "Working in Positron" bullet now refer to Quarto documents (`.qmd`) rather than notebooks.
- Two small complements: a note that Positron may offer to create the virtual environment with dependencies pre-installed when it detects `pyproject.toml` (making `uv sync` optional), and a Quarto documentation link under Further Resources.

Prose-only change, no executed code affected, so no re-render needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)