### PR TITLE
Render and publish the site automatically via GitHub Actions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,47 @@
+name: Render and Publish
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: publish-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+
+jobs:
+  render:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Quarto
+        uses: quarto-dev/quarto-actions/setup@v2
+        with:
+          # Keep in sync with the Quarto version used for local renders.
+          version: 1.9.38
+
+      # With `freeze: auto` in _quarto.yml, the render reuses the committed
+      # results in _freeze/, so no R, Python, data, or credentials are needed
+      # on the runner. If this step fails on a specific chapter, that chapter
+      # was changed without refreshing its freeze: render it locally
+      # (`quarto render chapters/<file>.qmd`) and commit the updated _freeze/
+      # entry. Rendering to _site keeps the output separate from the docs/
+      # folder tracked in git.
+      - name: Render site
+        run: quarto render --output-dir _site
+
+      # On pull requests the render above acts as a check only; the site is
+      # deployed exclusively from pushes to main.
+      - name: Deploy to gh-pages
+        if: github.event_name != 'pull_request'
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./_site
+          cname: www.tidy-finance.org

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ config.yaml
 
 /python/.jupyter_cache
 /python/__pycache__
+
+# CI render output (see .github/workflows/publish.yml)
+/_site/

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -20,6 +20,12 @@ link-citations: true
 links-as-notes: true
 
 execute:
+  # freeze: auto — project renders reuse the committed results in _freeze/ for
+  # unchanged files, so CI can render and publish the site without R, Python,
+  # data, or credentials. A changed chapter must be re-rendered locally
+  # (e.g. `quarto render chapters/foo.qmd`) and its updated _freeze/ entry
+  # committed alongside the source; otherwise the CI render fails on that
+  # chapter, which is intentional — it prevents publishing stale content.
   freeze: auto
   eval: true
   echo: true


### PR DESCRIPTION
Follow-up to #294, as discussed: this adds a CI workflow that renders the site with Quarto and publishes it automatically, so prose-level changes no longer require a manual full-site render and `docs/` commit.

## What it does

- **`.github/workflows/publish.yml`**: on every push to `main`, renders the site (Quarto pinned to **1.9.38**, the version used for the current committed render) and deploys the output to a `gh-pages` branch with the `www.tidy-finance.org` CNAME. On pull requests, the render runs as a **check only** — no deploy.
- **`_quarto.yml`**: keeps `freeze: auto`, now with a comment documenting the contract (see below).
- **`.gitignore`**: ignores `_site/`, the CI render output directory.

## Why this works without R/Python/data in CI

The committed `_freeze/` results let Quarto render every unchanged chapter without executing any code — no R, no Python, no `data/` folder, no WRDS/FMP credentials on the runner. I verified this end-to-end with Quarto 1.9.38 in a clean container without R: the full site (34 files, including the legacy archive and blog redirect stubs) renders successfully.

## The contract for code changes

`freeze: auto` re-executes a chapter whenever its source file changes — including prose-only edits. Importantly, the frozen result embeds the *entire* rendered document, so reusing a stale freeze would silently publish old content. I tested this: with `freeze: true`, the typo fixes from #294 did **not** appear in the rendered HTML. That's why this PR keeps `freeze: auto`:

- A chapter changed without a refreshed freeze **fails the CI render loudly** (verified locally), turning the PR check red with a clear message instead of publishing stale HTML.
- The fix is always the same: render the changed chapter locally (`quarto render chapters/<file>.qmd`) and commit the updated `_freeze/` entry alongside the source.

So the maintainer workflow becomes: render only the changed chapter locally, commit source + `_freeze`, and CI renders and publishes the whole site.

## Expected check status on this PR

The render check on this PR will be **red until the local re-render of the two chapters from #294 lands on `main`** and this branch is updated — their freezes are currently stale, which is exactly the failure mode the check is meant to catch. I'll update the branch once the render commit is pushed, after which the check should go green.

## After merging

1. Let the workflow run once on `main` (it creates the `gh-pages` branch).
2. Switch GitHub Pages in the repo settings from `main /docs` to `gh-pages` (root). The custom domain keeps working — the workflow writes the CNAME file.
3. Optionally, in a later cleanup: stop committing `docs/` and remove it from the repository.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WKsQhDBjvX5gET67MycdjX

---
_Generated by [Claude Code](https://claude.ai/code/session_01WKsQhDBjvX5gET67MycdjX)_