### PR TITLE
Render R data frames as HTML tables

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -32,6 +32,10 @@ format:
     theme:
       light: [cosmo, assets/scss/theme-light.scss]
     css: assets/css/global.css
+    # Print R data frames as HTML tables, matching the polars output in the
+    # Python tabs. Tibbles are handled by assets/render-settings.R, which caps
+    # the preview at five rows before handing off to knitr::kable().
+    df-print: kable
     toc: true
     section-divs: true
     number-sections: false

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -33,8 +33,8 @@ format:
       light: [cosmo, assets/scss/theme-light.scss]
     css: assets/css/global.css
     # Print R data frames as HTML tables, matching the polars output in the
-    # Python tabs. Tibbles are handled by assets/render-settings.R, which caps
-    # the preview at five rows before handing off to knitr::kable().
+    # Python tabs. The knit_print() method in assets/render-settings.R caps the
+    # preview at five rows before handing off to knitr::kable().
     df-print: kable
     toc: true
     section-divs: true

--- a/assets/render-settings.R
+++ b/assets/render-settings.R
@@ -16,11 +16,11 @@ options(
 
 # Data frame printing --------------------------------------------------------
 # The Python tabs show polars data frames as HTML tables, so we style R data
-# frames the same way. `df-print: kable` in _quarto.yml takes care of plain data
-# frames, but it prints *every* row, which is not an option for the tibbles in
-# this book (some have millions of rows). The knit_print() method below keeps
-# the five-row preview that print.tbl_df() gives us, reports the full
-# dimensions above the table like polars does, and only then calls kable().
+# frames the same way. `df-print: kable` in _quarto.yml switches the printing on,
+# but on its own it prints *every* row, which is not an option for the data
+# frames in this book (some have millions of rows). The knit_print() method
+# below keeps the five-row preview that print.tbl_df() gives us, reports the
+# full dimensions above the table like polars does, and only then calls kable().
 local({
 
   # Formats one column the way the tibble would print it: pillar keeps the
@@ -28,7 +28,8 @@ local({
   # and summarizes list columns as, e.g., "tibble [299 x 3]".
   format_column <- function(column) {
     if (is.list(column) && !is.data.frame(column)) {
-      return(escape_html(as.character(pillar::obj_sum(column))))
+      summaries <- vapply(column, function(cell) pillar::obj_sum(cell), character(1))
+      return(escape_html(summaries))
     }
     shaft <- pillar::pillar_shaft(column)
     width <- attr(shaft, "width")
@@ -43,10 +44,11 @@ local({
     gsub(">", "&gt;", values, fixed = TRUE)
   }
 
-  kable_tibble <- function(x, n = getOption("tibble.print_min", 5)) {
+  kable_preview <- function(x, n = getOption("tibble.print_min", 5)) {
     cells <- lapply(utils::head(x, n), format_column)
     if (nrow(x) > n) {
-      cells <- lapply(cells, function(column) c(column, "\u2026"))
+      # An HTML entity, so the ellipsis does not depend on the render locale.
+      cells <- lapply(cells, function(column) c(column, "&hellip;"))
     }
     preview <- as.data.frame(cells, stringsAsFactors = FALSE, check.names = FALSE)
     table <- knitr::kable(
@@ -56,31 +58,46 @@ local({
       align = unname(ifelse(vapply(x, is.numeric, logical(1)), "r", "l"))
     )
     shape <- sprintf("shape: (%s, %s)", format(nrow(x), big.mark = ","), ncol(x))
+    # Grouping is part of what print.grouped_df reports, so keep it visible.
+    if (inherits(x, "grouped_df") && requireNamespace("dplyr", quietly = TRUE)) {
+      shape <- sprintf(
+        "%s, groups: %s [%s]", shape,
+        paste(dplyr::group_vars(x), collapse = ", "), dplyr::n_groups(x)
+      )
+    }
     paste0("<small>", shape, "</small>\n\n", paste(table, collapse = "\n"), "\n")
   }
 
-  knit_print_tibble <- function(x, options = NULL, ...) {
+  knit_print_data_frame <- function(x, options = NULL, ...) {
     if (!knitr::is_html_output()) {
       return(knitr::normal_print(x))
     }
-    out <- try(kable_tibble(x), silent = TRUE)
+    out <- try(kable_preview(x), silent = TRUE)
     if (inherits(out, "try-error")) {
       return(knitr::normal_print(x))
     }
     knitr::asis_output(out)
   }
 
-  # rmarkdown registers knit_print.data.frame for df-print, so the method for
-  # the more specific tbl_df class wins for tibbles and grouped tibbles.
   register <- function(...) {
-    registerS3method(
-      "knit_print", "tbl_df", knit_print_tibble,
-      envir = asNamespace("knitr")
-    )
+    for (class in c("data.frame", "tbl_df", "grouped_df", "rowwise_df")) {
+      registerS3method(
+        "knit_print", class, knit_print_data_frame,
+        envir = asNamespace("knitr")
+      )
+    }
   }
-  if (isNamespaceLoaded("knitr")) {
-    register()
-  } else {
-    setHook(packageEvent("knitr", "onLoad"), register)
+  register_on_load <- function(package) {
+    if (isNamespaceLoaded(package)) {
+      register()
+    } else {
+      setHook(packageEvent(package, "onLoad"), register)
+    }
   }
+  # rmarkdown registers its own knit_print methods for df-print when it loads,
+  # for the same classes (its knit_print.tbl_sql for lazy database tables is
+  # left alone). They format with getOption("digits"), which would turn a volume
+  # of 535796800 into 5.36e+08, so we register once more after rmarkdown.
+  register_on_load("knitr")
+  register_on_load("rmarkdown")
 })

--- a/assets/render-settings.R
+++ b/assets/render-settings.R
@@ -13,3 +13,74 @@ options(
   width = 69,
   crayon.enabled = FALSE
 )
+
+# Data frame printing --------------------------------------------------------
+# The Python tabs show polars data frames as HTML tables, so we style R data
+# frames the same way. `df-print: kable` in _quarto.yml takes care of plain data
+# frames, but it prints *every* row, which is not an option for the tibbles in
+# this book (some have millions of rows). The knit_print() method below keeps
+# the five-row preview that print.tbl_df() gives us, reports the full
+# dimensions above the table like polars does, and only then calls kable().
+local({
+
+  # Formats one column the way the tibble would print it: pillar keeps the
+  # significant digits set above, avoids scientific notation for large counts,
+  # and summarizes list columns as, e.g., "tibble [299 x 3]".
+  format_column <- function(column) {
+    if (is.list(column) && !is.data.frame(column)) {
+      return(escape_html(as.character(pillar::obj_sum(column))))
+    }
+    shaft <- pillar::pillar_shaft(column)
+    width <- attr(shaft, "width")
+    formatted <- if (is.null(width)) format(shaft) else format(shaft, width = width)
+    escape_html(trimws(gsub("\033\\[[0-9;]*m", "", as.character(formatted))))
+  }
+
+  # Values are placed in a Markdown table, so angle brackets would otherwise be
+  # read as inline HTML by Pandoc.
+  escape_html <- function(values) {
+    values <- gsub("<", "&lt;", values, fixed = TRUE)
+    gsub(">", "&gt;", values, fixed = TRUE)
+  }
+
+  kable_tibble <- function(x, n = getOption("tibble.print_min", 5)) {
+    cells <- lapply(utils::head(x, n), format_column)
+    if (nrow(x) > n) {
+      cells <- lapply(cells, function(column) c(column, "\u2026"))
+    }
+    preview <- as.data.frame(cells, stringsAsFactors = FALSE, check.names = FALSE)
+    table <- knitr::kable(
+      preview,
+      row.names = FALSE,
+      col.names = names(x),
+      align = unname(ifelse(vapply(x, is.numeric, logical(1)), "r", "l"))
+    )
+    shape <- sprintf("shape: (%s, %s)", format(nrow(x), big.mark = ","), ncol(x))
+    paste0("<small>", shape, "</small>\n\n", paste(table, collapse = "\n"), "\n")
+  }
+
+  knit_print_tibble <- function(x, options = NULL, ...) {
+    if (!knitr::is_html_output()) {
+      return(knitr::normal_print(x))
+    }
+    out <- try(kable_tibble(x), silent = TRUE)
+    if (inherits(out, "try-error")) {
+      return(knitr::normal_print(x))
+    }
+    knitr::asis_output(out)
+  }
+
+  # rmarkdown registers knit_print.data.frame for df-print, so the method for
+  # the more specific tbl_df class wins for tibbles and grouped tibbles.
+  register <- function(...) {
+    registerS3method(
+      "knit_print", "tbl_df", knit_print_tibble,
+      envir = asNamespace("knitr")
+    )
+  }
+  if (isNamespaceLoaded("knitr")) {
+    register()
+  } else {
+    setHook(packageEvent("knitr", "onLoad"), register)
+  }
+})


### PR DESCRIPTION
The Python tabs show polars data frames as styled HTML tables, while the R tabs show plain text inside a code block. This makes the R side use the same styling.

## Changes

**`_quarto.yml`** — `df-print: kable` for the HTML format, which switches data frame printing from `print()` to tables.

**`assets/render-settings.R`** — `knit_print()` methods for `data.frame`, `tbl_df`, `grouped_df` and `rowwise_df`, because `df-print: kable` on its own prints *every* row of a data frame. The book prints data frames with 6,288, 1,199 and even 4,665,538 rows, all of which currently show a five-row preview. The methods:

- keep the five-row preview (`tibble.print_min`) and append an ellipsis row when the frame is longer, like polars does;
- put `shape: (6,288, 8)` in `<small>` above the table, mirroring the polars shape line, since the `# A tibble: 6,288 × 8` header disappears — for grouped tibbles the grouping is appended, so `print.grouped_df()`'s `# Groups:` line is not lost either;
- format columns with `pillar`, so numbers keep the significant digits they have today and list columns keep their `tibble [299 × 3]` summaries instead of being deparsed;
- fall back to today's plain-text printing for non-HTML output or if formatting fails.

The methods are registered after `rmarkdown` loads, because `rmarkdown` registers its own methods for those classes when it does. Its `knit_print.tbl_sql` for lazy database tables is left alone. `df-print: kable` still matters as the fallback: if the registration ever stops applying, data frames degrade to plain `kable()` tables rather than back to text.

## Verified by rendering

Rendered a test chapter inside the project with R 4.3.3, knitr 1.45, rmarkdown 2.25, pillar 1.9.0 and Quarto 1.9.9. The tables come out with `class="caption-top table table-sm table-striped small"` — the same classes Quarto gives the polars tables — and cover: a truncated tibble, a `head()`, a list column, a grouped tibble, a plain data frame, an empty tibble, and strings containing `|`, `<` and quotes.

That render caught three bugs, fixed in the second commit:

| | before | after |
|---|---|---|
| list column | `list [2]`, recycled over all rows | `tibble [299 × 3]` per row |
| ellipsis row | `<U+2026>` when the render locale is not UTF-8 | `…` |
| grouped tibble | missed the method entirely, `volume` printed as `5.36e+08` | goes through the preview, `535796800` |

The last one also applied to plain data frames, which is why the methods now cover `data.frame` as well.

Two caveats:

- The renders used the Ubuntu package versions above; `renv.lock` pins newer ones (knitr 1.51, rmarkdown 2.31, pillar 1.11.1). `llms-txt: true` is also not in Quarto 1.9.9's schema, so that key was dropped for the test renders only.
- `execute: freeze: auto` keys off the `.qmd` files, so none of the 25 chapters pick this up until they are re-executed (`quarto render --no-freeze`, or by clearing `_freeze/chapters`), which needs the WRDS and data access the chapters use.

One cosmetic note: Pandoc's smart quotes turn the quotes `pillar` puts around strings that need escaping into typographic quotes, e.g. `“filter(crsp_monthly, …)”` in the size-sorts chapter.