### PR TITLE
Use ggplot(prices, ...) instead of .pipe on landing page

### DIFF
--- a/index.qmd
+++ b/index.qmd
@@ -83,8 +83,7 @@ prices = tf.download_data(
   end_date="2024-12-31"
 )
 
-(prices
-  .pipe(ggplot, aes("date", "adjusted_close"))
+(ggplot(prices, aes("date", "adjusted_close"))
   + geom_line())
 ```
 


### PR DESCRIPTION
Closes #291

Replaces the `.pipe(ggplot, ...)` pattern in the landing page's Python plotnine example with a direct `ggplot(prices, ...)` call:

```python
(ggplot(prices, aes("date", "adjusted_close"))
  + geom_line())
```

The snippet is a static (non-executed) code block, so only `index.qmd` changes; the rendered `docs/` output will pick this up on the next Quarto build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K3agT8zuXYGDZEATms3boS

---
_Generated by [Claude Code](https://claude.ai/code/session_01K3agT8zuXYGDZEATms3boS)_