### PR TITLE
Fix remaining typos reported in #293

### DIFF
--- a/chapters/accessing-and-managing-financial-data.qmd
+++ b/chapters/accessing-and-managing-financial-data.qmd
@@ -408,7 +408,7 @@ You should check out the other sets by calling `tf.get_available_famafrench_data
 
 In recent years, the academic discourse experienced the rise of alternative factor models, e.g., in the form of the @Hou2015 *q*-factor model. We refer to the [extended background](http://global-q.org/background.html) information provided by the original authors for further information. The *q* factors can be downloaded directly from the authors' homepage.\index{Data!q-factors}\index{Factor!q-factors}
 
-We also need to adjust this data. First, we discard information we will not use in the remainder of the book. Then, we rename the columns with the "R\_"-prescript using regular expressions and write all column names in lowercase. Finally, we apply the same transform of dividing by 100 to all factor returns. You should always try sticking to a consistent style for naming objects, which we try to illustrate here - the emphasis is on *try*. You can check out style guides available online, e.g., [Hadley Wickham's `tidyverse` style guide.](https://style.tidyverse.org/index.html)\index{Style guide}
+We also need to adjust this data. First, we discard information we will not use in the remainder of the book. Then, we rename the columns with the "R\_"-prefix using regular expressions and write all column names in lowercase. Finally, we apply the same transform of dividing by 100 to all factor returns. You should always try sticking to a consistent style for naming objects, which we try to illustrate here - the emphasis is on *try*. You can check out style guides available online, e.g., [Hadley Wickham's `tidyverse` style guide.](https://style.tidyverse.org/index.html)\index{Style guide}
 
 ::: {.panel-tabset group="language"}
 ### R

--- a/chapters/financial-statement-analysis.qmd
+++ b/chapters/financial-statement-analysis.qmd
@@ -87,7 +87,7 @@ This equation reflects a core principle of accounting: a company's resources (as
 The asset side of the balance sheet typically comprises three main categories, each serving different roles in the company's operations:
 
 1. Current assets: These are assets expected to be converted into cash or used within one operating cycle (typically one year). They include, e.g., cash and cash equivalents, short-term investments, accounts receivable (money owed by customers), and inventory (raw materials, work in progress, and finished goods).
-1. Non-current assets: These long-term assets support the company's operations beyond one year like, e.g., property, plant, and equipment (PP&E), long-term investments, and other long-term assets.
+1. Non-current assets: These long-term assets support the company's operations beyond one year, e.g., property, plant, and equipment (PP&E), long-term investments, and other long-term assets.
 1. Intangible assets: These non-physical assets often represent significant value in modern companies, e.g., patents and intellectual property, trademarks and brands, and goodwill from acquisitions (a premium paid on the book value of the acquired assets). Intangible assets are usually also considered long-term assets, which means that they are included in the group of non-current assets.
 
 @fig-401 illustrates this breakdown of assets, showing how companies classify their resources.


### PR DESCRIPTION
Closes #293

I checked all items from the reader's email against the current (migrated) chapters. Almost everything is already resolved; only two typos remained, which this PR fixes:

- `chapters/financial-statement-analysis.qmd`: "operations beyond one year like, e.g., property, plant, and equipment" → "operations beyond one year, e.g., property, plant, and equipment" (removed the redundant "like").
- `chapters/accessing-and-managing-financial-data.qmd`: `"R\_"-prescript` → `"R\_"-prefix`.

Already resolved by the migration (no action needed):

- "Prerequisits" — no longer appears in `setting-up-your-environment.qmd`.
- "an assets expected" — CAPM chapter now reads "an asset's expected excess return".
- "mean-variance approach in R" — now language-neutral: "implement the mean-variance approach".
- "analyze financial statements using R" — meta description now says "use R and Python".
- "R package `fmpapi`" — now just "the `fmpapi` package".
- Figure vs. text categorization of intangible assets — the text now explicitly explains that intangible assets are included in the group of non-current assets shown in the figure.
- "already scale them" — sentence no longer exists.
- SSL certificate note capitalization — the SSL workaround was removed.
- SQLite in key takeaways — takeaways now refer to Parquet files instead.
- Redundant `from sqlalchemy import create_engine` — no sqlalchemy imports remain.
- "Even if a specific R package doesn't exist" — now reads "Even if a specific package doesn't exist, R and Python can often retrieve data...".

Note: only the `.qmd` sources are changed here; the rendered `docs/` output still needs a re-render, following the convention from #292.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WKsQhDBjvX5gET67MycdjX

---
_Generated by [Claude Code](https://claude.ai/code/session_01WKsQhDBjvX5gET67MycdjX)_