### PR TITLE
Stabilize the hero language tabs on mobile

### DIFF
--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -535,7 +535,10 @@ p#toast-message {
     max-width: 1120px;
     margin: 0 auto;
     display: grid;
-    grid-template-columns: 1.05fr .95fr;
+    /* minmax(0, …) instead of plain fr: grid items default to `min-width: auto`,
+       so the long code lines in the hero window would otherwise blow the track
+       (and the card) up past the viewport. */
+    grid-template-columns: minmax(0, 1.05fr) minmax(0, .95fr);
     gap: 56px;
     align-items: center;
 }
@@ -607,6 +610,8 @@ p#toast-message {
     border-radius: 14px;
     box-shadow: var(--tf-shadow-lg);
     overflow: hidden;
+    min-width: 0;
+    max-width: 100%;
 }
 
 .tf-window__bar {
@@ -676,6 +681,38 @@ p#toast-message {
     padding: 6px 14px 14px 14px;
 }
 
+/* Stack both panes in the same grid cell so the window keeps the height of the
+   tallest snippet. Switching R <-> Python then swaps the code in place instead
+   of resizing the card and shoving everything below it up or down. */
+.tf-window .panel-tabset>.tab-content {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr);
+}
+
+/* Let the shorter snippet's code box fill the shared row, so the framed area
+   looks the same in both tabs instead of leaving a gap under the code. */
+.tf-window .panel-tabset>.tab-content>.tab-pane,
+.tf-window .panel-tabset .code-copy-outer-scaffold,
+.tf-window .panel-tabset .sourceCode,
+.tf-window .panel-tabset pre {
+    height: 100%;
+}
+
+.tf-window .panel-tabset>.tab-content>.tab-pane {
+    /* Bootstrap hides inactive panes with `display: none !important`, so the
+       override has to be !important too. */
+    display: block !important;
+    grid-area: 1 / 1;
+    min-width: 0;
+    /* `visibility` (not `display: none`) keeps the pane in the layout while
+       taking it out of the tab order and the accessibility tree. */
+    visibility: hidden;
+}
+
+.tf-window .panel-tabset>.tab-content>.tab-pane.active {
+    visibility: visible;
+}
+
 .tf-window pre {
     margin: 0;
     background: #fbfdfe !important;
@@ -684,10 +721,15 @@ p#toast-message {
     border-radius: 10px;
     font-size: .82rem;
     line-height: 1.5;
+    max-width: 100%;
+    /* Long lines scroll inside the card instead of stretching it. */
+    overflow-x: auto;
+    overscroll-behavior-x: contain;
 }
 
 .tf-window .sourceCode {
     background: transparent;
+    min-width: 0;
 }
 
 /* ---------- STATS ---------- */
@@ -925,7 +967,7 @@ p#toast-message {
 /* ---------- responsive ---------- */
 @media (max-width: 900px) {
     .tf-hero__inner {
-        grid-template-columns: 1fr;
+        grid-template-columns: minmax(0, 1fr);
         gap: 36px;
     }
 
@@ -964,5 +1006,24 @@ p#toast-message {
 
     .tf-section {
         padding: 56px 24px;
+    }
+
+    /* Tighter code window so most snippet lines fit a phone screen without
+       horizontal scrolling. */
+    .tf-window .panel-tabset>.nav-tabs {
+        padding: 10px 10px 0 10px;
+    }
+
+    .tf-window .panel-tabset .tab-content {
+        padding: 6px 10px 10px 10px;
+    }
+
+    /* Wrap instead of clipping long lines: the snippets stay fully readable on a
+       phone, and the window keeps the height of the tallest one either way. */
+    .tf-window pre,
+    .tf-window pre code {
+        font-size: .74rem;
+        white-space: pre-wrap;
+        overflow-wrap: break-word;
     }
 }

--- a/docs/assets/css/index.css
+++ b/docs/assets/css/index.css
@@ -535,7 +535,10 @@ p#toast-message {
     max-width: 1120px;
     margin: 0 auto;
     display: grid;
-    grid-template-columns: 1.05fr .95fr;
+    /* minmax(0, …) instead of plain fr: grid items default to `min-width: auto`,
+       so the long code lines in the hero window would otherwise blow the track
+       (and the card) up past the viewport. */
+    grid-template-columns: minmax(0, 1.05fr) minmax(0, .95fr);
     gap: 56px;
     align-items: center;
 }
@@ -607,6 +610,8 @@ p#toast-message {
     border-radius: 14px;
     box-shadow: var(--tf-shadow-lg);
     overflow: hidden;
+    min-width: 0;
+    max-width: 100%;
 }
 
 .tf-window__bar {
@@ -676,6 +681,38 @@ p#toast-message {
     padding: 6px 14px 14px 14px;
 }
 
+/* Stack both panes in the same grid cell so the window keeps the height of the
+   tallest snippet. Switching R <-> Python then swaps the code in place instead
+   of resizing the card and shoving everything below it up or down. */
+.tf-window .panel-tabset>.tab-content {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr);
+}
+
+/* Let the shorter snippet's code box fill the shared row, so the framed area
+   looks the same in both tabs instead of leaving a gap under the code. */
+.tf-window .panel-tabset>.tab-content>.tab-pane,
+.tf-window .panel-tabset .code-copy-outer-scaffold,
+.tf-window .panel-tabset .sourceCode,
+.tf-window .panel-tabset pre {
+    height: 100%;
+}
+
+.tf-window .panel-tabset>.tab-content>.tab-pane {
+    /* Bootstrap hides inactive panes with `display: none !important`, so the
+       override has to be !important too. */
+    display: block !important;
+    grid-area: 1 / 1;
+    min-width: 0;
+    /* `visibility` (not `display: none`) keeps the pane in the layout while
+       taking it out of the tab order and the accessibility tree. */
+    visibility: hidden;
+}
+
+.tf-window .panel-tabset>.tab-content>.tab-pane.active {
+    visibility: visible;
+}
+
 .tf-window pre {
     margin: 0;
     background: #fbfdfe !important;
@@ -684,10 +721,15 @@ p#toast-message {
     border-radius: 10px;
     font-size: .82rem;
     line-height: 1.5;
+    max-width: 100%;
+    /* Long lines scroll inside the card instead of stretching it. */
+    overflow-x: auto;
+    overscroll-behavior-x: contain;
 }
 
 .tf-window .sourceCode {
     background: transparent;
+    min-width: 0;
 }
 
 /* ---------- STATS ---------- */
@@ -925,7 +967,7 @@ p#toast-message {
 /* ---------- responsive ---------- */
 @media (max-width: 900px) {
     .tf-hero__inner {
-        grid-template-columns: 1fr;
+        grid-template-columns: minmax(0, 1fr);
         gap: 36px;
     }
 
@@ -964,5 +1006,24 @@ p#toast-message {
 
     .tf-section {
         padding: 56px 24px;
+    }
+
+    /* Tighter code window so most snippet lines fit a phone screen without
+       horizontal scrolling. */
+    .tf-window .panel-tabset>.nav-tabs {
+        padding: 10px 10px 0 10px;
+    }
+
+    .tf-window .panel-tabset .tab-content {
+        padding: 6px 10px 10px 10px;
+    }
+
+    /* Wrap instead of clipping long lines: the snippets stay fully readable on a
+       phone, and the window keeps the height of the tallest one either way. */
+    .tf-window pre,
+    .tf-window pre code {
+        font-size: .74rem;
+        white-space: pre-wrap;
+        overflow-wrap: break-word;
     }
 }


### PR DESCRIPTION
## What

On phones, switching between **R** and **Python** in the landing-page code window made the whole card jump around. Two separate causes:

1. **The card resized horizontally.** `.tf-hero__inner` used plain `fr` tracks, and grid items default to `min-width: auto`, so the track was sized by the code's longest line. On a 390px viewport the card was 363px wide with R active and **438px with Python active** — 72px past the viewport, clipped by the hero's `overflow: hidden`, so the Python snippet was cut off.
2. **The card resized vertically.** The R snippet is one line taller than the Python one, so every switch changed the card height and shifted the stats band and everything below it (measured: 21–54px shift).

## Changes

All in `assets/css/index.css` (plus the built copy in `docs/`), scoped to `.tf-window` so other tabsets on the site are untouched:

- Hero grid tracks use `minmax(0, …)`, and `.tf-window` gets `min-width: 0; max-width: 100%` — the card can no longer be stretched by its content.
- `.tf-window pre` scrolls horizontally (`overflow-x: auto`, `overscroll-behavior-x: contain`) instead of expanding the card.
- Both tab panes are stacked in a single grid cell (`grid-area: 1 / 1`), with the inactive one hidden via `visibility` rather than `display: none`. The window keeps the height of the taller snippet, so the switch happens in place. The inactive pane stays out of the tab order and the accessibility tree, and its copy button is not clickable.
- The code box fills the shared row so the framed area looks identical in both tabs.
- Below 560px: tighter tab/window padding, smaller code font, and `pre-wrap` so long lines wrap instead of being clipped — no hidden code and no horizontal scrolling on a phone.

## Verification

Chromium (Playwright, iPhone 13 emulation plus fixed viewports at 320/360/390/430/768/900/1280px):

| | before (390px) | after (390px) |
|---|---|---|
| card width R / Python | 363 / 438 | 342 / 342 |
| card height R / Python | 423 / 402 | 398 / 398 |
| document height R / Python | 9858 / 9805 | 9833 / 9833 |
| card right edge vs viewport | 462 vs 390 (overflow) | 366 vs 390 |

At every tested width the card's width, height, and the document height are identical for both tabs, and nothing overflows the viewport. Tab persistence across reloads (Quarto's `group="language"` sync) still works, and there are no console errors. Desktop rendering is unchanged apart from the Python tab now matching the R tab's height.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XAVDkuEAkJ7Z8J6B9CaQh4)_